### PR TITLE
Add touch gesture event triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,11 @@ This section provides an overview of all available classes and their purpose in 
 - **DoubleTappedEventBehavior**  
   *Listens for double-tap events and triggers its actions when detected.*
 
-- **GotFocusEventBehavior**  
+- **GotFocusEventBehavior**
   *Executes actions when the associated control receives focus.*
+
+- **HoldingEventBehavior**
+  *Triggers actions when a holding gesture is detected.*
 
 - **KeyDownEventBehavior**  
   *Monitors key down events and triggers actions when the specified key is pressed.*
@@ -315,8 +318,14 @@ This section provides an overview of all available classes and their purpose in 
 - **KeyUpEventBehavior**  
   *Monitors key up events and triggers actions when the specified key is released.*
 
-- **LostFocusEventBehavior**  
+- **LostFocusEventBehavior**
   *Triggers actions when the control loses focus.*
+
+- **PinchEndedEventBehavior**
+  *Triggers actions when a pinch gesture ends.*
+
+- **PinchEventBehavior**
+  *Triggers actions when a pinch gesture occurs.*
 
 - **PointerCaptureLostEventBehavior**  
   *Listens for events when pointer capture is lost and triggers associated actions.*
@@ -336,11 +345,26 @@ This section provides an overview of all available classes and their purpose in 
 - **PointerPressedEventBehavior**  
   *Triggers actions on pointer press events.*
 
-- **PointerReleasedEventBehavior**  
+- **PointerReleasedEventBehavior**
   *Triggers actions on pointer release events.*
 
-- **PointerWheelChangedEventBehavior**  
+- **PointerTouchPadGestureMagnifyEventBehavior**
+  *Triggers actions during a touchpad magnify gesture.*
+
+- **PointerTouchPadGestureRotateEventBehavior**
+  *Triggers actions during a touchpad rotation gesture.*
+
+- **PointerTouchPadGestureSwipeEventBehavior**
+  *Triggers actions during a touchpad swipe gesture.*
+
+- **PointerWheelChangedEventBehavior**
   *Triggers actions when the pointer wheel (scroll) changes.*
+
+- **PullGestureEndedEventBehavior**
+  *Triggers actions when a pull gesture ends.*
+
+- **PullGestureEventBehavior**
+  *Triggers actions when a pull gesture occurs.*
 
 - **RightTappedEventBehavior**  
   *Triggers actions when the control is right-tapped.*
@@ -487,28 +511,44 @@ This section provides an overview of all available classes and their purpose in 
 - **DoubleTappedGestureTrigger**  
   *Triggers actions when a double-tap gesture is detected.*
 
-- **HoldingGestureTrigger**  
+- **HoldingGestureTrigger**
   *Triggers actions when a holding (long press) gesture is detected.*
+- **HoldingEventTrigger**
+  *Triggers actions when a holding gesture is detected.*
 
-- **PinchEndedGestureTrigger**  
+- **PinchEndedGestureTrigger**
+  *Triggers actions when a pinch gesture has ended.*
+- **PinchEndedEventTrigger**
   *Triggers actions when a pinch gesture has ended.*
 
-- **PinchGestureTrigger**  
+- **PinchGestureTrigger**
+  *Triggers actions during a pinch gesture.*
+- **PinchEventTrigger**
   *Triggers actions during a pinch gesture.*
 
-- **PointerTouchPadGestureMagnifyGestureTrigger**  
+- **PointerTouchPadGestureMagnifyGestureTrigger**
   *Triggers actions during a touchpad magnification gesture.*
+- **PointerTouchPadGestureMagnifyEventTrigger**
+  *Triggers actions during a touchpad magnify gesture.*
 
-- **PointerTouchPadGestureRotateGestureTrigger**  
+- **PointerTouchPadGestureRotateGestureTrigger**
+  *Triggers actions during a touchpad rotation gesture.*
+- **PointerTouchPadGestureRotateEventTrigger**
   *Triggers actions during a touchpad rotation gesture.*
 
-- **PointerTouchPadGestureSwipeGestureTrigger**  
+- **PointerTouchPadGestureSwipeGestureTrigger**
+  *Triggers actions during a touchpad swipe gesture.*
+- **PointerTouchPadGestureSwipeEventTrigger**
   *Triggers actions during a touchpad swipe gesture.*
 
