### PR TITLE
Improve event behavior XML docs

### DIFF
--- a/src/Avalonia.Xaml.Interactions.Events/Core/InteractiveBehaviorBase.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/Core/InteractiveBehaviorBase.cs
@@ -4,20 +4,20 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Base class for behaviors that listen for routed events.
 /// </summary>
 public abstract class InteractiveBehaviorBase : StyledElementBehavior<Interactive>
 {
     /// <summary>
-    /// 
+    /// Identifies the <see cref="RoutingStrategies"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<RoutingStrategies> RoutingStrategiesProperty = 
+    public static readonly StyledProperty<RoutingStrategies> RoutingStrategiesProperty =
         AvaloniaProperty.Register<InteractiveBehaviorBase, RoutingStrategies>(
             nameof(RoutingStrategies),
             RoutingStrategies.Bubble);
 
     /// <summary>
-    /// 
+    /// Gets or sets the routing strategies used when subscribing to events.
     /// </summary>
     public RoutingStrategies RoutingStrategies
     {

--- a/src/Avalonia.Xaml.Interactions.Events/DoubleTappedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/DoubleTappedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that listens for <see cref="Gestures.DoubleTappedEvent"/>.
 /// </summary>
 public abstract class DoubleTappedEventBehavior : InteractiveBehaviorBase
 {
@@ -26,7 +26,7 @@ public abstract class DoubleTappedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a double tap gesture is raised on the associated object.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/GotFocusEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/GotFocusEventBehavior.cs
@@ -3,7 +3,7 @@
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.GotFocusEvent"/>.
 /// </summary>
 public abstract class GotFocusEventBehavior : InteractiveBehaviorBase
 {
@@ -25,7 +25,7 @@ public abstract class GotFocusEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when the associated control receives focus.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/KeyDownEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/KeyDownEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that listens for the <see cref="InputElement.KeyDownEvent"/>.
 /// </summary>
 public abstract class KeyDownEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class KeyDownEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a key is pressed while the associated control has focus.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/KeyUpEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/KeyUpEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that listens for the <see cref="InputElement.KeyUpEvent"/>.
 /// </summary>
 public abstract class KeyUpEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class KeyUpEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a key is released while the associated control has focus.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/LostFocusEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/LostFocusEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.LostFocusEvent"/>.
 /// </summary>
 public abstract class LostFocusEventBehavior : InteractiveBehaviorBase
 {
@@ -26,7 +26,7 @@ public abstract class LostFocusEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when the associated control loses focus.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerCaptureLostEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerCaptureLostEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that listens for the <see cref="InputElement.PointerCaptureLostEvent"/>.
 /// </summary>
 public abstract class PointerCaptureLostEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class PointerCaptureLostEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when pointer capture is lost on the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerEnteredEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerEnteredEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.PointerEnteredEvent"/>.
 /// </summary>
 public abstract class PointerEnteredEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class PointerEnteredEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer enters the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerEventsBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerEventsBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that listens for multiple pointer events.
 /// </summary>
 public abstract class PointerEventsBehavior : InteractiveBehaviorBase
 {
@@ -53,7 +53,7 @@ public abstract class PointerEventsBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer is pressed over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -62,7 +62,7 @@ public abstract class PointerEventsBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer is released over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -71,7 +71,7 @@ public abstract class PointerEventsBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer moves over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerExitedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerExitedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.PointerExitedEvent"/>.
 /// </summary>
 public abstract class PointerExitedEventBehavior : InteractiveBehaviorBase
 {
@@ -34,7 +34,7 @@ public abstract class PointerExitedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer leaves the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerMovedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerMovedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.PointerMovedEvent"/>.
 /// </summary>
 public abstract class PointerMovedEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class PointerMovedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer moves over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerPressedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerPressedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.PointerPressedEvent"/>.
 /// </summary>
 public abstract class PointerPressedEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class PointerPressedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer is pressed over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerReleasedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerReleasedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.PointerReleasedEvent"/>.
 /// </summary>
 public abstract class PointerReleasedEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class PointerReleasedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a pointer is released over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/PointerWheelChangedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/PointerWheelChangedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.PointerWheelChangedEvent"/>.
 /// </summary>
 public abstract class PointerWheelChangedEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class PointerWheelChangedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when the mouse wheel changes while over the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/RightTappedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/RightTappedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="Gestures.RightTappedEvent"/>.
 /// </summary>
 public abstract class RightTappedEventBehavior : InteractiveBehaviorBase
 {
@@ -26,7 +26,7 @@ public abstract class RightTappedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a right-tap gesture is raised on the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/ScrollGestureEndedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/ScrollGestureEndedEventBehavior.cs
@@ -3,7 +3,7 @@
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="Gestures.ScrollGestureEndedEvent"/>.
 /// </summary>
 public abstract class ScrollGestureEndedEventBehavior : InteractiveBehaviorBase
 {
@@ -25,7 +25,7 @@ public abstract class ScrollGestureEndedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a scroll gesture ends on the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/ScrollGestureEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/ScrollGestureEventBehavior.cs
@@ -3,7 +3,7 @@
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="Gestures.ScrollGestureEvent"/>.
 /// </summary>
 public abstract class ScrollGestureEventBehavior : InteractiveBehaviorBase
 {
@@ -25,7 +25,7 @@ public abstract class ScrollGestureEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a scroll gesture occurs on the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/TappedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/TappedEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="Gestures.TappedEvent"/>.
 /// </summary>
 public abstract class TappedEventBehavior : InteractiveBehaviorBase
 {
@@ -26,7 +26,7 @@ public abstract class TappedEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when a tap gesture is raised on the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/TextInputEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/TextInputEventBehavior.cs
@@ -4,7 +4,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that listens for the <see cref="InputElement.TextInputEvent"/>.
 /// </summary>
 public abstract class TextInputEventBehavior : InteractiveBehaviorBase
 {
@@ -33,7 +33,7 @@ public abstract class TextInputEventBehavior : InteractiveBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Called when text input is received by the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions.Events/TextInputMethodClientRequestedEventBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Events/TextInputMethodClientRequestedEventBehavior.cs
@@ -5,7 +5,7 @@ using Avalonia.Interactivity;
 namespace Avalonia.Xaml.Interactions.Events;
 
 /// <summary>
-/// 
+/// Behavior that handles the <see cref="InputElement.TextInputMethodClientRequestedEvent"/>.
 /// </summary>
 public abstract class TextInputMethodClientRequestedEventBehavior : InteractiveBehaviorBase
 {
@@ -34,7 +34,7 @@ public abstract class TextInputMethodClientRequestedEventBehavior : InteractiveB
     }
 
     /// <summary>
-    /// 
+    /// Called when a text input method client is requested for the associated control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>

--- a/src/Avalonia.Xaml.Interactions/StorageProvider/OpenFilePickerBehaviorBase.cs
+++ b/src/Avalonia.Xaml.Interactions/StorageProvider/OpenFilePickerBehaviorBase.cs
@@ -50,7 +50,7 @@ public abstract class OpenFilePickerBehaviorBase : PickerBehaviorBase
     }
 
     /// <summary>
-    /// 
+    /// Executes the open file picker using the provided sender and parameter.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="parameter"></param>


### PR DESCRIPTION
## Summary
- fill out missing XML documentation comments for event behaviors
- document routing strategies property and file picker Execute method

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*