### PR TITLE
Add fluid move behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,14 @@ This section provides an overview of all available classes and their purpose in 
   *Displays a control's context menu programmatically.*
 
 ### Animations
-- **FadeInBehavior**  
+- **FadeInBehavior**
   *Animates the fade-in effect for the associated element, gradually increasing its opacity.*
 
-- **StartAnimationAction**  
+- **StartAnimationAction**
   *Triggers a defined animation on the target control when executed.*
+
+- **FluidMoveBehavior**
+  *Animates elements as they change layout positions for smooth transitions.*
 
 ### AutoCompleteBox
 - **FocusAutoCompleteBoxTextBoxBehavior**  
@@ -646,8 +649,11 @@ This section provides an overview of all available classes and their purpose in 
 - **ScrollToItemBehavior**
   *Automatically scrolls the ItemsControl to make a specified item visible.*
 
-- **ScrollToItemIndexBehavior**  
+- **ScrollToItemIndexBehavior**
   *Scrolls to a specific item index in the ItemsControl.*
+
+- **FluidMoveSetTagBehavior**
+  *Assigns each generated container's Tag to its data item for FluidMoveBehavior.*
 
 ### ListBox
 - **ListBoxSelectAllBehavior**  

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -90,6 +90,8 @@ public partial class MainWindowViewModel : ViewModelBase
         OpenFoldersCommand = ReactiveCommand.Create<IEnumerable<IStorageFolder>>(OpenFolders);
 
         GetClipboardTextCommand = ReactiveCommand.Create<string?>(GetClipboardText);
+
+        ShuffleItemsCommand = ReactiveCommand.Create(ShuffleItems);
     }
 
     [Reactive]
@@ -137,6 +139,8 @@ public partial class MainWindowViewModel : ViewModelBase
     
     public ICommand GetClipboardTextCommand { get; set; }
 
+    public ICommand ShuffleItemsCommand { get; set; }
+
     private void DataContextChanged()
     {
         Console.WriteLine("DataContextChanged");
@@ -182,6 +186,19 @@ public partial class MainWindowViewModel : ViewModelBase
     private void GetClipboardText(string? text)
     {
         Console.WriteLine($"GetClipboardTextCommand: {text}");
+    }
+
+    private void ShuffleItems()
+    {
+        if (Items is { } items)
+        {
+            var rnd = new Random();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var j = rnd.Next(i, items.Count);
+                (items[i], items[j]) = (items[j], items[i]);
+            }
+        }
     }
 
     public void IncrementCount() => Count++;

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -76,6 +76,9 @@
     <TabItem Header="Sliding Animation">
       <pages:SlidingAnimationView />
     </TabItem>
+    <TabItem Header="FluidMoveBehavior">
+      <pages:FluidMoveBehaviorView />
+    </TabItem>
     <TabItem Header="BehaviorCollectionTemplate">
       <pages:BehaviorCollectionTemplateView />
     </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FluidMoveBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="10" Margin="5">
