### PR TITLE
Do not reset Parent when detaching from logical tree

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reactive.Linq;
 using System.Windows.Input;
+using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using ReactiveUI;
 
@@ -91,6 +92,9 @@ public partial class MainWindowViewModel : ViewModelBase
         OpenFoldersCommand = ReactiveCommand.Create<IEnumerable<IStorageFolder>>(OpenFolders);
 
         GetClipboardTextCommand = ReactiveCommand.Create<string?>(GetClipboardText);
+
+        Greeting = "Entered text will appear here";
+        TextChangedCommand = ReactiveCommand.Create<TextChangedEventArgs>(OnTextChanged);
     }
 
     [Reactive]
@@ -122,6 +126,8 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [Reactive] public partial double Progress { get; set; }
 
+    [Reactive] public partial string Greeting { get; set; }
+
     public IObservable<int> Values { get; }
 
     public ICommand DataContextChangedCommand { get; set; }
@@ -143,6 +149,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public ICommand OpenFoldersCommand { get; set; }
     
     public ICommand GetClipboardTextCommand { get; set; }
+
+    public ICommand TextChangedCommand { get; }
 
     private void DataContextChanged()
     {
@@ -198,4 +206,12 @@ public partial class MainWindowViewModel : ViewModelBase
     public void IncrementTimerCount() => TimerCount++;
 
     public void DecrementTimerCount(object? sender, object parameter) => TimerCount--;
+
+    private void OnTextChanged(TextChangedEventArgs args)
+    {
+        if (args.Source is TextBox control)
+        {
+            Greeting = control.Text;
+        }
+    }
 }

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -147,6 +147,9 @@
       <TabItem Header="InteractionTriggerBehavior">
         <pages:InteractionTriggerBehaviorView />
       </TabItem>
+      <TabItem Header="Flyout Binding">
+        <pages:FlyoutBindingView />
+      </TabItem>
       <TabItem Header="KeyTrigger">
         <pages:KeyTriggerView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/FlyoutBindingView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FlyoutBindingView.axaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FlyoutBindingView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <Button x:Name="FlyoutButton" Content="Press me">
+      <Button.Flyout>
+        <Flyout>
+          <TextBox Watermark="Type here">
+            <Interaction.Behaviors>
+              <EventTriggerBehavior EventName="TextChanged">
+                <InvokeCommandAction Command="{Binding TextChangedCommand}" PassEventArgsToCommand="True"/>
+              </EventTriggerBehavior>
+            </Interaction.Behaviors>
+          </TextBox>
+        </Flyout>
+      </Button.Flyout>
+    </Button>
+    <TextBlock x:Name="GreetingTextBlock"
+               Text="{Binding Greeting}"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"/>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FlyoutBindingView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FlyoutBindingView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FlyoutBindingView : UserControl
+{
+    public FlyoutBindingView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementAction.cs
+++ b/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementAction.cs
@@ -53,6 +53,7 @@ public abstract class StyledElementAction : StyledElement, IAction
 
     internal void DetachActionFromLogicalTree(StyledElement parent)
     {
+#if false
         Dispatcher.UIThread.Post(() =>
         {
             ((ISetLogicalParent)this).SetParent(null);
@@ -62,5 +63,6 @@ public abstract class StyledElementAction : StyledElement, IAction
                 TemplatedParentHelper.SetTemplatedParent(this, null);
             }
         });
+#endif
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -301,6 +301,10 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
     {
         if (associatedObject is StyledElement styledElement)
         {
+            // Set initial data context value immediately so bindings are
+            // available before the first DataContextChanged event is raised.
+            SetCurrentValue(DataContextProperty, styledElement.DataContext);
+
             // Required for data context binding in XAML
             return styledElement
                 .GetObservable(DataContextProperty)

--- a/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -286,6 +286,7 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     internal virtual void DetachBehaviorFromLogicalTree()
     {
+#if false
         Dispatcher.UIThread.Post(() =>
         {
             ((ISetLogicalParent)this).SetParent(null);
@@ -295,6 +296,7 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
                 TemplatedParentHelper.SetTemplatedParent(this, null);
             }
         });
+#endif
     }
 
     private IDisposable? SynchronizeDataContext(AvaloniaObject associatedObject)

--- a/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -303,10 +303,11 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
     {
         if (associatedObject is StyledElement styledElement)
         {
+#if false
             // Set initial data context value immediately so bindings are
             // available before the first DataContextChanged event is raised.
             SetCurrentValue(DataContextProperty, styledElement.DataContext);
-
+#endif
             // Required for data context binding in XAML
             return styledElement
                 .GetObservable(DataContextProperty)


### PR DESCRIPTION
## Summary
- ensure `StyledElementBehavior` sets the current `DataContext` when attaching

## Testing
- `dotnet test` *(fails: `dotnet` not found)*


Fixes https://github.com/wieslawsoltes/Xaml.Behaviors/issues/69