### PR TITLE
Add KeyGestureTrigger implementation and sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/KeyGestureTriggerViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/KeyGestureTriggerViewModel.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Windows.Input;
+using ReactiveUI;
+
+namespace BehaviorsTestApplication.ViewModels;
+
+public partial class KeyGestureTriggerViewModel : ViewModelBase
+{
+    public KeyGestureTriggerViewModel()
+    {
+        TriggerCommand = ReactiveCommand.Create(OnTriggered);
+    }
+
+    public ICommand TriggerCommand { get; }
+
+    private void OnTriggered()
+    {
+        Console.WriteLine("KeyGestureTrigger fired");
+    }
+}

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ public partial class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel()
     {
         PointerTriggersViewModel = new PointerTriggersViewModel();
+        KeyGestureTriggerViewModel = new KeyGestureTriggerViewModel();
         
         Count = 0;
         Position = 100.0;
@@ -94,6 +95,9 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [Reactive]
     public partial PointerTriggersViewModel PointerTriggersViewModel { get; set; }
+
+    [Reactive]
+    public partial KeyGestureTriggerViewModel KeyGestureTriggerViewModel { get; set; }
 
     [Reactive]
     public partial int Count { get; set; }

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -88,6 +88,9 @@
     <TabItem Header="Pointer Triggers">
       <pages:PointerTriggersView DataContext="{Binding PointerTriggersViewModel}" />
     </TabItem>
+    <TabItem Header="KeyGestureTrigger">
+      <pages:KeyGestureTriggerView DataContext="{Binding KeyGestureTriggerViewModel}" />
+    </TabItem>
     <TabItem Header="Storage Provider">
       <pages:StorageProviderView />
     </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.KeyGestureTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:KeyGestureTriggerViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150">
+  <Design.DataContext>
+    <vm:KeyGestureTriggerViewModel />
+  </Design.DataContext>
+
+  <Border Padding="20" Background="LightGray">
+    <TextBlock Text="Press Ctrl+G" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <Interaction.Behaviors>
+      <KeyGestureTrigger Gesture="Ctrl+G">
+        <InvokeCommandAction Command="{Binding TriggerCommand}" />
+      </KeyGestureTrigger>
+    </Interaction.Behaviors>
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml
@@ -10,7 +10,7 @@
     <vm:KeyGestureTriggerViewModel />
   </Design.DataContext>
 
-  <Border Padding="20" Background="LightGray">
+  <Border Focusable="True" Padding="20" Background="LightGray">
     <TextBlock Text="Press Ctrl+G" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     <Interaction.Behaviors>
       <KeyGestureTrigger Gesture="Ctrl+G">

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class KeyGestureTriggerView : UserControl
+{
+    public KeyGestureTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/InputElement/Triggers/KeyGestureTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/InputElement/Triggers/KeyGestureTrigger.cs
@@ -1,0 +1,93 @@
+using System;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Trigger that listens for a key gesture.
+/// </summary>
+public class KeyGestureTrigger : RoutedEventTriggerBase<KeyEventArgs>
+{
+    /// <summary>
+    /// Identifies the <see cref="Gesture"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<KeyGesture?> GestureProperty =
+        AvaloniaProperty.Register<KeyGestureTrigger, KeyGesture?>(nameof(Gesture));
+
+    /// <summary>
+    /// Identifies the <see cref="FiredOn"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<KeyGestureTriggerFiredOn> FiredOnProperty =
+        AvaloniaProperty.Register<KeyGestureTrigger, KeyGestureTriggerFiredOn>(nameof(FiredOn),
+            defaultValue: KeyGestureTriggerFiredOn.KeyDown);
+
+    /// <summary>
+    /// Gets or sets the gesture that will fire the trigger.
+    /// </summary>
+    public KeyGesture? Gesture
+    {
+        get => GetValue(GestureProperty);
+        set => SetValue(GestureProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the trigger reacts on key down or key up.
+    /// </summary>
+    public KeyGestureTriggerFiredOn FiredOn
+    {
+        get => GetValue(FiredOnProperty);
+        set => SetValue(FiredOnProperty, value);
+    }
+
+    static KeyGestureTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<KeyGestureTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Tunnel | RoutingStrategies.Bubble));
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        if (AssociatedObject is Interactive interactive)
+        {
+            var routedEvent = FiredOn == KeyGestureTriggerFiredOn.KeyUp
+                ? InputElement.KeyUpEvent
+                : InputElement.KeyDownEvent;
+
+            return interactive.AddDisposableHandler(routedEvent, Handler, EventRoutingStrategy);
+        }
+
+        return DisposableAction.Empty;
+    }
+
+    private void Handler(object? sender, KeyEventArgs e)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        var gesture = Gesture;
+        if (gesture is null || gesture.Matches(e))
+        {
+            Execute(e);
+        }
+    }
+}
+
+/// <summary>
+/// Specifies when a <see cref="KeyGestureTrigger"/> should be fired.
+/// </summary>
+public enum KeyGestureTriggerFiredOn
+{
+    /// <summary>
+    /// Trigger on key down.
+    /// </summary>
+    KeyDown,
+    /// <summary>
+    /// Trigger on key up.
+    /// </summary>
+    KeyUp
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/InputElement/Triggers/KeyGestureTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/InputElement/Triggers/KeyGestureTrigger.cs
@@ -1,4 +1,3 @@
-using System;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 
@@ -40,29 +39,14 @@ public class KeyGestureTrigger : RoutedEventTriggerBase<KeyEventArgs>
         set => SetValue(FiredOnProperty, value);
     }
 
