### PR TITLE
Fix AddClassAction duplicate classes

### DIFF
--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/AddClassAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/AddClassAction.cs
@@ -73,9 +73,16 @@ public class AddClassAction : Avalonia.Xaml.Interactivity.StyledElementAction
             return false;
         }
 
-        if (RemoveIfExists && target.Classes.Contains(ClassName))
+        if (target.Classes.Contains(ClassName))
         {
-            target.Classes.Remove(ClassName);
+            if (RemoveIfExists)
+            {
+                target.Classes.Remove(ClassName);
+            }
+            else
+            {
+                return true;
+            }
         }
 
         target.Classes.Add(ClassName);


### PR DESCRIPTION
## Summary
- prevent AddClassAction from adding duplicate class names when `RemoveIfExists` is false

## Testing
- `./build.sh test` *(fails: unable to download dotnet)*