### PR TITLE
Add ExecuteCompiledScriptAction source generator

### DIFF
--- a/AvaloniaBehaviors.sln
+++ b/AvaloniaBehaviors.sln
@@ -79,6 +79,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Xaml.Interactions.ReactiveUI", "src\Avalonia.Xaml.Interactions.ReactiveUI\Avalonia.Xaml.Interactions.ReactiveUI.csproj", "{25AC5B10-0D9A-4070-8D96-DB593790C288}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Xaml.Interactions.Scripting", "src\Avalonia.Xaml.Interactions.Scripting\Avalonia.Xaml.Interactions.Scripting.csproj", "{AF98B42B-1483-47DA-903F-4C1BE6573B9B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Xaml.Interactions.Scripting.Generator", "src\Avalonia.Xaml.Interactions.Scripting.Generator\Avalonia.Xaml.Interactions.Scripting.Generator.csproj", "{EFCD4B24-4A40-4C2A-9E5F-C9AF9439689F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,9 +145,13 @@ Global
 		{25AC5B10-0D9A-4070-8D96-DB593790C288}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AF98B42B-1483-47DA-903F-4C1BE6573B9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AF98B42B-1483-47DA-903F-4C1BE6573B9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AF98B42B-1483-47DA-903F-4C1BE6573B9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AF98B42B-1483-47DA-903F-4C1BE6573B9B}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {AF98B42B-1483-47DA-903F-4C1BE6573B9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {AF98B42B-1483-47DA-903F-4C1BE6573B9B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {EFCD4B24-4A40-4C2A-9E5F-C9AF9439689F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EFCD4B24-4A40-4C2A-9E5F-C9AF9439689F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EFCD4B24-4A40-4C2A-9E5F-C9AF9439689F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EFCD4B24-4A40-4C2A-9E5F-C9AF9439689F}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -168,8 +174,9 @@ Global
 		{80D2C64D-B560-475D-941F-D5F28DDB2591} = {2BDB1F89-9B32-45A8-AAE2-3DC61281F9FE}
 		{C2229490-39CA-4192-A28C-1B5EC186E027} = {2BDB1F89-9B32-45A8-AAE2-3DC61281F9FE}
 		{25AC5B10-0D9A-4070-8D96-DB593790C288} = {84224365-32B6-46AF-85A2-45640E6D7EEB}
-		{AF98B42B-1483-47DA-903F-4C1BE6573B9B} = {84224365-32B6-46AF-85A2-45640E6D7EEB}
-	EndGlobalSection
+                {AF98B42B-1483-47DA-903F-4C1BE6573B9B} = {84224365-32B6-46AF-85A2-45640E6D7EEB}
+                {EFCD4B24-4A40-4C2A-9E5F-C9AF9439689F} = {84224365-32B6-46AF-85A2-45640E6D7EEB}
+        EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E64CD420-15B1-487C-9806-41EBE6DC15A4}
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -751,6 +751,13 @@ This section provides an overview of all available classes and their purpose in 
 ### Scripting
 - **ExecuteScriptAction**
   *Executes a C# script using the Roslyn scripting API.*
+- **ExecuteCompiledScriptAction**
+  *Executes C# code generated at build time via a source generator.*
+
+  `Avalonia.Xaml.Interactions.Scripting.Generator` scans XAML files for
+  `ExecuteCompiledScriptAction` elements and emits a partial method
+  implementation based on the provided `Script` property. This removes the
+  runtime Roslyn compilation cost.
 
 ### ReactiveUI
 - **ClearNavigationStackAction**

--- a/src/Avalonia.Xaml.Interactions.Scripting.Generator/Avalonia.Xaml.Interactions.Scripting.Generator.csproj
+++ b/src/Avalonia.Xaml.Interactions.Scripting.Generator/Avalonia.Xaml.Interactions.Scripting.Generator.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+  </ItemGroup>
+  <PropertyGroup>
+    <AnalyzerAssembly>$(TargetPath)</AnalyzerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**/*.cs" />
+    <AdditionalFiles Include="**/*.axaml" />
+    <AdditionalFiles Include="**/*.xaml" />
+  </ItemGroup>
+</Project>

--- a/src/Avalonia.Xaml.Interactions.Scripting.Generator/ExecuteCompiledScriptActionGenerator.cs
+++ b/src/Avalonia.Xaml.Interactions.Scripting.Generator/ExecuteCompiledScriptActionGenerator.cs
@@ -1,0 +1,58 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Linq;
+
+namespace Avalonia.Xaml.Interactions.Scripting.Generator;
+
+[Generator]
+public class ExecuteCompiledScriptActionGenerator : IIncrementalGenerator
+{
+    private static readonly Regex s_scriptRegex = new(
+        "<[^:]+:ExecuteCompiledScriptAction[^>]*Script=\"(?<script>[^\"]*)\"",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var xamlFiles = context.AdditionalTextsProvider.Where(static file =>
+            file.Path.EndsWith(".xaml") || file.Path.EndsWith(".axaml"));
+
+        var scriptEntries = xamlFiles.SelectMany((file, cancellation) =>
+        {
+            var text = file.GetText(cancellation);
+            if (text is null)
+            {
+                return ImmutableArray<(string Path, string Script)>.Empty;
+            }
+
+            var matches = s_scriptRegex.Matches(text.ToString());
+            var builder = ImmutableArray.CreateBuilder<(string, string)>();
+            foreach (Match match in matches.Cast<Match>())
+            {
+                if (match.Groups["script"].Success)
+                {
+                    builder.Add((file.Path, match.Groups["script"].Value));
+                }
+            }
+            return builder.ToImmutable();
+        });
+
+        context.RegisterSourceOutput(scriptEntries, static (spc, entry) =>
+        {
+            var (path, script) = entry;
+            var className = $"ExecuteCompiledScriptAction_{path.GetHashCode():X}";
+            var source = $@"namespace Avalonia.Xaml.Interactions.Scripting;
+public partial class {className} : ExecuteCompiledScriptAction
+{{
+    partial void ExecuteCompiledCode(object? sender, object? parameter)
+    {{
+        {script}
+    }}
+}}";
+            spc.AddSource($"{className}.g.cs", SourceText.From(source, Encoding.UTF8));
+        });
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Scripting/ExecuteCompiledScriptAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Scripting/ExecuteCompiledScriptAction.cs
@@ -1,0 +1,49 @@
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Scripting;
+
+/// <summary>
+/// Executes C# code that is generated at build time from a script.
+/// </summary>
+/// <remarks>
+/// A source generator or Fody weaver is expected to replace the body of
+/// <see cref="ExecuteCompiledCode"/> with code produced from the provided script.
+/// </remarks>
+public partial class ExecuteCompiledScriptAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="Script"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ScriptProperty =
+        AvaloniaProperty.Register<ExecuteCompiledScriptAction, string?>(nameof(Script));
+
+    /// <summary>
+    /// Gets or sets the C# script which will be processed at build time.
+    /// This is an avalonia property.
+    /// </summary>
+    public string? Script
+    {
+        get => GetValue(ScriptProperty);
+        set => SetValue(ScriptProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        ExecuteCompiledCode(sender, parameter);
+        return true;
+    }
+
+    /// <summary>
+    /// Contains the code generated from <see cref="Script"/>.
+    /// This method is populated by a source generator or Fody weaver at build time.
+    /// </summary>
+    /// <param name="sender">The object that invoked the action.</param>
+    /// <param name="parameter">Additional data passed to the action.</param>
+    partial void ExecuteCompiledCode(object? sender, object? parameter);
+}


### PR DESCRIPTION
## Summary
- add ExecuteCompiledScriptActionGenerator to compile scripts at build time
- document generator usage

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*