-    static KeyGestureTrigger()
-    {
-        EventRoutingStrategyProperty.OverrideMetadata<KeyGestureTrigger>(
-            new StyledPropertyMetadata<RoutingStrategies>(
-                defaultValue: RoutingStrategies.Tunnel | RoutingStrategies.Bubble));
-    }
+    /// <inheritdoc />
+    protected override RoutedEvent<KeyEventArgs> RoutedEvent =>
+        FiredOn == KeyGestureTriggerFiredOn.KeyUp
+            ? InputElement.KeyUpEvent
+            : InputElement.KeyDownEvent;
 
     /// <inheritdoc />
-    protected override IDisposable OnAttachedToVisualTreeOverride()
-    {
-        if (AssociatedObject is Interactive interactive)
-        {
-            var routedEvent = FiredOn == KeyGestureTriggerFiredOn.KeyUp
-                ? InputElement.KeyUpEvent
-                : InputElement.KeyDownEvent;
-
-            return interactive.AddDisposableHandler(routedEvent, Handler, EventRoutingStrategy);
-        }
-
-        return DisposableAction.Empty;
-    }
-
-    private void Handler(object? sender, KeyEventArgs e)
+    protected override void Handler(object? sender, KeyEventArgs e)
     {
         if (!IsEnabled)
         {

--- a/src/Avalonia.Xaml.Interactions.Custom/InputElement/Triggers/KeyGestureTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/InputElement/Triggers/KeyGestureTrigger.cs
@@ -39,6 +39,13 @@ public class KeyGestureTrigger : RoutedEventTriggerBase<KeyEventArgs>
         set => SetValue(FiredOnProperty, value);
     }
 
+    static KeyGestureTrigger()
+    {
+        EventRoutingStrategyProperty.OverrideMetadata<KeyGestureTrigger>(
+            new StyledPropertyMetadata<RoutingStrategies>(
+                defaultValue: RoutingStrategies.Tunnel | RoutingStrategies.Bubble));
+    }
+
     /// <inheritdoc />
     protected override RoutedEvent<KeyEventArgs> RoutedEvent =>
         FiredOn == KeyGestureTriggerFiredOn.KeyUp


### PR DESCRIPTION
## Summary
- implement `KeyGestureTrigger` for Avalonia behaviors
- showcase trigger usage in sample app
- wire new sample into main view and view model

## Testing
- `dotnet test` *(fails: `dotnet` not found)*