### PR TITLE
Add sample page for theme variant behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,12 @@ This section provides an overview of all available classes and their purpose in 
 - **AspectRatioClassSetter**
   *Defines aspect ratio comparison conditions and the class to apply when those conditions are met.*
 
+- **ThemeVariantBehavior**
+  *Applies or removes style classes when the source control's theme variant changes (light, dark, etc.).*
+
+- **ThemeVariantClassSetter**
+  *Specifies a theme variant and the class to toggle when that variant is active.*
+
 ### ScrollViewer
 - **HorizontalScrollViewerBehavior**  
   *Enables horizontal scrolling via the pointer wheel. Optionally requires the Shift key and supports line or page scrolling.*

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -87,6 +87,9 @@
       <TabItem Header="AspectRatioBehavior">
         <pages:AspectRatioBehaviorView />
       </TabItem>
+      <TabItem Header="ThemeVariantBehavior">
+        <pages:ThemeVariantBehaviorView />
+      </TabItem>
       <TabItem Header="EditableListBox">
         <pages:EditableListBoxView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantBehaviorView.axaml
@@ -1,0 +1,44 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ThemeVariantBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:responsive="using:Avalonia.Xaml.Interactions.Responsive"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+
+  <UserControl.Styles>
+    <Style Selector="Border.theme-sample">
+      <Setter Property="Width" Value="200" />
+      <Setter Property="Height" Value="100" />
+      <Setter Property="HorizontalAlignment" Value="Center" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Border.theme-sample.light">
+      <Setter Property="Background" Value="{DynamicResource YellowBrush}" />
+    </Style>
+    <Style Selector="Border.theme-sample.dark">
+      <Setter Property="Background" Value="{DynamicResource BlueBrush}" />
+    </Style>
+  </UserControl.Styles>
+
+  <StackPanel Spacing="10" Margin="5">
+    <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+      <Button Name="LightButton" Content="Light" />
+      <Button Name="DarkButton" Content="Dark" />
+      <TextBlock Text="{Binding $parent[Window].ActualThemeVariant}" Margin="5,0,0,0" VerticalAlignment="Center" />
+    </StackPanel>
+    <Border Name="ThemeBorder" Classes="theme-sample">
+      <Interaction.Behaviors>
+        <responsive:ThemeVariantBehavior>
+          <responsive:ThemeVariantClassSetter ThemeVariant="Light" ClassName="light" />
+          <responsive:ThemeVariantClassSetter ThemeVariant="Dark" ClassName="dark" />
+        </responsive:ThemeVariantBehavior>
+      </Interaction.Behaviors>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantBehaviorView.axaml.cs
@@ -1,0 +1,40 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ThemeVariantBehaviorView : UserControl
+{
+    public ThemeVariantBehaviorView()
+    {
+        InitializeComponent();
+
+        var lightButton = this.FindControl<Button>("LightButton");
+        var darkButton = this.FindControl<Button>("DarkButton");
+
+        if (lightButton is not null)
+        {
+            lightButton.Click += (_, _) => ChangeTheme(ThemeVariant.Light);
+        }
+
+        if (darkButton is not null)
+        {
+            darkButton.Click += (_, _) => ChangeTheme(ThemeVariant.Dark);
+        }
+    }
+
+    private static void ChangeTheme(ThemeVariant variant)
+    {
+        if (Application.Current is { } app)
+        {
+            app.RequestedThemeVariant = variant;
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Responsive/ThemeVariantBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Responsive/ThemeVariantBehavior.cs
@@ -1,0 +1,140 @@
+using System;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Metadata;
+using Avalonia.Reactive;
+using Avalonia.Styling;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace Avalonia.Xaml.Interactions.Responsive;
+
+/// <summary>
+/// Observes <see cref="StyledElement.ActualThemeVariant"/> changes on a control and
+/// toggles classes when specified theme variants are active.
+/// </summary>
+public class ThemeVariantBehavior : ActualThemeVariantChangedBehavior<StyledElement>
+{
+    private AvaloniaList<ThemeVariantClassSetter>? _setters;
+
+    /// <summary>
+    /// Identifies the <seealso cref="SourceElement"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<StyledElement?> SourceElementProperty =
+        AvaloniaProperty.Register<ThemeVariantBehavior, StyledElement?>(nameof(SourceElement));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<ThemeVariantBehavior, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Setters"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<ThemeVariantBehavior, AvaloniaList<ThemeVariantClassSetter>> SettersProperty =
+        AvaloniaProperty.RegisterDirect<ThemeVariantBehavior, AvaloniaList<ThemeVariantClassSetter>>(nameof(Setters), t => t.Setters);
+
+    /// <summary>
+    /// Gets or sets the element whose theme variant is observed. If not set, <see cref="StyledElementBehavior{T}.AssociatedObject"/> is used. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public StyledElement? SourceElement
+    {
+        get => GetValue(SourceElementProperty);
+        set => SetValue(SourceElementProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the target control to add or remove classes from. If not set, the associated object or setter TargetControl is used. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <summary>
+    /// Gets theme variant class setters collection. This is an avalonia property.
+    /// </summary>
+    [Content]
+    public AvaloniaList<ThemeVariantClassSetter> Setters => _setters ??= [];
+
+    /// <inheritdoc />
+    protected override IDisposable OnActualThemeVariantChangedEventOverride()
+    {
+        var source = SourceElement ?? AssociatedObject;
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        Execute(source.ActualThemeVariant);
+
+        return source.GetObservable(StyledElement.ActualThemeVariantProperty)
+            .Subscribe(new AnonymousObserver<ThemeVariant>(variant => Execute(variant)));
+    }
+
+    private void Execute(ThemeVariant variant)
+    {
+        if (Setters is null)
+        {
+            return;
+        }
+
+        foreach (var setter in Setters)
+        {
+            var target = setter.GetValue(ThemeVariantClassSetter.TargetControlProperty) ?? TargetControl ?? AssociatedObject as Control;
+            if (target is null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            var className = setter.ClassName;
+            var isPseudoClass = setter.IsPseudoClass;
+
+            if (variant.Equals(setter.ThemeVariant))
+            {
+                Add(target, className, isPseudoClass);
+            }
+            else
+            {
+                Remove(target, className, isPseudoClass);
+            }
+        }
+    }
+
+    private static void Add(Control targetControl, string? className, bool isPseudoClass)
+    {
+        if (className is null || string.IsNullOrEmpty(className) || targetControl.Classes.Contains(className))
+        {
+            return;
+        }
+
+        if (isPseudoClass)
+        {
+            ((IPseudoClasses)targetControl.Classes).Add(className);
+        }
+        else
+        {
+            targetControl.Classes.Add(className);
+        }
+    }
+
+    private static void Remove(Control targetControl, string? className, bool isPseudoClass)
+    {
+        if (className is null || string.IsNullOrEmpty(className) || !targetControl.Classes.Contains(className))
+        {
+            return;
+        }
+
+        if (isPseudoClass)
+        {
+            ((IPseudoClasses)targetControl.Classes).Remove(className);
+        }
+        else
+        {
+            targetControl.Classes.Remove(className);
+        }
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Responsive/ThemeVariantClassSetter.cs
+++ b/src/Avalonia.Xaml.Interactions.Responsive/ThemeVariantClassSetter.cs
@@ -1,0 +1,73 @@
+using Avalonia.Controls;
+using Avalonia.Metadata;
+using Avalonia.Styling;
+
+namespace Avalonia.Xaml.Interactions.Responsive;
+
+/// <summary>
+/// Conditional class setter based on the control's actual theme variant.
+/// </summary>
+public class ThemeVariantClassSetter : AvaloniaObject
+{
+    /// <summary>
+    /// Identifies the <seealso cref="ThemeVariant"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ThemeVariant> ThemeVariantProperty =
+        AvaloniaProperty.Register<ThemeVariantClassSetter, ThemeVariant>(nameof(ThemeVariant));
+
+    /// <summary>
+    /// Identifies the <seealso cref="ClassName"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ClassNameProperty =
+        AvaloniaProperty.Register<ThemeVariantClassSetter, string?>(nameof(ClassName));
+
+    /// <summary>
+    /// Identifies the <seealso cref="IsPseudoClass"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsPseudoClassProperty =
+        AvaloniaProperty.Register<ThemeVariantClassSetter, bool>(nameof(IsPseudoClass));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<ThemeVariantClassSetter, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Gets or sets the theme variant that should trigger adding the class. This is an avalonia property.
+    /// </summary>
+    public ThemeVariant ThemeVariant
+    {
+        get => GetValue(ThemeVariantProperty);
+        set => SetValue(ThemeVariantProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the class name that should be added or removed. This is an avalonia property.
+    /// </summary>
+    [Content]
+    public string? ClassName
+    {
+        get => GetValue(ClassNameProperty);
+        set => SetValue(ClassNameProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the flag whether <see cref="ClassName"/> is a pseudo class. This is an avalonia property.
+    /// </summary>
+    public bool IsPseudoClass
+    {
+        get => GetValue(IsPseudoClassProperty);
+        set => SetValue(IsPseudoClassProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the target control that class name should be added or removed from when triggered. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThemeVariantBehaviorView` page showing how to toggle classes per theme
- wire the new sample into `MainView`

## Testing
- `./build.sh` *(fails: dotnet not installed / no network)*