### PR TITLE
Fix: Buttons no longer work on the TreeView element when the element is selected.

### DIFF
--- a/src/Avalonia.Xaml.Interactions.DragAndDrop/ContextDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.DragAndDrop/ContextDragBehavior.cs
@@ -144,6 +144,7 @@ public class ContextDragBehavior : StyledElementBehavior<Control>
                 _captured = true;
             }
         }
+        e.Handled = false;
     }
 
     private void AssociatedObject_PointerReleased(object? sender, PointerReleasedEventArgs e)


### PR DESCRIPTION
Buttons no longer work on the TreeView element when the element is selected.
For example, if Node0 is not selected in the DragAndDropSample application, the collapse arrow will work.
However, if Node0 is selected, it no longer works.
Other buttons that are added to the element will also no longer work.

![problem](https://github.com/user-attachments/assets/f37f4d3b-b3af-495c-b972-c3be3eea94cb)


As a fix, I have added the following line locally in the AssociatedObject_PointerPressed method in the ContextDragBehavior class at the end of the method:
e.Handled = false;
Drag and drop still works and the buttons still work with a selected element.

