### PR TITLE
Add new MVVM behaviors and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ This section provides an overview of all available classes and their purpose in 
 - **PopupAction**  
   *Displays a popup window for showing additional UI content.*
 
-- **RemoveClassAction**  
+- **RemoveClassAction**
   *Removes a style class from a control’s class collection.*
+- **GoToStateAction**
+  *Transitions a control to a specified VisualState using Avalonia's VisualStateManager.*
 
 ### Animations
 - **FadeInBehavior**  
@@ -225,8 +227,10 @@ This section provides an overview of all available classes and their purpose in 
 - **DisposingTrigger**  
   *A base class for triggers that need to dispose of resources when detached.*
 
-- **EventTriggerBehavior**  
+- **EventTriggerBehavior**
   *Listens for a specified event on the associated object and triggers actions accordingly.*
+- **EventToCommandBehavior**
+  *Binds an arbitrary event directly to an ICommand for concise event-to-command hookups.*
 
 - **InitializedBehavior**  
   *A base class for behaviors that execute code when the associated object is initialized.*
@@ -711,8 +715,24 @@ This section provides an overview of all available classes and their purpose in 
   *Selects all text in a TextBox immediately upon attachment.*
 
 ### TreeViewItem
-- **ToggleIsExpandedOnDoubleTappedBehavior**  
+- **ToggleIsExpandedOnDoubleTappedBehavior**
   *Toggles the IsExpanded property of a TreeViewItem when it is double-tapped.*
+
+### DataGrid
+- **DataGridSelectionChangedCommandBehavior**
+  *Executes a command whenever the DataGrid selection changes.*
+
+### Window
+- **WindowEventCommandBehavior**
+  *Invokes a command for common window lifecycle events (Opened, Closing, Closed).* 
+
+### Validation
+- **NotifyErrorsCommandBehavior**
+  *Executes a command when the DataContext raises validation errors.*
+
+### Asynchronous
+- **DelayedCommandBehavior**
+  *Runs a command after a specified delay once the control is attached.*
 
 ## Interactivity (Infrastructure)
 

