### PR TITLE
Add TranslateZoomRotateBehavior

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -124,5 +124,8 @@
     <TabItem Header="Reactive Navigation">
       <pages:ReactiveNavigationView />
     </TabItem>
+    <TabItem Header="TranslateZoomRotateBehavior">
+      <pages:TranslateZoomRotateBehaviorView />
+    </TabItem>
   </TabControl>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/TranslateZoomRotateBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/TranslateZoomRotateBehaviorView.axaml
@@ -3,12 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
   <Canvas Background="{DynamicResource GrayBrush}">
     <Rectangle Width="100" Height="100" Fill="{DynamicResource BlueBrush}">
       <Interaction.Behaviors>
-        <custom:TranslateZoomRotateBehavior />
+        <TranslateZoomRotateBehavior />
       </Interaction.Behaviors>
     </Rectangle>
   </Canvas>

--- a/samples/BehaviorsTestApplication/Views/Pages/TranslateZoomRotateBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/TranslateZoomRotateBehaviorView.axaml
@@ -1,0 +1,15 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.TranslateZoomRotateBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Canvas Background="{DynamicResource GrayBrush}">
+    <Rectangle Width="100" Height="100" Fill="{DynamicResource BlueBrush}">
+      <Interaction.Behaviors>
+        <custom:TranslateZoomRotateBehavior />
+      </Interaction.Behaviors>
+    </Rectangle>
+  </Canvas>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/TranslateZoomRotateBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/TranslateZoomRotateBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class TranslateZoomRotateBehaviorView : UserControl
+{
+    public TranslateZoomRotateBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Control/TranslateZoomRotateBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Control/TranslateZoomRotateBehavior.cs
@@ -1,7 +1,6 @@
-using System;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Xaml.Interactivity;
 
@@ -145,19 +144,21 @@ public sealed class TranslateZoomRotateBehavior : StyledElementBehavior<Control>
 
         if (e is PinchEventArgs pinch)
         {
-            var origin = pinch.Origin;
-            _scale.CenterX = origin.X;
-            _scale.CenterY = origin.Y;
+            var origin = pinch.ScaleOrigin;
+            // TODO:
+            // _scale.CenterX = origin.X;
+            // _scale.CenterY = origin.Y;
             _scale.ScaleX *= pinch.Scale;
             _scale.ScaleY *= pinch.Scale;
 
             _rotate.CenterX = origin.X;
             _rotate.CenterY = origin.Y;
-            _rotate.Angle += pinch.Rotation;
+            _rotate.Angle += pinch.Angle;
 
-            var delta = pinch.Translation;
-            _translate.X += delta.X;
-            _translate.Y += delta.Y;
+            // TODO:
+            // var delta = pinch.Translation;
+            // _translate.X += delta.X;
+            // _translate.Y += delta.Y;
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/Control/TranslateZoomRotateBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Control/TranslateZoomRotateBehavior.cs
@@ -1,0 +1,163 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Behavior that enables translate, zoom and rotate interactions on a control using multi-touch gestures.
+/// </summary>
+public sealed class TranslateZoomRotateBehavior : StyledElementBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<TranslateZoomRotateBehavior, Control?>(nameof(TargetControl));
+
+    private Control? _parent;
+    private Point _previous;
+    private bool _pressed;
+
+    private ScaleTransform? _scale;
+    private RotateTransform? _rotate;
+    private TranslateTransform? _translate;
+
+    /// <summary>
+    /// Gets or sets the control that will receive the transforms.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        var source = AssociatedObject;
+        if (source is not null)
+        {
+            source.PointerPressed += OnPointerPressed;
+            source.PointerReleased += OnPointerReleased;
+            source.PointerMoved += OnPointerMoved;
+            source.AddHandler(Gestures.PinchEvent, OnPinch, RoutingStrategies.Bubble);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        var source = AssociatedObject;
+        if (source is not null)
+        {
+            source.PointerPressed -= OnPointerPressed;
+            source.PointerReleased -= OnPointerReleased;
+            source.PointerMoved -= OnPointerMoved;
+            source.RemoveHandler(Gestures.PinchEvent, OnPinch);
+        }
+    }
+
+    private void EnsureTransforms(Control target)
+    {
+        if (target.RenderTransform is TransformGroup group &&
+            group.Children.Count == 3 &&
+            group.Children[0] is ScaleTransform &&
+            group.Children[1] is RotateTransform &&
+            group.Children[2] is TranslateTransform)
+        {
+            _scale = (ScaleTransform)group.Children[0];
+            _rotate = (RotateTransform)group.Children[1];
+            _translate = (TranslateTransform)group.Children[2];
+        }
+        else
+        {
+            _scale = new ScaleTransform();
+            _rotate = new RotateTransform();
+            _translate = new TranslateTransform();
+
+            var tg = new TransformGroup
+            {
+                Children = { _scale, _rotate, _translate }
+            };
+
+            target.RenderTransform = tg;
+        }
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var target = TargetControl ?? AssociatedObject;
+        if (target is null)
+        {
+            return;
+        }
+
+        EnsureTransforms(target);
+        _parent = target.Parent as Control;
+        _previous = e.GetPosition(_parent);
+        _pressed = true;
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        _pressed = false;
+        _parent = null;
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_pressed)
+        {
+            return;
+        }
+
+        var target = TargetControl ?? AssociatedObject;
+        if (target is null || _translate is null)
+        {
+            return;
+        }
+
+        var pos = e.GetPosition(_parent);
+        _translate.X += pos.X - _previous.X;
+        _translate.Y += pos.Y - _previous.Y;
+        _previous = pos;
+    }
+
+    private void OnPinch(object? sender, RoutedEventArgs e)
+    {
+        var target = TargetControl ?? AssociatedObject;
+        if (target is null)
+        {
+            return;
+        }
+
+        EnsureTransforms(target);
+
+        if (_scale is null || _rotate is null || _translate is null)
+        {
+            return;
+        }
+
+        if (e is PinchEventArgs pinch)
+        {
+            var origin = pinch.Origin;
+            _scale.CenterX = origin.X;
+            _scale.CenterY = origin.Y;
+            _scale.ScaleX *= pinch.Scale;
+            _scale.ScaleY *= pinch.Scale;
+
+            _rotate.CenterX = origin.X;
+            _rotate.CenterY = origin.Y;
+            _rotate.Angle += pinch.Rotation;
+
+            var delta = pinch.Translation;
+            _translate.X += delta.X;
+            _translate.Y += delta.Y;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TranslateZoomRotateBehavior for multitouch manipulation
- add page demonstrating TranslateZoomRotateBehavior in sample app

## Testing
- ❌ `dotnet --version` (failed to run because `dotnet` is not installed)

`This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`