+    <Button Content="Shuffle" Command="{Binding ShuffleItemsCommand}" Width="100" />
+    <ItemsControl ItemsSource="{Binding Items}">
+      <Interaction.Behaviors>
+        <FluidMoveSetTagBehavior />
+        <FluidMoveBehavior Duration="0:0:0.3" />
+      </Interaction.Behaviors>
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <WrapPanel />
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="vm:ItemViewModel">
+          <Border Background="{Binding Color}" Width="80" Height="40" Margin="4" CornerRadius="4">
+            <TextBlock Text="{Binding Value}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+          </Border>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FluidMoveBehaviorView : UserControl
+{
+    public FluidMoveBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Animations/FluidMoveBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Animations/FluidMoveBehavior.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Animates elements to smoothly transition to their new layout positions.
+/// </summary>
+public class FluidMoveBehavior : AttachedToVisualTreeBehavior<Panel>
+{
+    /// <summary>
+    /// Defines whether the animation applies to the panel itself or its children.
+    /// </summary>
+    public enum AppliesTo
+    {
+        /// <summary>
+        /// Animate the associated panel.
+        /// </summary>
+        Self,
+
+        /// <summary>
+        /// Animate the immediate children of the panel.
+        /// </summary>
+        Children
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="Duration"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TimeSpan> DurationProperty =
+        AvaloniaProperty.Register<FluidMoveBehavior, TimeSpan>(nameof(Duration),
+            TimeSpan.FromMilliseconds(250));
+
+    /// <summary>
+    /// Identifies the <see cref="Easing"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Easing?> EasingProperty =
+        AvaloniaProperty.Register<FluidMoveBehavior, Easing?>(nameof(Easing));
+
+    /// <summary>
+    /// Identifies the <see cref="Scope"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<AppliesTo> ScopeProperty =
+        AvaloniaProperty.Register<FluidMoveBehavior, AppliesTo>(nameof(Scope), AppliesTo.Children);
+
+    /// <summary>
+    /// Gets or sets the duration of the animation.
+    /// </summary>
+    public TimeSpan Duration
+    {
+        get => GetValue(DurationProperty);
+        set => SetValue(DurationProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the easing of the animation.
+    /// </summary>
+    public Easing? Easing
+    {
+        get => GetValue(EasingProperty);
+        set => SetValue(EasingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the scope of the animation.
+    /// </summary>
+    public AppliesTo Scope
+    {
+        get => GetValue(ScopeProperty);
+        set => SetValue(ScopeProperty, value);
+    }
+
+    private readonly Dictionary<object, Rect> _bounds = new();
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        if (AssociatedObject is { } panel)
+        {
+            panel.LayoutUpdated += PanelOnLayoutUpdated;
+
+            foreach (var child in panel.Children)
+            {
+                if (child is Visual visual)
+                {
+                    _bounds[GetKey(visual)] = visual.Bounds;
+                }
+            }
+
+            return DisposableAction.Create(() =>
+            {
+                panel.LayoutUpdated -= PanelOnLayoutUpdated;
+                _bounds.Clear();
+            });
+        }
+
+        return DisposableAction.Empty;
+    }
+
+    private void PanelOnLayoutUpdated(object? sender, EventArgs e)
+    {
+        if (AssociatedObject is not Panel panel)
+        {
+            return;
+        }
+
+        IEnumerable<Visual> elements = Scope == AppliesTo.Self
+            ? new[] { panel }
+            : panel.Children;
+
+        foreach (var element in elements)
+        {
+            var key = GetKey(element);
+            var newBounds = element.Bounds;
+
+            if (_bounds.TryGetValue(key, out var oldBounds))
+            {
+                if (oldBounds.Position != newBounds.Position)
+                {
+                    var dx = oldBounds.X - newBounds.X;
+                    var dy = oldBounds.Y - newBounds.Y;
+                    StartAnimation(element, dx, dy);
+                }
+
+                _bounds[key] = newBounds;
+            }
+            else
+            {
+                _bounds.Add(key, newBounds);
+            }
+        }
+    }
+
+    private static object GetKey(Visual element) => (element as Control)?.Tag ?? element;
+
+    private void StartAnimation(Visual element, double dx, double dy)
+    {
+        if (Math.Abs(dx) < double.Epsilon && Math.Abs(dy) < double.Epsilon)
+        {
+            return;
+        }
+
+        var transform = new TranslateTransform(dx, dy);
+        element.RenderTransform = transform;
+
+        var animation = new Animation.Animation
+        {
+            Duration = Duration,
+            Children =
+            {
+                new KeyFrame
+                {
+                    KeyTime = TimeSpan.Zero,
+                    Setters =
+                    {
+                        new Setter(TranslateTransform.XProperty, dx),
+                        new Setter(TranslateTransform.YProperty, dy)
+                    }
+                },
+                new KeyFrame
+                {
+                    KeyTime = Duration,
+                    Setters =
+                    {
+                        new Setter(TranslateTransform.XProperty, 0d),
+                        new Setter(TranslateTransform.YProperty, 0d)
+                    },
+                    Easing = Easing
+                }
+            }
+        };
+
+        _ = animation.RunAsync(transform);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Animations/FluidMoveBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Animations/FluidMoveBehavior.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using Avalonia;
 using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Media;
-using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Styling;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
@@ -104,7 +104,7 @@ public class FluidMoveBehavior : AttachedToVisualTreeBehavior<Panel>
 
     private void PanelOnLayoutUpdated(object? sender, EventArgs e)
     {
-        if (AssociatedObject is not Panel panel)
+        if (AssociatedObject is not { } panel)
         {
             return;
         }
@@ -169,11 +169,15 @@ public class FluidMoveBehavior : AttachedToVisualTreeBehavior<Panel>
                     {
                         new Setter(TranslateTransform.XProperty, 0d),
                         new Setter(TranslateTransform.YProperty, 0d)
-                    },
-                    Easing = Easing
+                    }
                 }
             }
         };
+
+        if (Easing is { } easing)
+        {
+            animation.Easing = easing;
+        }
 
         _ = animation.RunAsync(transform);
     }

--- a/src/Avalonia.Xaml.Interactions.Custom/ItemsControl/FluidMoveSetTagBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ItemsControl/FluidMoveSetTagBehavior.cs
@@ -10,16 +10,16 @@ public class FluidMoveSetTagBehavior : ItemsControlContainerEventsBehavior
     /// <inheritdoc />
     protected override void OnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
     {
-        if (e.Container is Control control)
+        if (e.Container is { } control)
         {
-            control.Tag = e.Item;
+            control.Tag = e.Container.DataContext;
         }
     }
 
     /// <inheritdoc />
     protected override void OnContainerClearing(object? sender, ContainerClearingEventArgs e)
     {
-        if (e.Container is Control control)
+        if (e.Container is { } control)
         {
             control.ClearValue(Control.TagProperty);
         }

--- a/src/Avalonia.Xaml.Interactions.Custom/ItemsControl/FluidMoveSetTagBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ItemsControl/FluidMoveSetTagBehavior.cs
@@ -1,0 +1,27 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Sets the <see cref="Control.Tag"/> of generated item containers to their data item.
+/// </summary>
+public class FluidMoveSetTagBehavior : ItemsControlContainerEventsBehavior
+{
+    /// <inheritdoc />
+    protected override void OnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
+    {
+        if (e.Container is Control control)
+        {
+            control.Tag = e.Item;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnContainerClearing(object? sender, ContainerClearingEventArgs e)
+    {
+        if (e.Container is Control control)
+        {
+            control.ClearValue(Control.TagProperty);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FluidMoveBehavior` to animate layout movement
- implement `FluidMoveSetTagBehavior` for tagging containers
- document new behaviors in README
- add FluidMoveBehavior sample page

## Testing
- `dotnet test` *(fails: `dotnet` not found)*