### PR TITLE
Implement RemoveElementAction with sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ This section provides an overview of all available classes and their purpose in 
 - **RemoveClassAction**
   *Removes a style class from a control’s class collection.*
 
+- **RemoveElementAction**
+  *Removes a control from its parent container when executed.*
+
 - **ShowContextMenuAction**
   *Displays a control's context menu programmatically.*
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -61,6 +61,9 @@
     <TabItem Header="Add/RemoveClassAction">
       <pages:AddRemoveClassActionView />
     </TabItem>
+    <TabItem Header="RemoveElementAction">
+      <pages:RemoveElementActionView />
+    </TabItem>
     <TabItem Header="AdaptiveBehavior">
       <pages:AdaptiveBehaviorView />
     </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveElementActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveElementActionView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.RemoveElementActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Grid Background="{DynamicResource GrayBrush}" Margin="5">
+    <StackPanel Spacing="10">
+      <Border x:Name="RemovableBorder"
+              Background="{DynamicResource PinkBrush}"
+              BorderBrush="{DynamicResource GrayBrush}"
+              BorderThickness="2"
+              Height="60"/>
+      <Button x:Name="RemoveButton" Content="Remove Border">
+        <Interaction.Behaviors>
+          <EventTriggerBehavior EventName="Click" SourceObject="RemoveButton">
+            <RemoveElementAction TargetObject="RemovableBorder" />
+          </EventTriggerBehavior>
+        </Interaction.Behaviors>
+      </Button>
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveElementActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveElementActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class RemoveElementActionView : UserControl
+{
+    public RemoveElementActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/RemoveElementAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/RemoveElementAction.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Removes the associated or target element from its parent when executed.
+/// </summary>
+public class RemoveElementAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="TargetObject"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetObjectProperty =
+        AvaloniaProperty.Register<RemoveElementAction, Control?>(nameof(TargetObject));
+
+    /// <summary>
+    /// Gets or sets the element to remove. This is an avalonia property.
+    /// If not set, the sender will be used.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetObject
+    {
+        get => GetValue(TargetObjectProperty);
+        set => SetValue(TargetObjectProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var element = GetValue(TargetObjectProperty) is not null ? TargetObject : sender as Control;
+        if (element is null)
+        {
+            return false;
+        }
+
+        var parent = element.Parent;
+        if (parent is null)
+        {
+            return false;
+        }
+
+        if (parent is Panel panel)
+        {
+            panel.Children.Remove(element);
+            return true;
+        }
+
+        if (parent is Decorator decorator)
+        {
+            if (decorator.Child == element)
+            {
+                decorator.Child = null;
+                return true;
+            }
+        }
+
+        if (parent is ContentControl contentControl)
+        {
+            if (contentControl.Content == element)
+            {
+                contentControl.Content = null;
+                return true;
+            }
+        }
+
+        if (parent is ContentPresenter presenter)
+        {
+            if (presenter.Content == element)
+            {
+                presenter.Content = null;
+                return true;
+            }
+        }
+
+        if (parent is ItemsControl itemsControl && itemsControl.Items is IList list && list.Contains(element))
+        {
+            list.Remove(element);
+            return true;
+        }
+
+        return false;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RemoveElementAction action to remove a control from its parent
- document RemoveElementAction in README
- add RemoveElementActionView sample and hook into MainView

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*