### PR TITLE
Fix null handling in ChangeAvaloniaPropertyAction

### DIFF
--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/ChangeAvaloniaPropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/ChangeAvaloniaPropertyAction.cs
@@ -143,7 +143,7 @@ public class ChangeAvaloniaPropertyAction : Avalonia.Xaml.Interactivity.StyledEl
     {
         if (targetProperty is null)
         {
-            throw new ArgumentException(nameof(TargetProperty));
+            throw new ArgumentNullException(nameof(targetProperty));
         }
         else if (targetProperty.IsReadOnly)
         {


### PR DESCRIPTION
## Summary
- throw `ArgumentNullException` if `targetProperty` is null

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*