-- **PullGestureEndedGestureTrigger**  
+- **PullGestureEndedGestureTrigger**
+  *Triggers actions when a pull gesture ends.*
+- **PullGestureEndedEventTrigger**
   *Triggers actions when a pull gesture ends.*
 
-- **PullGestureGestureTrigger**  
+- **PullGestureGestureTrigger**
+  *Triggers actions during a pull gesture.*
+- **PullGestureEventTrigger**
   *Triggers actions during a pull gesture.*
 
 - **RightTappedGestureTrigger**  

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/HoldingEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/HoldingEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions when a holding gesture is detected.
+/// </summary>
+public class HoldingEventTrigger : RoutedEventTriggerBase<HoldingRoutedEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<HoldingRoutedEventArgs> RoutedEvent
+        => Gestures.HoldingEvent;
+
+    static HoldingEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<HoldingEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PinchEndedEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PinchEndedEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions when a pinch gesture ends.
+/// </summary>
+public class PinchEndedEventTrigger : RoutedEventTriggerBase<PinchEndedEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PinchEndedEventArgs> RoutedEvent
+        => Gestures.PinchEndedEvent;
+
+    static PinchEndedEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PinchEndedEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PinchEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PinchEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions during a pinch gesture.
+/// </summary>
+public class PinchEventTrigger : RoutedEventTriggerBase<PinchEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PinchEventArgs> RoutedEvent
+        => Gestures.PinchEvent;
+
+    static PinchEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PinchEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PointerTouchPadGestureMagnifyEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PointerTouchPadGestureMagnifyEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions during a touchpad magnify gesture.
+/// </summary>
+public class PointerTouchPadGestureMagnifyEventTrigger : RoutedEventTriggerBase<PointerDeltaEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PointerDeltaEventArgs> RoutedEvent
+        => Gestures.PointerTouchPadGestureMagnifyEvent;
+
+    static PointerTouchPadGestureMagnifyEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PointerTouchPadGestureMagnifyEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PointerTouchPadGestureRotateEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PointerTouchPadGestureRotateEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions during a touchpad rotation gesture.
+/// </summary>
+public class PointerTouchPadGestureRotateEventTrigger : RoutedEventTriggerBase<PointerDeltaEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PointerDeltaEventArgs> RoutedEvent
+        => Gestures.PointerTouchPadGestureRotateEvent;
+
+    static PointerTouchPadGestureRotateEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PointerTouchPadGestureRotateEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PointerTouchPadGestureSwipeEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PointerTouchPadGestureSwipeEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions during a touchpad swipe gesture.
+/// </summary>
+public class PointerTouchPadGestureSwipeEventTrigger : RoutedEventTriggerBase<PointerDeltaEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PointerDeltaEventArgs> RoutedEvent
+        => Gestures.PointerTouchPadGestureSwipeEvent;
+
+    static PointerTouchPadGestureSwipeEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PointerTouchPadGestureSwipeEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PullGestureEndedEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PullGestureEndedEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions when a pull gesture ends.
+/// </summary>
+public class PullGestureEndedEventTrigger : RoutedEventTriggerBase<PullGestureEndedEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PullGestureEndedEventArgs> RoutedEvent
+        => Gestures.PullGestureEndedEvent;
+
+    static PullGestureEndedEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PullGestureEndedEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Gestures/PullGestureEventTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Gestures/PullGestureEventTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Triggers actions during a pull gesture.
+/// </summary>
+public class PullGestureEventTrigger : RoutedEventTriggerBase<PullGestureEventArgs>
+{
+    /// <inheritdoc />
+    protected override RoutedEvent<PullGestureEventArgs> RoutedEvent
+        => Gestures.PullGestureEvent;
+
+    static PullGestureEventTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<PullGestureEventTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Bubble));
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/HoldingEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/HoldingEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for holding gestures and triggers its actions when detected.
+/// </summary>
+public abstract class HoldingEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.HoldingEvent, Holding, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.HoldingEvent, Holding);
+    }
+
+    private void Holding(object? sender, HoldingRoutedEventArgs e)
+    {
+        OnHolding(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a holding gesture is detected.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnHolding(object? sender, HoldingRoutedEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PinchEndedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PinchEndedEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for pinch end gestures and triggers its actions when detected.
+/// </summary>
+public abstract class PinchEndedEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PinchEndedEvent, PinchEnded, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PinchEndedEvent, PinchEnded);
+    }
+
+    private void PinchEnded(object? sender, PinchEndedEventArgs e)
+    {
+        OnPinchEnded(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a pinch gesture ends.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPinchEnded(object? sender, PinchEndedEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PinchEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PinchEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for pinch gestures and triggers its actions when detected.
+/// </summary>
+public abstract class PinchEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PinchEvent, Pinch, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PinchEvent, Pinch);
+    }
+
+    private void Pinch(object? sender, PinchEventArgs e)
+    {
+        OnPinch(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a pinch gesture is detected.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPinch(object? sender, PinchEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PointerTouchPadGestureMagnifyEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerTouchPadGestureMagnifyEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for touchpad magnify gestures and triggers its actions when detected.
+/// </summary>
+public abstract class PointerTouchPadGestureMagnifyEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, PointerTouchPadGestureMagnify, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PointerTouchPadGestureMagnifyEvent, PointerTouchPadGestureMagnify);
+    }
+
+    private void PointerTouchPadGestureMagnify(object? sender, PointerDeltaEventArgs e)
+    {
+        OnPointerTouchPadGestureMagnify(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a touchpad magnify gesture occurs.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPointerTouchPadGestureMagnify(object? sender, PointerDeltaEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PointerTouchPadGestureRotateEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerTouchPadGestureRotateEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for touchpad rotate gestures and triggers its actions when detected.
+/// </summary>
+public abstract class PointerTouchPadGestureRotateEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PointerTouchPadGestureRotateEvent, PointerTouchPadGestureRotate, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PointerTouchPadGestureRotateEvent, PointerTouchPadGestureRotate);
+    }
+
+    private void PointerTouchPadGestureRotate(object? sender, PointerDeltaEventArgs e)
+    {
+        OnPointerTouchPadGestureRotate(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a touchpad rotation gesture occurs.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPointerTouchPadGestureRotate(object? sender, PointerDeltaEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PointerTouchPadGestureSwipeEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerTouchPadGestureSwipeEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for touchpad swipe gestures and triggers its actions when detected.
+/// </summary>
+public abstract class PointerTouchPadGestureSwipeEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PointerTouchPadGestureSwipeEvent, PointerTouchPadGestureSwipe, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PointerTouchPadGestureSwipeEvent, PointerTouchPadGestureSwipe);
+    }
+
+    private void PointerTouchPadGestureSwipe(object? sender, PointerDeltaEventArgs e)
+    {
+        OnPointerTouchPadGestureSwipe(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a touchpad swipe gesture occurs.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPointerTouchPadGestureSwipe(object? sender, PointerDeltaEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PullGestureEndedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PullGestureEndedEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for pull gesture end events and triggers its actions when detected.
+/// </summary>
+public abstract class PullGestureEndedEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PullGestureEndedEvent, PullGestureEnded, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PullGestureEndedEvent, PullGestureEnded);
+    }
+
+    private void PullGestureEnded(object? sender, PullGestureEndedEventArgs e)
+    {
+        OnPullGestureEnded(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a pull gesture ends.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPullGestureEnded(object? sender, PullGestureEndedEventArgs e)
+    {
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Events/PullGestureEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PullGestureEventBehavior.cs
@@ -1,0 +1,36 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Events;
+
+/// <summary>
+/// Listens for pull gestures and triggers its actions when detected.
+/// </summary>
+public abstract class PullGestureEventBehavior : InteractiveBehaviorBase
+{
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        AssociatedObject?.AddHandler(Gestures.PullGestureEvent, PullGesture, RoutingStrategies);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        AssociatedObject?.RemoveHandler(Gestures.PullGestureEvent, PullGesture);
+    }
+
+    private void PullGesture(object? sender, PullGestureEventArgs e)
+    {
+        OnPullGesture(sender, e);
+    }
+
+    /// <summary>
+    /// Called when a pull gesture occurs.
+    /// </summary>
+    /// <param name="sender">The sender object.</param>
+    /// <param name="e">The event args.</param>
+    protected virtual void OnPullGesture(object? sender, PullGestureEventArgs e)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- switch HoldingEventBehavior, PinchEventBehavior and PinchEndedEventBehavior to typed event args
- add new event triggers for pinch, holding, pull and touchpad gestures
- document the event triggers in the README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*