### PR TITLE
Avoid crash when round-trip conversion to string fails

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -230,8 +230,10 @@ public class ChangePropertyAction : Avalonia.Xaml.Interactivity.StyledElementAct
                 var valueAsString = Value.ToString();
                 if (valueAsString is not null)
                 {
-                    result = propertyTypeInfo.IsEnum ? Enum.Parse(propertyType, valueAsString, false) :
-                        Interactivity.TypeConverterHelper.Convert(valueAsString, propertyType);
+                    result = propertyTypeInfo.IsEnum
+                        ? Enum.Parse(propertyType, valueAsString, false)
+                        : Interactivity.TypeConverterHelper.TryConvert(valueAsString, propertyType, out var converted)
+                            ? converted : Value;
                 }
             }
 
@@ -283,8 +285,10 @@ public class ChangePropertyAction : Avalonia.Xaml.Interactivity.StyledElementAct
                 var valueAsString = Value.ToString();
                 if (valueAsString is not null)
                 {
-                    result = propertyTypeInfo.IsEnum ? Enum.Parse(propertyType, valueAsString, false) :
-                        Interactivity.TypeConverterHelper.Convert(valueAsString, propertyType);
+                    result = propertyTypeInfo.IsEnum
+                        ? Enum.Parse(propertyType, valueAsString, false)
+                        : Interactivity.TypeConverterHelper.TryConvert(valueAsString, propertyType, out var converted)
+                            ? converted : Value;
                 }
             }
 

--- a/src/Avalonia.Xaml.Interactivity/Helpers/ComparisonConditionTypeHelper.cs
+++ b/src/Avalonia.Xaml.Interactivity/Helpers/ComparisonConditionTypeHelper.cs
@@ -15,7 +15,8 @@ internal static class ComparisonConditionTypeHelper
             var destinationType = leftOperand.GetType();
             if (value is not null)
             {
-                rightOperand = TypeConverterHelper.Convert(value, destinationType);
+                if (TypeConverterHelper.TryConvert(value, destinationType, out var converted))
+                	rightOperand = converted;
             }
         }
 

--- a/src/Avalonia.Xaml.Interactivity/Helpers/TypeConverterHelper.cs
+++ b/src/Avalonia.Xaml.Interactivity/Helpers/TypeConverterHelper.cs
@@ -105,6 +105,10 @@ internal static class TypeConverterHelper
         {
             // not able to convert to anything
         }
+        catch (FormatException)
+        {
+            // not able to convert from string
+        }
         catch (NotSupportedException)
         {
             // not able to convert from string


### PR DESCRIPTION
(note: this patch is for version 11.2.6 and later)

## Description
I encounter crashes when trying to use a custom type as the comparand of a `DataTriggerBehavior`.

The `TypeConverterHelper` doesn't handle the `NotSupportedException` from the call to `converter.ConvertFromInvariantString`.

On top of that, not all types are necessarily convertible to a string with a round trip back to the type. In such case, we still want to be able to compare using the standard `object.Equals` method.

## Context
In my case, I have xaml that looks like this:
```xml
<TextBlock x:Name="MyTextBlock" Text="{Binding NodeValue}">
  <Interaction.Behaviors>
    <DataTriggerBehavior Binding="{Binding NodeValue}" Value="{x:Static local:NodeViewModel.DifferentValues}">
      <ChangePropertyAction TargetObject="TextBlock" PropertyName="Text" Value="(Different values)"/>
    </DataTriggerBehavior>
  </Interaction.Behaviors>
</TextBlock>
```

The bound property `NodeValue` can be of any type (it is defined as `object`  on the view model). On the other hand `NodeViewModel.DifferentValues` is a special value that identify when a Node is a combination of several nodes which values are different (not important for the issue). The idea is in this particular case, we can't display the value (since there are at least two that are different), so instead we display a constant "(Different values)".

## Solution
This PR introduces a `TryConvert()` method in `TypeConverterHelper` that does the same as `Convert()` but returns false in case the conversion did not succeed.

In addition, this PR uses the new method in a few places where the aforementioned crash was detected.