### PR TITLE
Add InvokeMethodAction generator

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Avalonia.Xaml.Interactions.csproj
+++ b/src/Avalonia.Xaml.Interactions/Avalonia.Xaml.Interactions.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\Avalonia.Xaml.Interactivity\Avalonia.Xaml.Interactivity.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Analyzer Include="SourceGenerators/InvokeMethodActionGenerator.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Avalonia.Xaml.Interactions/Core/GenerateInvokeAttribute.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/GenerateInvokeAttribute.cs
@@ -1,0 +1,13 @@
+#pragma warning disable MA0048 // File name must match type name
+using System;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Marks a method for which an <see cref="InvokeMethodAction"/> delegate should be generated.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+public sealed class GenerateInvokeAttribute : Attribute
+{
+}
+#pragma warning restore MA0048

--- a/src/Avalonia.Xaml.Interactions/Core/IInvokeMethodGenerated.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/IInvokeMethodGenerated.cs
@@ -1,0 +1,16 @@
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Implemented by classes that support generated method invocation.
+/// </summary>
+public interface IInvokeMethodGenerated
+{
+    /// <summary>
+    /// Invokes a generated method.
+    /// </summary>
+    /// <param name="methodName">Name of the method.</param>
+    /// <param name="sender">Action sender.</param>
+    /// <param name="parameter">Action parameter.</param>
+    /// <returns>True if the method was invoked; otherwise false.</returns>
+    bool InvokeGenerated(string methodName, object? sender, object? parameter);
+}

--- a/src/Avalonia.Xaml.Interactions/Core/InvokeMethodAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/InvokeMethodAction.cs
@@ -1,0 +1,25 @@
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// An action that invokes a generated method on a specified object.
+/// If the target object does not implement <see cref="IInvokeMethodGenerated"/>,
+/// the action falls back to <see cref="CallMethodAction"/>.
+/// </summary>
+public class InvokeMethodAction : CallMethodAction
+{
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        var target = GetValue(TargetObjectProperty) ?? sender;
+        if (IsEnabled &&
+            target is IInvokeMethodGenerated generated &&
+            !string.IsNullOrEmpty(MethodName))
+        {
+            return generated.InvokeGenerated(MethodName!, sender, parameter);
+        }
+
+        return base.Execute(sender, parameter);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/SourceGenerators/InvokeMethodActionGenerator.cs
+++ b/src/Avalonia.Xaml.Interactions/SourceGenerators/InvokeMethodActionGenerator.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Avalonia.Xaml.Interactions.SourceGenerators;
+
+[Generator]
+public sealed class InvokeMethodActionGenerator : ISourceGenerator
+{
+    private const string AttributeName = "Avalonia.Xaml.Interactions.Core.GenerateInvokeAttribute";
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.SyntaxReceiver is not SyntaxReceiver receiver)
+        {
+            return;
+        }
+
+        var attributeSymbol = context.Compilation.GetTypeByMetadataName(AttributeName);
+        if (attributeSymbol is null)
+        {
+            return;
+        }
+
+        var methods = new List<(IMethodSymbol Method, ClassDeclarationSyntax ClassSyntax)>();
+        foreach (var method in receiver.CandidateMethods)
+        {
+            var model = context.Compilation.GetSemanticModel(method.SyntaxTree);
+            if (model.GetDeclaredSymbol(method) is IMethodSymbol symbol &&
+                symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeSymbol)))
+            {
+                if (method.Parent is ClassDeclarationSyntax cds)
+                {
+                    methods.Add((symbol, cds));
+                }
+            }
+        }
+
+        foreach (var group in methods.GroupBy(m => m.Method.ContainingType, SymbolEqualityComparer.Default))
+        {
+            var classSymbol = group.Key;
+            var classSyntax = group.First().ClassSyntax;
+            if (!classSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)))
+            {
+                continue;
+            }
+
+            var ns = classSymbol.ContainingNamespace.IsGlobalNamespace
+                ? string.Empty
+                : $"namespace {classSymbol.ContainingNamespace.ToDisplayString()};";
+
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(ns))
+            {
+                sb.AppendLine(ns);
+            }
+
+            sb.AppendLine($"partial class {classSymbol.Name} : Avalonia.Xaml.Interactions.Core.IInvokeMethodGenerated");
+            sb.AppendLine("{");
+            sb.AppendLine("    public bool InvokeGenerated(string methodName, object? sender, object? parameter)");
+            sb.AppendLine("    {");
+            sb.AppendLine("        switch (methodName)");
+            sb.AppendLine("        {");
+
+            foreach (var (methodSymbol, _) in group)
+            {
+                var name = methodSymbol.Name;
+                var parameters = methodSymbol.Parameters;
+                if (parameters.Length == 0)
+                {
+                    sb.AppendLine($"            case \"{name}\":");
+                    sb.AppendLine($"                {name}();");
+                    sb.AppendLine("                return true;");
+                }
+                else if (parameters.Length == 2 && parameters[0].Type.SpecialType == SpecialType.System_Object)
+                {
+                    var secondType = parameters[1].Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    sb.AppendLine($"            case \"{name}\":");
+                    sb.AppendLine($"                {name}(sender, ({secondType})parameter!);");
+                    sb.AppendLine("                return true;");
+                }
+            }
+
+            sb.AppendLine("            default:");
+            sb.AppendLine("                return false;");
+            sb.AppendLine("        }");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+
+            context.AddSource($"{classSymbol.Name}.InvokeMethod.g.cs", sb.ToString());
+        }
+    }
+
+    private sealed class SyntaxReceiver : ISyntaxReceiver
+    {
+        public List<MethodDeclarationSyntax> CandidateMethods { get; } = new();
+
+        public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+        {
+            if (syntaxNode is MethodDeclarationSyntax method && method.AttributeLists.Count > 0)
+            {
+                CandidateMethods.Add(method);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Xaml.Interactions.UnitTests/Core/CallMethodAction001.axaml.cs
+++ b/tests/Avalonia.Xaml.Interactions.UnitTests/Core/CallMethodAction001.axaml.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia.Controls;
 
+using Avalonia.Xaml.Interactions.Core;
+
 namespace Avalonia.Xaml.Interactions.UnitTests.Core;
 
 public partial class CallMethodAction001 : Window
@@ -11,6 +13,7 @@ public partial class CallMethodAction001 : Window
         InitializeComponent();
     }
 
+    [GenerateInvoke]
     public void TestMethod()
     {
         TestProperty = "Test String";

--- a/tests/Avalonia.Xaml.Interactions.UnitTests/Core/CallMethodAction002.axaml.cs
+++ b/tests/Avalonia.Xaml.Interactions.UnitTests/Core/CallMethodAction002.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Controls;
+using Avalonia.Xaml.Interactions.Core;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.Core;
 
@@ -16,6 +17,7 @@ public partial class CallMethodAction002 : Window
         InitializeComponent();
     }
 
+    [GenerateInvoke]
     public void TestMethod(object? sender, EventArgs args)
     {
         TestProperty = "Test String";


### PR DESCRIPTION
## Summary
- add `GenerateInvokeAttribute` and `IInvokeMethodGenerated`
- implement `InvokeMethodAction` for generated calls
- create `InvokeMethodActionGenerator` source generator
- register generator in `Avalonia.Xaml.Interactions.csproj`
- annotate tests with `GenerateInvoke`

## Testing
- `bash -x build.sh Compile` *(fails: curl to download dotnet blocked)*