### PR TITLE
Fix indentation in ButtonHideFlyoutOnClickBehavior

### DIFF
--- a/src/Avalonia.Xaml.Interactions.Custom/Button/ButtonHideFlyoutOnClickBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Button/ButtonHideFlyoutOnClickBehavior.cs
@@ -6,28 +6,24 @@ using Avalonia.VisualTree;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// 
 /// </summary>
 public class ButtonHideFlyoutOnClickBehavior : AttachedToVisualTreeBehavior<Button>
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     protected override System.IDisposable OnAttachedToVisualTreeOverride()
     {
         var button = AssociatedObject;
-        
-		if (button is null)
-		{
-			return DisposableAction.Empty;
-		}
-        
-		var flyoutPresenter = button.FindAncestorOfType<FlyoutPresenter>();
-		if (flyoutPresenter?.Parent is not Popup popup)
-		{
+
+        if (button is null)
+        {
             return DisposableAction.Empty;
-		}
+        }
+
+        var flyoutPresenter = button.FindAncestorOfType<FlyoutPresenter>();
+        if (flyoutPresenter?.Parent is not Popup popup)
+        {
+            return DisposableAction.Empty;
+        }
 
         button.Click += AssociatedObjectOnClick;
 
@@ -43,9 +39,8 @@ public class ButtonHideFlyoutOnClickBehavior : AttachedToVisualTreeBehavior<Butt
             {
                 button.Command.Execute(button.CommandParameter);
             }
+
             popup.Close();
         }
-	}
-
-
+    }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/Button/ButtonHideFlyoutOnClickBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Button/ButtonHideFlyoutOnClickBehavior.cs
@@ -6,6 +6,7 @@ using Avalonia.VisualTree;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
+/// Hides the flyout when the button is clicked.
 /// </summary>
 public class ButtonHideFlyoutOnClickBehavior : AttachedToVisualTreeBehavior<Button>
 {


### PR DESCRIPTION
## Summary
- clean up indentation in ButtonHideFlyoutOnClickBehavior

## Testing
- `bash -x build.sh` *(fails: curl attempt to download dotnet)*