### PR TITLE
Add ShowHideFlyoutAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ This section provides an overview of all available classes and their purpose in 
 - **PopupAction**
   *Displays a popup window for showing additional UI content.*
 
-- **ShowHideFlyoutAction**
-  *Shows or hides a flyout attached to a control or specified explicitly.*
+- **ShowFlyoutAction**
+  *Shows a flyout attached to a control or specified explicitly.*
+
+- **HideFlyoutAction**
+  *Hides a flyout attached to a control or specified explicitly.*
 
 - **RemoveClassAction**  
   *Removes a style class from a control’s class collection.*

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ This section provides an overview of all available classes and their purpose in 
 - **FocusControlAction**  
   *Sets the keyboard focus on a specified control or the associated control.*
 
-- **PopupAction**  
+- **PopupAction**
   *Displays a popup window for showing additional UI content.*
+
+- **ShowHideFlyoutAction**
+  *Shows or hides a flyout attached to a control or specified explicitly.*
 
 - **RemoveClassAction**  
   *Removes a style class from a control’s class collection.*

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/HideFlyoutAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/HideFlyoutAction.cs
@@ -1,0 +1,82 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Hides a <see cref="FlyoutBase"/> when executed.
+/// </summary>
+public class HideFlyoutAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Flyout"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<FlyoutBase?> FlyoutProperty =
+        AvaloniaProperty.Register<HideFlyoutAction, FlyoutBase?>(nameof(Flyout));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<HideFlyoutAction, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Identifies the <seealso cref="IsOpen"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsOpenProperty =
+        AvaloniaProperty.Register<HideFlyoutAction, bool>(nameof(IsOpen), true);
+
+    /// <summary>
+    /// Gets or sets the flyout instance to hide. If not set, the attached flyout of the target control is used.
+    /// </summary>
+    public FlyoutBase? Flyout
+    {
+        get => GetValue(FlyoutProperty);
+        set => SetValue(FlyoutProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the target control that hosts the flyout. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the flyout should be shown or hidden when the action executes.
+    /// </summary>
+    public bool IsOpen
+    {
+        get => GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var control = TargetControl ?? sender as Control;
+        if (control is null)
+        {
+            return false;
+        }
+
+        var flyout = Flyout ?? FlyoutBase.GetAttachedFlyout(control);
+        if (flyout is null)
+        {
+            return false;
+        }
+
+        flyout.Hide();
+
+        return true;
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowFlyoutAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowFlyoutAction.cs
@@ -5,30 +5,24 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Shows or hides a <see cref="FlyoutBase"/> when executed.
+/// Shows a <see cref="FlyoutBase"/> when executed.
 /// </summary>
-public class ShowHideFlyoutAction : StyledElementAction
+public class ShowFlyoutAction : StyledElementAction
 {
     /// <summary>
     /// Identifies the <seealso cref="Flyout"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<FlyoutBase?> FlyoutProperty =
-        AvaloniaProperty.Register<ShowHideFlyoutAction, FlyoutBase?>(nameof(Flyout));
+        AvaloniaProperty.Register<ShowFlyoutAction, FlyoutBase?>(nameof(Flyout));
 
     /// <summary>
     /// Identifies the <seealso cref="TargetControl"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<Control?> TargetControlProperty =
-        AvaloniaProperty.Register<ShowHideFlyoutAction, Control?>(nameof(TargetControl));
+        AvaloniaProperty.Register<ShowFlyoutAction, Control?>(nameof(TargetControl));
 
     /// <summary>
-    /// Identifies the <seealso cref="IsOpen"/> avalonia property.
-    /// </summary>
-    public static readonly StyledProperty<bool> IsOpenProperty =
-        AvaloniaProperty.Register<ShowHideFlyoutAction, bool>(nameof(IsOpen), true);
-
-    /// <summary>
-    /// Gets or sets the flyout instance to show or hide. If not set, the attached flyout of the target control is used.
+    /// Gets or sets the flyout instance to show. If not set, the attached flyout of the target control is used.
     /// </summary>
     public FlyoutBase? Flyout
     {
@@ -44,15 +38,6 @@ public class ShowHideFlyoutAction : StyledElementAction
     {
         get => GetValue(TargetControlProperty);
         set => SetValue(TargetControlProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the flyout should be shown or hidden when the action executes.
-    /// </summary>
-    public bool IsOpen
-    {
-        get => GetValue(IsOpenProperty);
-        set => SetValue(IsOpenProperty, value);
     }
 
     /// <inheritdoc />
@@ -75,14 +60,7 @@ public class ShowHideFlyoutAction : StyledElementAction
             return false;
         }
 
-        if (IsOpen)
-        {
-            flyout.ShowAt(control);
-        }
-        else
-        {
-            flyout.Hide();
-        }
+        flyout.ShowAt(control);
 
         return true;
     }

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowHideFlyoutAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ShowHideFlyoutAction.cs
@@ -1,0 +1,89 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Shows or hides a <see cref="FlyoutBase"/> when executed.
+/// </summary>
+public class ShowHideFlyoutAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Flyout"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<FlyoutBase?> FlyoutProperty =
+        AvaloniaProperty.Register<ShowHideFlyoutAction, FlyoutBase?>(nameof(Flyout));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<ShowHideFlyoutAction, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Identifies the <seealso cref="IsOpen"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsOpenProperty =
+        AvaloniaProperty.Register<ShowHideFlyoutAction, bool>(nameof(IsOpen), true);
+
+    /// <summary>
+    /// Gets or sets the flyout instance to show or hide. If not set, the attached flyout of the target control is used.
+    /// </summary>
+    public FlyoutBase? Flyout
+    {
+        get => GetValue(FlyoutProperty);
+        set => SetValue(FlyoutProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the target control that hosts the flyout. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the flyout should be shown or hidden when the action executes.
+    /// </summary>
+    public bool IsOpen
+    {
+        get => GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object? Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var control = TargetControl ?? sender as Control;
+        if (control is null)
+        {
+            return false;
+        }
+
+        var flyout = Flyout ?? FlyoutBase.GetAttachedFlyout(control);
+        if (flyout is null)
+        {
+            return false;
+        }
+
+        if (IsOpen)
+        {
+            flyout.ShowAt(control);
+        }
+        else
+        {
+            flyout.Hide();
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ShowHideFlyoutAction` to allow showing or hiding a flyout programmatically
- document the action in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*