### PR TITLE
Add ShowContextMenuAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ This section provides an overview of all available classes and their purpose in 
 - **PopupAction**  
   *Displays a popup window for showing additional UI content.*
 
-- **RemoveClassAction**  
+- **RemoveClassAction**
   *Removes a style class from a control’s class collection.*
+
+- **ShowContextMenuAction**
+  *Displays a control's context menu programmatically.*
 
 ### Animations
 - **FadeInBehavior**  

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowContextMenuAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowContextMenuAction.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Metadata;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Custom;
@@ -31,7 +30,7 @@ public class ShowContextMenuAction : StyledElementAction
     /// <param name="sender">The object that triggered the action.</param>
     /// <param name="parameter">Optional parameter.</param>
     /// <returns>True if a context menu was shown; otherwise false.</returns>
-    public override object? Execute(object? sender, object? parameter)
+    public override object Execute(object? sender, object? parameter)
     {
         if (!IsEnabled)
         {
@@ -39,13 +38,13 @@ public class ShowContextMenuAction : StyledElementAction
         }
 
         var control = TargetControl ?? sender as Control;
-        var menu = control?.ContextMenu;
-        if (control is null || menu is null)
+        var contextMenu = control?.ContextMenu;
+        if (control is null || contextMenu is null)
         {
             return false;
         }
 
-        menu.Open(control);
+        contextMenu.Open(control);
         return true;
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowContextMenuAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowContextMenuAction.cs
@@ -1,0 +1,51 @@
+using Avalonia.Controls;
+using Avalonia.Metadata;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Shows the <see cref="ContextMenu"/> of the associated or target control when executed.
+/// </summary>
+public class ShowContextMenuAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <seealso cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<ShowContextMenuAction, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Gets or sets the control whose context menu will be shown. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The object that triggered the action.</param>
+    /// <param name="parameter">Optional parameter.</param>
+    /// <returns>True if a context menu was shown; otherwise false.</returns>
+    public override object? Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var control = TargetControl ?? sender as Control;
+        var menu = control?.ContextMenu;
+        if (control is null || menu is null)
+        {
+            return false;
+        }
+
+        menu.Open(control);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ShowContextMenuAction` for displaying a control's context menu
- document the new action in the README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*