### PR TITLE
Add show/hide control actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,16 @@ This section provides an overview of all available classes and their purpose in 
 - **CloseNotificationAction**  
   *Closes an open notification, for example, from a notification control.*
 
-- **FocusControlAction**  
+- **FocusControlAction**
   *Sets the keyboard focus on a specified control or the associated control.*
 
-- **PopupAction**  
+- **HideControlAction**
+  *Hides a control by setting its `IsVisible` property to false.*
+
+- **ShowControlAction**
+  *Shows a control and gives it focus when executed.*
+
+- **PopupAction**
   *Displays a popup window for showing additional UI content.*
 
 - **RemoveClassAction**  

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/HideControlAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/HideControlAction.cs
@@ -25,14 +25,14 @@ public class HideControlAction : StyledElementAction
     }
 
     /// <inheritdoc />
-    public override object? Execute(object? sender, object? parameter)
+    public override object Execute(object? sender, object? parameter)
     {
         if (!IsEnabled)
         {
             return false;
         }
 
-        var control = GetValue(TargetControlProperty) is not null ? TargetControl : sender as Control;
+        var control = TargetControl ?? sender as Control;
         if (control is null)
         {
             return false;

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/HideControlAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/HideControlAction.cs
@@ -1,0 +1,48 @@
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Hides the associated or target control when executed.
+/// </summary>
+public class HideControlAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<HideControlAction, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Gets or sets the target control. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object? Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var control = GetValue(TargetControlProperty) is not null ? TargetControl : sender as Control;
+        if (control is null)
+        {
+            return false;
+        }
+
+        if (control.IsVisible)
+        {
+            control.SetCurrentValue(Visual.IsVisibleProperty, false);
+        }
+
+        return true;
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowControlAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowControlAction.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Threading;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Custom;
@@ -26,14 +25,14 @@ public class ShowControlAction : StyledElementAction
     }
 
     /// <inheritdoc />
-    public override object? Execute(object? sender, object? parameter)
+    public override object Execute(object? sender, object? parameter)
     {
         if (!IsEnabled)
         {
             return false;
         }
 
-        var control = GetValue(TargetControlProperty) is not null ? TargetControl : sender as Control;
+        var control = TargetControl ?? sender as Control;
         if (control is null)
         {
             return false;
@@ -42,7 +41,6 @@ public class ShowControlAction : StyledElementAction
         if (!control.IsVisible)
         {
             control.SetCurrentValue(Visual.IsVisibleProperty, true);
-            Dispatcher.UIThread.Post(() => control.Focus());
         }
 
         return true;

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowControlAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowControlAction.cs
@@ -1,0 +1,50 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Shows the associated or target control when executed.
+/// </summary>
+public class ShowControlAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<ShowControlAction, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Gets or sets the target control. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object? Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var control = GetValue(TargetControlProperty) is not null ? TargetControl : sender as Control;
+        if (control is null)
+        {
+            return false;
+        }
+
+        if (!control.IsVisible)
+        {
+            control.SetCurrentValue(Visual.IsVisibleProperty, true);
+            Dispatcher.UIThread.Post(() => control.Focus());
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ShowControlAction` and `HideControlAction` to toggle visibility of controls
- document new actions in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*