### PR TITLE
Add SelectingItemsControlSearchBehavior behavior

### DIFF
--- a/samples/BehaviorsTestApplication/Controls/SingleSelectionTabControl.cs
+++ b/samples/BehaviorsTestApplication/Controls/SingleSelectionTabControl.cs
@@ -1,0 +1,14 @@
+using System;
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Controls;
+
+public class SingleSelectionTabControl : TabControl
+{
+    protected override Type StyleKeyOverride => typeof(TabControl);
+    
+    static SingleSelectionTabControl()
+    {
+        SelectionModeProperty.OverrideDefaultValue<SingleSelectionTabControl>(SelectionMode.Single);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -22,10 +22,10 @@
                Margin="0,0,0,8" 
                IsVisible="False"
                DockPanel.Dock="Top" />
-    <TabControl x:Name="PagesTabControl" Classes="sidebar">
+    <SingleSelectionTabControl x:Name="PagesTabControl" SelectedIndex="0" Classes="sidebar">
       <Interaction.Behaviors>
-        <TabControlSearchBehavior SearchBox="SearchBox"
-                                  NoMatchesText="NoMatchesText" />
+        <SelectingItemsControlSearchBehavior SearchBox="SearchBox"
+                                             NoMatchesControl="NoMatchesText" />
       </Interaction.Behaviors>
       <TabItem Header="CallMethodAction">
         <pages:CallMethodActionView />
@@ -153,6 +153,6 @@
       <TabItem Header="Reactive Navigation">
         <pages:ReactiveNavigationView />
       </TabItem>
-    </TabControl>
+    </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -13,10 +13,9 @@
     </Style>
   </UserControl.Styles>
   <DockPanel>
-    <TextBox x:Name="SearchBox" 
-             Watermark="Search pages..." 
-             Margin="0,0,0,8" 
-             TextChanged="OnSearchTextChanged"
+    <TextBox x:Name="SearchBox"
+             Watermark="Search pages..."
+             Margin="0,0,0,8"
              DockPanel.Dock="Top"  />
     <TextBlock x:Name="NoMatchesText" 
                Text="No pages match the search." 
@@ -24,6 +23,10 @@
                IsVisible="False"
                DockPanel.Dock="Top" />
     <TabControl x:Name="PagesTabControl" Classes="sidebar">
+      <Interaction.Behaviors>
+        <TabControlSearchBehavior SearchBox="SearchBox"
+                                  NoMatchesText="NoMatchesText" />
+      </Interaction.Behaviors>
       <TabItem Header="CallMethodAction">
         <pages:CallMethodActionView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia.Controls;
-using System.Linq;
+using Avalonia.Controls;
 
 namespace BehaviorsTestApplication.Views;
 
@@ -10,27 +9,5 @@ public partial class MainView : UserControl
         InitializeComponent();
     }
 
-    private void OnSearchTextChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
-    {
-        var query = SearchBox.Text?.ToLowerInvariant() ?? string.Empty;
-        var visibleCount = 0;
-
-        var tabItems = PagesTabControl.Items.OfType<TabItem>().ToList();
-
-        foreach (var item in tabItems)
-        {
-            var header = item.Header?.ToString()?.ToLowerInvariant() ?? string.Empty;
-            var visible = header.Contains(query);
-            item.IsVisible = visible;
-
-            if (visible)
-            {
-                visibleCount++;
-            }
-        }
-
-        PagesTabControl.SelectedItem = tabItems.FirstOrDefault(x => x.IsVisible);
-
-        NoMatchesText.IsVisible = visibleCount == 0;
-    }
+    // Search functionality moved to TabControlSearchBehavior
 }

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml.cs
@@ -8,6 +8,4 @@ public partial class MainView : UserControl
     {
         InitializeComponent();
     }
-
-    // Search functionality moved to TabControlSearchBehavior
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/SelectingItemsControl/SelectingItemsControlSearchBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/SelectingItemsControl/SelectingItemsControlSearchBehavior.cs
@@ -86,15 +86,7 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
             }
         }
 