--- a/src/Avalonia.Xaml.Interactions/Core/DataGridSelectionChangedCommandBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/DataGridSelectionChangedCommandBehavior.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Controls.Selection;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Executes a command when the DataGrid selection changes.
+/// </summary>
+public class DataGridSelectionChangedCommandBehavior : DisposingBehavior<DataGrid>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Command"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<DataGridSelectionChangedCommandBehavior, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CommandParameterProperty =
+        AvaloniaProperty.Register<DataGridSelectionChangedCommandBehavior, object?>(nameof(CommandParameter));
+
+    /// <summary>
+    /// Command to execute on selection change.
+    /// </summary>
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Optional command parameter.
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedOverride()
+    {
+        if (AssociatedObject is not { } grid)
+        {
+            return DisposableAction.Empty;
+        }
+
+        void Handler(object? s, SelectionChangedEventArgs e)
+        {
+            if (Command?.CanExecute(CommandParameter) == true)
+            {
+                Command.Execute(CommandParameter);
+            }
+        }
+
+        grid.SelectionChanged += Handler;
+        return DisposableAction.Create(() => grid.SelectionChanged -= Handler);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/DelayedCommandBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/DelayedCommandBehavior.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Executes a command after a delay when attached to the visual tree.
+/// </summary>
+public class DelayedCommandBehavior : AttachedToVisualTreeBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Delay"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TimeSpan> DelayProperty =
+        AvaloniaProperty.Register<DelayedCommandBehavior, TimeSpan>(nameof(Delay), TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Command"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<DelayedCommandBehavior, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CommandParameterProperty =
+        AvaloniaProperty.Register<DelayedCommandBehavior, object?>(nameof(CommandParameter));
+
+    /// <summary>
+    /// Gets or sets the delay before the command is executed.
+    /// </summary>
+    public TimeSpan Delay
+    {
+        get => GetValue(DelayProperty);
+        set => SetValue(DelayProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command to execute.
+    /// </summary>
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command parameter.
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        _ = ExecuteAsync();
+        return DisposableAction.Empty;
+    }
+
+    private async Task ExecuteAsync()
+    {
+        await Task.Delay(Delay);
+        if (Command?.CanExecute(CommandParameter) == true)
+        {
+            Command.Execute(CommandParameter);
+        }
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/EventToCommandBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/EventToCommandBehavior.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Reflection;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Reactive;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Simplified behavior that connects an event to an <see cref="ICommand"/>.
+/// </summary>
+public class EventToCommandBehavior : StyledElementBehavior
+{
+    /// <summary>
+    /// Identifies the <seealso cref="EventName"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> EventNameProperty =
+        AvaloniaProperty.Register<EventToCommandBehavior, string?>(nameof(EventName));
+
+    /// <summary>
+    /// Identifies the <seealso cref="SourceObject"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> SourceObjectProperty =
+        AvaloniaProperty.Register<EventToCommandBehavior, object?>(nameof(SourceObject));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Command"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<EventToCommandBehavior, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CommandParameterProperty =
+        AvaloniaProperty.Register<EventToCommandBehavior, object?>(nameof(CommandParameter));
+
+    /// <summary>
+    /// Identifies the <seealso cref="PassEventArgsToCommand"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> PassEventArgsToCommandProperty =
+        AvaloniaProperty.Register<EventToCommandBehavior, bool>(nameof(PassEventArgsToCommand));
+
+    private object? _resolvedSource;
+    private Delegate? _eventHandler;
+
+    /// <summary>
+    /// Gets or sets the name of the event to listen for.
+    /// </summary>
+    public string? EventName
+    {
+        get => GetValue(EventNameProperty);
+        set => SetValue(EventNameProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the source object from which this behavior listens for events.
+    /// </summary>
+    [ResolveByName]
+    public object? SourceObject
+    {
+        get => GetValue(SourceObjectProperty);
+        set => SetValue(SourceObjectProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command to execute when the event fires.
+    /// </summary>
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a command parameter.
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the event args should be passed to the command.
+    /// </summary>
+    public bool PassEventArgsToCommand
+    {
+        get => GetValue(PassEventArgsToCommandProperty);
+        set => SetValue(PassEventArgsToCommandProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        _resolvedSource = SourceObject ?? AssociatedObject;
+        RegisterEvent();
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        UnregisterEvent();
+        _resolvedSource = null;
+        base.OnDetaching();
+    }
+
+    private void RegisterEvent()
+    {
+        if (_resolvedSource is null || string.IsNullOrEmpty(EventName))
+        {
+            return;
+        }
+
+        var eventInfo = _resolvedSource.GetType().GetRuntimeEvent(EventName!);
+        if (eventInfo is null)
+        {
+            return;
+        }
+
+        var methodInfo = typeof(EventToCommandBehavior).GetTypeInfo().GetDeclaredMethod(nameof(OnEvent));
+        if (methodInfo is null)
+        {
+            return;
+        }
+
+        var eventHandlerType = eventInfo.EventHandlerType;
+        if (eventHandlerType is null)
+        {
+            return;
+        }
+
+        _eventHandler = methodInfo.CreateDelegate(eventHandlerType, this);
+        eventInfo.AddEventHandler(_resolvedSource, _eventHandler);
+    }
+
+    private void UnregisterEvent()
+    {
+        if (_eventHandler is null || _resolvedSource is null || string.IsNullOrEmpty(EventName))
+        {
+            return;
+        }
+
+        var eventInfo = _resolvedSource.GetType().GetRuntimeEvent(EventName!);
+        eventInfo?.RemoveEventHandler(_resolvedSource, _eventHandler);
+        _eventHandler = null;
+    }
+
+    private void OnEvent(object? sender, object eventArgs)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        var parameter = PassEventArgsToCommand ? eventArgs : CommandParameter;
+        if (Command?.CanExecute(parameter) == true)
+        {
+            Command.Execute(parameter);
+        }
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/GoToStateAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/GoToStateAction.cs
@@ -1,0 +1,50 @@
+using Avalonia.Controls;
+using Avalonia.Styling;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Action that switches the visual state of a control.
+/// </summary>
+public class GoToStateAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <seealso cref="StateName"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> StateNameProperty =
+        AvaloniaProperty.Register<GoToStateAction, string?>(nameof(StateName));
+
+    /// <summary>
+    /// Identifies the <seealso cref="UseTransitions"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> UseTransitionsProperty =
+        AvaloniaProperty.Register<GoToStateAction, bool>(nameof(UseTransitions), true);
+
+    /// <summary>
+    /// Gets or sets the state name to switch to.
+    /// </summary>
+    public string? StateName
+    {
+        get => GetValue(StateNameProperty);
+        set => SetValue(StateNameProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether transitions should be used.
+    /// </summary>
+    public bool UseTransitions
+    {
+        get => GetValue(UseTransitionsProperty);
+        set => SetValue(UseTransitionsProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void Invoke(object? parameter)
+    {
+        if (AssociatedObject is Control control && StateName is not null)
+        {
+            VisualStateManager.GoToState(control, StateName, UseTransitions);
+        }
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/NotifyErrorsCommandBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/NotifyErrorsCommandBehavior.cs
@@ -1,0 +1,64 @@
+using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Executes a command when the associated control's DataContext reports validation errors.
+/// </summary>
+public class NotifyErrorsCommandBehavior : DisposingBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Command"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<NotifyErrorsCommandBehavior, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CommandParameterProperty =
+        AvaloniaProperty.Register<NotifyErrorsCommandBehavior, object?>(nameof(CommandParameter));
+
+    /// <summary>
+    /// Gets or sets the command to execute.
+    /// </summary>
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command parameter.
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedOverride()
+    {
+        if (AssociatedObject?.DataContext is not INotifyDataErrorInfo indei)
+        {
+            return DisposableAction.Empty;
+        }
+
+        void Handler(object? s, DataErrorsChangedEventArgs e)
+        {
+            if (Command?.CanExecute(CommandParameter) == true)
+            {
+                Command.Execute(CommandParameter);
+            }
+        }
+
+        indei.ErrorsChanged += Handler;
+
+        return DisposableAction.Create(() => indei.ErrorsChanged -= Handler);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/WindowEventCommandBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/WindowEventCommandBehavior.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Executes a command for specified window events.
+/// </summary>
+public class WindowEventCommandBehavior : AttachedToVisualTreeBehavior<Window>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Event"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<WindowEvent> EventProperty =
+        AvaloniaProperty.Register<WindowEventCommandBehavior, WindowEvent>(nameof(Event));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Command"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<WindowEventCommandBehavior, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CommandParameterProperty =
+        AvaloniaProperty.Register<WindowEventCommandBehavior, object?>(nameof(CommandParameter));
+
+    /// <summary>
+    /// Gets or sets the window event to listen for.
+    /// </summary>
+    public WindowEvent Event
+    {
+        get => GetValue(EventProperty);
+        set => SetValue(EventProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command to execute.
+    /// </summary>
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command parameter.
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        if (AssociatedObject is not Window window)
+        {
+            return DisposableAction.Empty;
+        }
+
+        void Handler(object? sender, EventArgs e)
+        {
+            if (Command?.CanExecute(CommandParameter) == true)
+            {
+                Command.Execute(CommandParameter);
+            }
+        }
+
+        switch (Event)
+        {
+            case WindowEvent.Opened:
+                window.Opened += Handler;
+                break;
+            case WindowEvent.Closing:
+                window.Closing += Handler;
+                break;
+            case WindowEvent.Closed:
+                window.Closed += Handler;
+                break;
+            default:
+                return DisposableAction.Empty;
+        }
+
+        return DisposableAction.Create(() =>
+        {
+            switch (Event)
+            {
+                case WindowEvent.Opened:
+                    window.Opened -= Handler;
+                    break;
+                case WindowEvent.Closing:
+                    window.Closing -= Handler;
+                    break;
+                case WindowEvent.Closed:
+                    window.Closed -= Handler;
+                    break;
+            }
+        });
+    }
+}
+
+/// <summary>
+/// Available window events for <see cref="WindowEventCommandBehavior"/>.
+/// </summary>
+public enum WindowEvent
+{
+    /// <summary>
+    /// Window opened.
+    /// </summary>
+    Opened,
+    /// <summary>
+    /// Window closing.
+    /// </summary>
+    Closing,
+    /// <summary>
+    /// Window closed.
+    /// </summary>
+    Closed,
+}

--- a/tests/Avalonia.Xaml.Interactions.UnitTests/Core/NewBehaviorsTests.cs
+++ b/tests/Avalonia.Xaml.Interactions.UnitTests/Core/NewBehaviorsTests.cs
@@ -1,0 +1,52 @@
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactions.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class NewBehaviorsTests
+{
+    [AvaloniaFact]
+    public void EventToCommandBehavior_CanBeCreated()
+    {
+        var behavior = new EventToCommandBehavior();
+        Assert.NotNull(behavior);
+    }
+
+    [AvaloniaFact]
+    public void GoToStateAction_CanBeCreated()
+    {
+        var action = new GoToStateAction();
+        Assert.NotNull(action);
+    }
+
+    [AvaloniaFact]
+    public void WindowEventCommandBehavior_CanBeCreated()
+    {
+        var behavior = new WindowEventCommandBehavior();
+        Assert.NotNull(behavior);
+    }
+
+    [AvaloniaFact]
+    public void NotifyErrorsCommandBehavior_CanBeCreated()
+    {
+        var behavior = new NotifyErrorsCommandBehavior();
+        Assert.NotNull(behavior);
+    }
+
+    [AvaloniaFact]
+    public void DataGridSelectionChangedCommandBehavior_CanBeCreated()
+    {
+        var behavior = new DataGridSelectionChangedCommandBehavior();
+        Assert.NotNull(behavior);
+    }
+
+    [AvaloniaFact]
+    public void DelayedCommandBehavior_CanBeCreated()
+    {
+        var behavior = new DelayedCommandBehavior();
+        Assert.NotNull(behavior);
+    }
+}


### PR DESCRIPTION
## Summary
- implement EventToCommandBehavior for simpler event to command binding
- add GoToStateAction for visual state transitions
- introduce window, validation, datagrid and async behaviors
- document new behaviors in README
- add unit tests covering the new types

## Testing
- `dotnet test` *(fails: dotnet not found)*