### PR TITLE
Add theme variant behaviors and actions

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -163,6 +163,9 @@
       <TabItem Header="Notifications">
         <pages:NotificationsView />
       </TabItem>
+      <TabItem Header="Theme Variant">
+        <pages:ThemeVariantView />
+      </TabItem>
     </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml
@@ -4,60 +4,33 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:pages="using:BehaviorsTestApplication.Views.Pages"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
   <Design.DataContext>
     <vm:MainWindowViewModel />
   </Design.DataContext>
-  <UserControl.Resources>
-    <ThemeVariant x:Key="PinkVariant">Pink</ThemeVariant>
-    <ResourceDictionary>
-      <ResourceDictionary.ThemeDictionaries>
-        <ResourceDictionary x:Key="Dark">
-          <SolidColorBrush x:Key="DemoBackground">Black</SolidColorBrush>
-        </ResourceDictionary>
-        <ResourceDictionary x:Key="Light">
-          <SolidColorBrush x:Key="DemoBackground">White</SolidColorBrush>
-        </ResourceDictionary>
-        <ResourceDictionary x:Key="{x:Static pages:ThemeVariantView.Pink}">
-          <SolidColorBrush x:Key="DemoBackground">#ffe5ea</SolidColorBrush>
-        </ResourceDictionary>
-      </ResourceDictionary.ThemeDictionaries>
-    </ResourceDictionary>
-  </UserControl.Resources>
   <StackPanel Margin="5" Spacing="5">
     <ComboBox x:Name="VariantSelector" SelectedIndex="0">
       <ComboBox.Items>
         <ThemeVariant>Default</ThemeVariant>
         <ThemeVariant>Dark</ThemeVariant>
         <ThemeVariant>Light</ThemeVariant>
-        <StaticResource ResourceKey="PinkVariant" />
       </ComboBox.Items>
     </ComboBox>
     <ThemeVariantScope x:Name="Scope">
       <Interaction.Behaviors>
-        <ThemeVariantBehavior ThemeVariant="{Binding SelectedItem, ElementName=VariantSelector}" />
+        <ThemeVariantBehavior ThemeVariant="{Binding #VariantSelector.SelectedItem}" />
       </Interaction.Behaviors>
-      <Border Background="{DynamicResource DemoBackground}" Padding="10" CornerRadius="4">
+      <Border Background="DarkGray" Padding="10" CornerRadius="4">
         <StackPanel Spacing="5">
-          <TextBlock Text="{Binding ActualThemeVariant, ElementName=Scope}" />
+          <TextBlock Text="{Binding #Scope.ActualThemeVariant}" />
           <Button Content="Toggle Dark" HorizontalAlignment="Left">
-            <Interaction.Triggers>
+            <Interaction.Behaviors>
               <EventTriggerBehavior EventName="Click">
-                <SetThemeVariantAction Target="{Binding ElementName=Scope}" ThemeVariant="Dark" />
+                <SetThemeVariantAction Target="{Binding #Scope}" ThemeVariant="Dark" />
               </EventTriggerBehavior>
-            </Interaction.Triggers>
+            </Interaction.Behaviors>
           </Button>
-          <TextBlock x:Name="PinkText" Text="Pink theme active" IsVisible="False" />
-          <Interaction.Triggers>
-            <ThemeVariantTrigger ThemeVariant="{StaticResource PinkVariant}">
-              <ChangePropertyAction TargetObject="PinkText" PropertyName="IsVisible" Value="True" />
-            </ThemeVariantTrigger>
-            <ThemeVariantTrigger ThemeVariant="{x:Static ThemeVariant.Dark}">
-              <ChangePropertyAction TargetObject="PinkText" PropertyName="IsVisible" Value="False" />
-            </ThemeVariantTrigger>
-          </Interaction.Triggers>
         </StackPanel>
       </Border>
     </ThemeVariantScope>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml
@@ -1,0 +1,65 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ThemeVariantView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:pages="using:BehaviorsTestApplication.Views.Pages"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <UserControl.Resources>
+    <ThemeVariant x:Key="PinkVariant">Pink</ThemeVariant>
+    <ResourceDictionary>
+      <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark">
+          <SolidColorBrush x:Key="DemoBackground">Black</SolidColorBrush>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+          <SolidColorBrush x:Key="DemoBackground">White</SolidColorBrush>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="{x:Static pages:ThemeVariantView.Pink}">
+          <SolidColorBrush x:Key="DemoBackground">#ffe5ea</SolidColorBrush>
+        </ResourceDictionary>
+      </ResourceDictionary.ThemeDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <StackPanel Margin="5" Spacing="5">
+    <ComboBox x:Name="VariantSelector" SelectedIndex="0">
+      <ComboBox.Items>
+        <ThemeVariant>Default</ThemeVariant>
+        <ThemeVariant>Dark</ThemeVariant>
+        <ThemeVariant>Light</ThemeVariant>
+        <StaticResource ResourceKey="PinkVariant" />
+      </ComboBox.Items>
+    </ComboBox>
+    <ThemeVariantScope x:Name="Scope">
+      <Interaction.Behaviors>
+        <ThemeVariantBehavior ThemeVariant="{Binding SelectedItem, ElementName=VariantSelector}" />
+      </Interaction.Behaviors>
+      <Border Background="{DynamicResource DemoBackground}" Padding="10" CornerRadius="4">
+        <StackPanel Spacing="5">
+          <TextBlock Text="{Binding ActualThemeVariant, ElementName=Scope}" />
+          <Button Content="Toggle Dark" HorizontalAlignment="Left">
+            <Interaction.Triggers>
+              <EventTriggerBehavior EventName="Click">
+                <SetThemeVariantAction Target="{Binding ElementName=Scope}" ThemeVariant="Dark" />
+              </EventTriggerBehavior>
+            </Interaction.Triggers>
+          </Button>
+          <TextBlock x:Name="PinkText" Text="Pink theme active" IsVisible="False" />
+          <Interaction.Triggers>
+            <ThemeVariantTrigger ThemeVariant="{StaticResource PinkVariant}">
+              <ChangePropertyAction TargetObject="PinkText" PropertyName="IsVisible" Value="True" />
+            </ThemeVariantTrigger>
+            <ThemeVariantTrigger ThemeVariant="{x:Static ThemeVariant.Dark}">
+              <ChangePropertyAction TargetObject="PinkText" PropertyName="IsVisible" Value="False" />
+            </ThemeVariantTrigger>
+          </Interaction.Triggers>
+        </StackPanel>
+      </Border>
+    </ThemeVariantScope>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ThemeVariantView : UserControl
+{
+    public static ThemeVariant Pink { get; } = new("Pink", ThemeVariant.Light);
+
+    public ThemeVariantView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/SetThemeVariantAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/SetThemeVariantAction.cs
@@ -5,15 +5,15 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Sets the <see cref="StyledElement.RequestedThemeVariant"/> on the target control when executed.
+/// Sets the <see cref="ThemeVariantScope.RequestedThemeVariant"/> on the target control when executed.
 /// </summary>
 public class SetThemeVariantAction : StyledElementAction
 {
     /// <summary>
     /// Identifies the <see cref="Target"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<StyledElement?> TargetProperty =
-        AvaloniaProperty.Register<SetThemeVariantAction, StyledElement?>(nameof(Target));
+    public static readonly StyledProperty<ThemeVariantScope?> TargetProperty =
+        AvaloniaProperty.Register<SetThemeVariantAction, ThemeVariantScope?>(nameof(Target));
 
     /// <summary>
     /// Identifies the <see cref="ThemeVariant"/> avalonia property.
@@ -25,7 +25,7 @@ public class SetThemeVariantAction : StyledElementAction
     /// Gets or sets the target element. This is an avalonia property.
     /// </summary>
     [ResolveByName]
-    public StyledElement? Target
+    public ThemeVariantScope? Target
     {
         get => GetValue(TargetProperty);
         set => SetValue(TargetProperty, value);
@@ -48,13 +48,13 @@ public class SetThemeVariantAction : StyledElementAction
             return false;
         }
 
-        var target = Target ?? sender as StyledElement;
+        var target = Target ?? sender as ThemeVariantScope;
         if (target is null)
         {
             return false;
         }
 
-        target.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, ThemeVariant);
+        target.SetCurrentValue(ThemeVariantScope.RequestedThemeVariantProperty, ThemeVariant);
         return true;
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/Actions/SetThemeVariantAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Actions/SetThemeVariantAction.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+using Avalonia.Styling;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Sets the <see cref="StyledElement.RequestedThemeVariant"/> on the target control when executed.
+/// </summary>
+public class SetThemeVariantAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="Target"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<StyledElement?> TargetProperty =
+        AvaloniaProperty.Register<SetThemeVariantAction, StyledElement?>(nameof(Target));
+
+    /// <summary>
+    /// Identifies the <see cref="ThemeVariant"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ThemeVariant?> ThemeVariantProperty =
+        AvaloniaProperty.Register<SetThemeVariantAction, ThemeVariant?>(nameof(ThemeVariant));
+
+    /// <summary>
+    /// Gets or sets the target element. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public StyledElement? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the theme variant to assign. This is an avalonia property.
+    /// </summary>
+    public ThemeVariant? ThemeVariant
+    {
+        get => GetValue(ThemeVariantProperty);
+        set => SetValue(ThemeVariantProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var target = Target ?? sender as StyledElement;
+        if (target is null)
+        {
+            return false;
+        }
+
+        target.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, ThemeVariant);
+        return true;
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantBehavior.cs
@@ -1,0 +1,56 @@
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Sets the <see cref="StyledElement.RequestedThemeVariant"/> on the associated control.
+/// </summary>
+public class ThemeVariantBehavior : AttachedToVisualTreeBehavior<StyledElement>
+{
+    /// <summary>
+    /// Identifies the <see cref="ThemeVariant"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ThemeVariant?> ThemeVariantProperty =
+        AvaloniaProperty.Register<ThemeVariantBehavior, ThemeVariant?>(nameof(ThemeVariant));
+
+    /// <summary>
+    /// Gets or sets the theme variant to assign. This is an avalonia property.
+    /// </summary>
+    public ThemeVariant? ThemeVariant
+    {
+        get => GetValue(ThemeVariantProperty);
+        set => SetValue(ThemeVariantProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        if (AssociatedObject is null)
+        {
+            return DisposableAction.Empty;
+        }
+
+        var old = AssociatedObject.RequestedThemeVariant;
+        AssociatedObject.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, ThemeVariant);
+
+        return DisposableAction.Create(() =>
+        {
+            if (AssociatedObject is not null)
+            {
+                AssociatedObject.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, old);
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == ThemeVariantProperty && AssociatedObject is not null)
+        {
+            AssociatedObject.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, change.GetNewValue<ThemeVariant?>());
+        }
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantBehavior.cs
@@ -1,12 +1,13 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Styling;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Sets the <see cref="StyledElement.RequestedThemeVariant"/> on the associated control.
+/// Sets the <see cref="ThemeVariantScope.RequestedThemeVariant"/> on the associated control.
 /// </summary>
-public class ThemeVariantBehavior : AttachedToVisualTreeBehavior<StyledElement>
+public class ThemeVariantBehavior : AttachedToVisualTreeBehavior<ThemeVariantScope>
 {
     /// <summary>
     /// Identifies the <see cref="ThemeVariant"/> avalonia property.
@@ -32,13 +33,13 @@ public class ThemeVariantBehavior : AttachedToVisualTreeBehavior<StyledElement>
         }
 
         var old = AssociatedObject.RequestedThemeVariant;
-        AssociatedObject.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, ThemeVariant);
+        AssociatedObject.SetCurrentValue(ThemeVariantScope.RequestedThemeVariantProperty, ThemeVariant);
 
         return DisposableAction.Create(() =>
         {
             if (AssociatedObject is not null)
             {
-                AssociatedObject.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, old);
+                AssociatedObject.SetCurrentValue(ThemeVariantScope.RequestedThemeVariantProperty, old);
             }
         });
     }
@@ -50,7 +51,7 @@ public class ThemeVariantBehavior : AttachedToVisualTreeBehavior<StyledElement>
 
         if (change.Property == ThemeVariantProperty && AssociatedObject is not null)
         {
-            AssociatedObject.SetCurrentValue(StyledElement.RequestedThemeVariantProperty, change.GetNewValue<ThemeVariant?>());
+            AssociatedObject.SetCurrentValue(ThemeVariantScope.RequestedThemeVariantProperty, change.GetNewValue<ThemeVariant?>());
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantTrigger.cs
@@ -1,4 +1,3 @@
-using Avalonia.Controls;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.Xaml.Interactivity;

--- a/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ThemeVariant/ThemeVariantTrigger.cs
@@ -1,0 +1,75 @@
+using Avalonia.Controls;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Executes actions when the associated control's <see cref="StyledElement.ActualThemeVariant"/>
+/// matches the specified <see cref="ThemeVariant"/>.
+/// </summary>
+public class ThemeVariantTrigger : StyledElementTrigger<StyledElement>
+{
+    /// <summary>
+    /// Identifies the <see cref="ThemeVariant"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ThemeVariant?> ThemeVariantProperty =
+        AvaloniaProperty.Register<ThemeVariantTrigger, ThemeVariant?>(nameof(ThemeVariant));
+
+    /// <summary>
+    /// Gets or sets the theme variant to watch for. This is an avalonia property.
+    /// </summary>
+    public ThemeVariant? ThemeVariant
+    {
+        get => GetValue(ThemeVariantProperty);
+        set => SetValue(ThemeVariantProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        Evaluate();
+    }
+
+    /// <inheritdoc />
+    protected override void OnActualThemeVariantChangedEvent()
+    {
+        Evaluate();
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == ThemeVariantProperty)
+        {
+            Evaluate();
+        }
+    }
+
+    private void Evaluate()
+    {
+        if (AssociatedObject is null || !IsEnabled)
+        {
+            return;
+        }
+
+        if (AssociatedObject.ActualThemeVariant == ThemeVariant)
+        {
+            Dispatcher.UIThread.Post(() => Execute(null));
+        }
+    }
+
+    private void Execute(object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        Interaction.ExecuteActions(AssociatedObject, Actions, parameter);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThemeVariantBehavior` and `ThemeVariantTrigger` for automatic theme switching and reacting
- add `SetThemeVariantAction` to programmatically set `RequestedThemeVariant`
- add a sample page demonstrating theme variant usage

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*