-        var firstVisibleItem = tabItems.FirstOrDefault(x => x.IsVisible);
-        if (firstVisibleItem is not null)
-        {
-            AssociatedObject.SelectedItem = firstVisibleItem;
-        }
-        else
-        {
-            AssociatedObject.SelectedItem = null;
-        }
+        AssociatedObject.SelectedItem = tabItems.FirstOrDefault(x => x.IsVisible);
 
         if (NoMatchesControl is not null)
         {

--- a/src/Avalonia.Xaml.Interactions.Custom/TabControl/TabControlSearchBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/TabControl/TabControlSearchBehavior.cs
@@ -1,26 +1,28 @@
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Filters <see cref="TabControl"/> items based on the text of a search box.
+/// Filters <see cref="SelectingItemsControl"/> items based on the text of a search box.
 /// </summary>
-public sealed class TabControlSearchBehavior : StyledElementBehavior<TabControl>
+public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<SelectingItemsControl>
 {
     /// <summary>
     /// Identifies the <seealso cref="SearchBox"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<TextBox?> SearchBoxProperty =
-        AvaloniaProperty.Register<TabControlSearchBehavior, TextBox?>(nameof(SearchBox));
+        AvaloniaProperty.Register<SelectingItemsControlSearchBehavior, TextBox?>(nameof(SearchBox));
 
     /// <summary>
-    /// Identifies the <seealso cref="NoMatchesText"/> avalonia property.
+    /// Identifies the <seealso cref="NoMatchesControl"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<TextBlock?> NoMatchesTextProperty =
-        AvaloniaProperty.Register<TabControlSearchBehavior, TextBlock?>(nameof(NoMatchesText));
+    public static readonly StyledProperty<TextBlock?> NoMatchesControlProperty =
+        AvaloniaProperty.Register<SelectingItemsControlSearchBehavior, TextBlock?>(nameof(NoMatchesControl));
 
     /// <summary>
     /// Gets or sets the search box control.
@@ -33,13 +35,13 @@ public sealed class TabControlSearchBehavior : StyledElementBehavior<TabControl>
     }
 
     /// <summary>
-    /// Gets or sets the text block displayed when no matches are found.
+    /// Gets or sets the control displayed when no matches are found.
     /// </summary>
     [ResolveByName]
-    public TextBlock? NoMatchesText
+    public Control? NoMatchesControl
     {
-        get => GetValue(NoMatchesTextProperty);
-        set => SetValue(NoMatchesTextProperty, value);
+        get => GetValue(NoMatchesControlProperty);
+        set => SetValue(NoMatchesControlProperty, value);
     }
 
     /// <inheritdoc />
@@ -84,11 +86,19 @@ public sealed class TabControlSearchBehavior : StyledElementBehavior<TabControl>
             }
         }
 
-        AssociatedObject.SelectedItem = tabItems.FirstOrDefault(x => x.IsVisible);
-
-        if (NoMatchesText is not null)
+        var firstVisibleItem = tabItems.FirstOrDefault(x => x.IsVisible);
+        if (firstVisibleItem is not null)
         {
-            NoMatchesText.IsVisible = visibleCount == 0;
+            AssociatedObject.SelectedItem = firstVisibleItem;
+        }
+        else
+        {
+            AssociatedObject.SelectedItem = null;
+        }
+
+        if (NoMatchesControl is not null)
+        {
+            NoMatchesControl.IsVisible = visibleCount == 0;
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/TabControl/TabControlSearchBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/TabControl/TabControlSearchBehavior.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Filters <see cref="TabControl"/> items based on the text of a search box.
+/// </summary>
+public sealed class TabControlSearchBehavior : StyledElementBehavior<TabControl>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="SearchBox"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TextBox?> SearchBoxProperty =
+        AvaloniaProperty.Register<TabControlSearchBehavior, TextBox?>(nameof(SearchBox));
+
+    /// <summary>
+    /// Identifies the <seealso cref="NoMatchesText"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TextBlock?> NoMatchesTextProperty =
+        AvaloniaProperty.Register<TabControlSearchBehavior, TextBlock?>(nameof(NoMatchesText));
+
+    /// <summary>
+    /// Gets or sets the search box control.
+    /// </summary>
+    [ResolveByName]
+    public TextBox? SearchBox
+    {
+        get => GetValue(SearchBoxProperty);
+        set => SetValue(SearchBoxProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the text block displayed when no matches are found.
+    /// </summary>
+    [ResolveByName]
+    public TextBlock? NoMatchesText
+    {
+        get => GetValue(NoMatchesTextProperty);
+        set => SetValue(NoMatchesTextProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        if (SearchBox is not null)
+        {
+            SearchBox.AddHandler(InputElement.TextInputEvent, SearchBox_TextChanged, RoutingStrategies.Bubble);
+            SearchBox.AddHandler(TextBox.TextChangedEvent, SearchBox_TextChanged, RoutingStrategies.Bubble);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        if (SearchBox is not null)
+        {
+            SearchBox.RemoveHandler(InputElement.TextInputEvent, SearchBox_TextChanged);
+            SearchBox.RemoveHandler(TextBox.TextChangedEvent, SearchBox_TextChanged);
+        }
+    }
+
+    private void SearchBox_TextChanged(object? sender, RoutedEventArgs e)
+    {
+        if (AssociatedObject is null)
+        {
+            return;
+        }
+
+        var query = SearchBox?.Text?.ToLowerInvariant() ?? string.Empty;
+        var visibleCount = 0;
+        var tabItems = AssociatedObject.Items.OfType<TabItem>().ToList();
+
+        foreach (var item in tabItems)
+        {
+            var header = item.Header?.ToString()?.ToLowerInvariant() ?? string.Empty;
+            var visible = header.Contains(query);
+            item.IsVisible = visible;
+            if (visible)
+            {
+                visibleCount++;
+            }
+        }
+
+        AssociatedObject.SelectedItem = tabItems.FirstOrDefault(x => x.IsVisible);
+
+        if (NoMatchesText is not null)
+        {
+            NoMatchesText.IsVisible = visibleCount == 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `TabControlSearchBehavior` for filtering TabControl items by search query
- use new behavior in `MainView` and remove code-behind logic

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*