### PR TITLE
Add missing drag-and-drop behavior samples

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -94,8 +94,14 @@
     <TabItem Header="File Drop Handler">
       <pages:FileDropHandlerView />
     </TabItem>
+    <TabItem Header="ContentControlFilesDropBehavior">
+      <pages:ContentControlFilesDropBehaviorView />
+    </TabItem>
     <TabItem Header="Drag and Drop">
       <pages:DragAndDropView />
+    </TabItem>
+    <TabItem Header="TypedDragBehavior">
+      <pages:TypedDragBehaviorView />
     </TabItem>
     <TabItem Header="Draggable">
       <pages:DraggableView />

--- a/samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml
@@ -1,0 +1,25 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:Class="BehaviorsTestApplication.Views.Pages.ContentControlFilesDropBehaviorView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+
+  <StackPanel Margin="5" Spacing="5">
+    <ContentControl Padding="20" BorderBrush="{DynamicResource SystemAccentColor}" BorderThickness="1">
+      <Interaction.Behaviors>
+        <ContentControlFilesDropBehavior
+          Command="{Binding OpenFilesCommand}"
+          ContentDuringDrag="Drop files here"
+          BackgroundDuringDrag="{DynamicResource SystemAccentColor}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Drag files here" HorizontalAlignment="Center" VerticalAlignment="Center" />
+    </ContentControl>
+    <ListBox ItemsSource="{Binding FileItems}" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml
@@ -11,14 +11,23 @@
   </Design.DataContext>
 
   <StackPanel Margin="5" Spacing="5">
-    <ContentControl Padding="20" BorderBrush="{DynamicResource SystemAccentColor}" BorderThickness="1">
+    <ContentControl Classes="Drag" Padding="20" BorderBrush="{DynamicResource SystemAccentColor}" BorderThickness="1">
+      <ContentControl.Styles>
+        <Style Selector="ContentControl.Drag">
+          <Setter Property="Content" Value="Drag files here" />
+        </Style>
+      </ContentControl.Styles>
       <Interaction.Behaviors>
         <ContentControlFilesDropBehavior
           Command="{Binding OpenFilesCommand}"
           ContentDuringDrag="Drop files here"
           BackgroundDuringDrag="{DynamicResource SystemAccentColor}" />
       </Interaction.Behaviors>
-      <TextBlock Text="Drag files here" HorizontalAlignment="Center" VerticalAlignment="Center" />
+      <ContentControl.ContentTemplate>
+        <DataTemplate DataType="x:String">
+          <TextBlock Text="{Binding .}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+        </DataTemplate>
+      </ContentControl.ContentTemplate>
     </ContentControl>
     <ListBox ItemsSource="{Binding FileItems}" />
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ContentControlFilesDropBehaviorView : UserControl
+{
+    public ContentControlFilesDropBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/TypedDragBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/TypedDragBehaviorView.axaml
@@ -1,0 +1,47 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:Class="BehaviorsTestApplication.Views.Pages.TypedDragBehaviorView"
+             x:DataType="vm:DragAndDropSampleViewModel"
+             x:CompileBindings="True"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:DragAndDropSampleViewModel />
+  </Design.DataContext>
+
+  <UserControl.Styles>
+    <Style Selector="ListBox.TypedDragAndDrop">
+      <Style.Resources>
+        <ItemsListBoxDropHandler x:Key="ItemsListBoxDropHandler" />
+      </Style.Resources>
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDropBehavior Handler="{StaticResource ItemsListBoxDropHandler}" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="ListBox.TypedDragAndDrop ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <TypedDragBehavior DataType="vm:DragItemViewModel" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+  </UserControl.Styles>
+
+  <ListBox ItemsSource="{Binding Items}" Classes="TypedDragAndDrop">
+    <ListBox.ItemTemplate>
+      <DataTemplate DataType="vm:DragItemViewModel">
+        <TextBlock Text="{Binding Title}" />
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/TypedDragBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/TypedDragBehaviorView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using BehaviorsTestApplication.ViewModels;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class TypedDragBehaviorView : UserControl
+{
+    public TypedDragBehaviorView()
+    {
+        InitializeComponent();
+        DataContext = new DragAndDropSampleViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add new sample page for `ContentControlFilesDropBehavior`
- add new sample page for `TypedDragBehavior`
- expose the new samples via `MainView`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not installed)*