### PR TITLE
Add search box for sample pages

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -12,7 +12,9 @@
       <Setter Property="FontSize" Value="16" />
     </Style>
   </UserControl.Styles>
-  <TabControl Classes="sidebar">
+  <DockPanel>
+    <TextBox x:Name="SearchBox" DockPanel.Dock="Top" Watermark="Search" Margin="0,0,0,5" />
+    <TabControl x:Name="SamplesTabControl" Classes="sidebar">
     <TabItem Header="CallMethodAction">
       <pages:CallMethodActionView />
     </TabItem>
@@ -137,4 +139,5 @@
       <pages:ReactiveNavigationView />
     </TabItem>
   </TabControl>
+  </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
@@ -1,13 +1,41 @@
-﻿using Avalonia.Controls;
+using System;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 
 namespace BehaviorsTestApplication.Views;
 
 public partial class MainView : UserControl
 {
+    private TextBox? _searchBox;
+    private TabControl? _tabControl;
+
     public MainView()
     {
         InitializeComponent();
+        _tabControl = this.FindControl<TabControl>("SamplesTabControl");
+        _searchBox = this.FindControl<TextBox>("SearchBox");
+        if (_searchBox != null)
+        {
+            _searchBox.GetObservable(TextBox.TextProperty)
+                .Subscribe(text => Search(text));
+        }
+    }
+
+    private void Search(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text) || _tabControl == null)
+            return;
+
+        var item = _tabControl.Items
+            .OfType<TabItem>()
+            .FirstOrDefault(i => i.Header is string header &&
+                header.Contains(text, StringComparison.OrdinalIgnoreCase));
+        if (item != null)
+        {
+            _tabControl.SelectedItem = item;
+        }
     }
 
     private void InitializeComponent()


### PR DESCRIPTION
## Summary
- add a search box to Samples `MainView`
- wire up new control in code-behind to select the first matching tab item

## Testing
- `dotnet test` *(fails: `dotnet` not found)*