### PR TITLE
Fix draggable behaviors with non-virtualizing panels

### DIFF
--- a/src/Avalonia.Xaml.Interactions.Draggable/CanvasDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/CanvasDragBehavior.cs
@@ -16,7 +16,6 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
     private Control? _parent;
     private Control? _draggedContainer;
     private Control? _adorner;
-    private bool _captured;
 
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
@@ -87,13 +86,13 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
 
             // AddAdorner(_draggedContainer);
 
-            _captured = e.Pointer.Capture(AssociatedObject);
+            e.Pointer.Capture(AssociatedObject);
         }
     }
 
     private void Released(object? sender, PointerReleasedEventArgs e)
     {
-        if (_captured)
+        if (Equals(e.Pointer.Captured, AssociatedObject))
         {
             if (e.InitialPressMouseButton == MouseButton.Left)
             {
@@ -101,20 +100,18 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
             }
 
             e.Pointer.Capture(null);
-            _captured = false;
         }
     }
 
     private void CaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
         Released();
-        _captured = false;
     }
 
     private void Moved(object? sender, PointerEventArgs e)
     {
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
-        if (_captured
+        if (Equals(e.Pointer.Captured, AssociatedObject)
             && properties.IsLeftButtonPressed)
         {
             if (_parent is null || _draggedContainer is null || !_enableDrag)

--- a/src/Avalonia.Xaml.Interactions.Draggable/CanvasDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/CanvasDragBehavior.cs
@@ -87,7 +87,7 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
 
             // AddAdorner(_draggedContainer);
 
-            _captured = true;
+            _captured = e.Pointer.Capture(AssociatedObject);
         }
     }
 
@@ -100,6 +100,7 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
                 Released();
             }
 
+            e.Pointer.Capture(null);
             _captured = false;
         }
     }

--- a/src/Avalonia.Xaml.Interactions.Draggable/GridDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/GridDragBehavior.cs
@@ -146,7 +146,7 @@ public class GridDragBehavior : StyledElementBehavior<Control>
 
             // AddAdorner(_draggedContainer);
 
-            _captured = true;
+            _captured = e.Pointer.Capture(AssociatedObject);
         }
     }
 
@@ -159,6 +159,7 @@ public class GridDragBehavior : StyledElementBehavior<Control>
                 Released();
             }
 
+            e.Pointer.Capture(null);
             _captured = false;
         }
     }

--- a/src/Avalonia.Xaml.Interactions.Draggable/GridDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/GridDragBehavior.cs
@@ -39,7 +39,6 @@ public class GridDragBehavior : StyledElementBehavior<Control>
     private Control? _parent;
     private Control? _draggedContainer;
     private Control? _adorner;
-    private bool _captured;
         
     /// <summary>
     /// Gets or sets whether to copy the dragged element's column.
@@ -146,13 +145,13 @@ public class GridDragBehavior : StyledElementBehavior<Control>
 
             // AddAdorner(_draggedContainer);
 
-            _captured = e.Pointer.Capture(AssociatedObject);
+            e.Pointer.Capture(AssociatedObject);
         }
     }
 
     private void Released(object? sender, PointerReleasedEventArgs e)
     {
-        if (_captured)
+        if (Equals(e.Pointer.Captured, AssociatedObject))
         {
             if (e.InitialPressMouseButton == MouseButton.Left)
             {
@@ -160,20 +159,18 @@ public class GridDragBehavior : StyledElementBehavior<Control>
             }
 
             e.Pointer.Capture(null);
-            _captured = false;
         }
     }
 
     private void CaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
         Released();
-        _captured = false;
     }
 
     private void Moved(object? sender, PointerEventArgs e)
     {
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
-        if (_captured
+        if (Equals(e.Pointer.Captured, AssociatedObject)
             && properties.IsLeftButtonPressed)
         {
             if (_parent is null || _draggedContainer is null || !_enableDrag)

--- a/src/Avalonia.Xaml.Interactions.Draggable/ItemDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/ItemDragBehavior.cs
@@ -114,7 +114,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
 
             AddTransforms(_itemsControl);
 
-            _captured = true;
+            _captured = e.Pointer.Capture(AssociatedObject);
         }
     }
 
@@ -127,6 +127,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
                 Released();
             }
 
+            e.Pointer.Capture(null);
             _captured = false;
         }
     }

--- a/src/Avalonia.Xaml.Interactions.Draggable/ItemDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/ItemDragBehavior.cs
@@ -22,7 +22,6 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
     private int _targetIndex;
     private ItemsControl? _itemsControl;
     private Control? _draggedContainer;
-    private bool _captured;
 
     /// <summary>
     /// Identifies the <see cref="Orientation"/> avalonia property.
@@ -114,13 +113,13 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
 
             AddTransforms(_itemsControl);
 
-            _captured = e.Pointer.Capture(AssociatedObject);
+            e.Pointer.Capture(AssociatedObject);
         }
     }
 
     private void PointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        if (_captured)
+        if (Equals(e.Pointer.Captured, AssociatedObject))
         {
             if (e.InitialPressMouseButton == MouseButton.Left)
             {
@@ -128,14 +127,12 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
             }
 
             e.Pointer.Capture(null);
-            _captured = false;
         }
     }
 
     private void PointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
         Released();
-        _captured = false;
     }
 
     private void Released()
@@ -259,7 +256,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
     private void PointerMoved(object? sender, PointerEventArgs e)
     {
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
-        if (_captured
+        if (Equals(e.Pointer.Captured, AssociatedObject)
             && properties.IsLeftButtonPressed)
         {
             if (_itemsControl?.Items is null || _draggedContainer?.RenderTransform is null || !_enableDrag)


### PR DESCRIPTION
## Summary
- ensure CanvasDragBehavior, GridDragBehavior and ItemDragBehavior capture and release the pointer
  so pointer released events are always received

## Testing
- `dotnet test` *(fails: `dotnet` not found)*