### PR TITLE
Optimize reflection

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -393,6 +393,13 @@ public class ChangePropertyAction : Avalonia.Xaml.Interactivity.StyledElementAct
         }
     }
 
+    /// <summary>
+    /// Creates and compiles a setter for the specified property.
+    /// </summary>
+    /// <param name="propertyInfo">The <see cref="PropertyInfo"/> object representing the property for which the setter is being created.</param>
+    /// <returns>
+    /// An <see cref="Action{T1, T2}"/> delegate that takes an object instance and a value, and sets the value of the specified property on the instance.
+    /// </returns>
     private static Action<object, object?> CreateSetter(PropertyInfo propertyInfo)
     {
         var target = Expression.Parameter(typeof(object), "target");

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -244,6 +244,14 @@ public class ChangePropertyAction : Avalonia.Xaml.Interactivity.StyledElementAct
                     propertyName,
                     targetTypeName));
             }
+            else if (propertyInfo.SetMethod is null)
+            {
+                throw new ArgumentException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Property {0} on type {1} does not have a setter method.",
+                    propertyName,
+                    targetTypeName));
+            }
 
             setter = new PropertySetter(CreateSetter(propertyInfo), propertyInfo.PropertyType);
             s_propertyCache.TryAdd((targetType, propertyName), setter);

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -61,6 +61,8 @@ public class ChangePropertyAction : Avalonia.Xaml.Interactivity.StyledElementAct
 
             return null;
         });
+
+        return cachedValue;
     }
 
     [RequiresUnreferencedCode("This functionality is not compatible with trimming.")]

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -35,7 +35,7 @@ public class ChangePropertyAction : Avalonia.Xaml.Interactivity.StyledElementAct
     [RequiresUnreferencedCode("This functionality is not compatible with trimming.")]
     private static Type? GetTypeByName(string name)
     {
-        return s_typeCache.GetOrAdd(name, static key =>
+        var cachedValue = s_typeCache.GetOrAdd(name, static key =>
         {
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 


### PR DESCRIPTION
## Summary
- reduce reflection with property and type caching in `ChangePropertyAction`
- compile property setters with expressions
- compile method calls for `CallMethodAction`

## Testing
- `./build.sh -t Test` *(failed: `dotnet` not found)*