### PR TITLE
Add editable drag TreeView sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,11 @@ This section provides an overview of all available classes and their purpose in 
 - **HideOnKeyPressedBehavior**  
   *Hides the target control when a specified key is pressed.*
 
-- **HideOnLostFocusBehavior**  
+- **HideOnLostFocusBehavior**
   *Hides the target control when it loses focus.*
+
+- **InlineEditBehavior**
+  *Toggles display and edit controls to enable in-place text editing.*
 
 - **ShowPointerPositionBehavior**
   *Displays the current pointer position (x, y coordinates) in a TextBlock for debugging or UI feedback.*
@@ -306,8 +309,11 @@ This section provides an overview of all available classes and their purpose in 
   *Executes one collection of actions when a condition is true and another when it is false.*
 
 ### DragAndDrop
-- **ContextDragBehavior**  
+- **ContextDragBehavior**
   *Enables drag operations using a “context” (data payload) that is carried during the drag–drop operation.*
+
+- **ContextDragWithDirectionBehavior**
+  *Starts a drag operation and includes the drag direction in the data object.*
 
 - **ContextDropBehavior**  
   *Handles drop events and passes context data between the drag source and drop target.*

--- a/samples/BehaviorsTestApplication/Controls/EditableItem.axaml
+++ b/samples/BehaviorsTestApplication/Controls/EditableItem.axaml
@@ -7,8 +7,7 @@
              Name="EditableItemUserControl">
   <Panel Background="Transparent">
     <Interaction.Behaviors>
-      <ShowOnDoubleTappedBehavior TargetControl="TextBoxEdit" />
-      <ShowOnKeyDownBehavior TargetControl="TextBoxEdit" Key="F2" />
+      <InlineEditBehavior EditControl="TextBoxEdit" DisplayControl="TextStackPanel" />
     </Interaction.Behaviors>
     <TextBox x:Name="TextBoxEdit"
              IsVisible="False"
@@ -20,9 +19,6 @@
              BorderThickness="0"
              Text="{Binding #EditableItemUserControl.Text, Mode=TwoWay}">
       <Interaction.Behaviors>
-        <HideOnKeyPressedBehavior TargetControl="TextBoxEdit" Key="Escape" />
-        <HideOnKeyPressedBehavior TargetControl="TextBoxEdit" Key="Enter" />
-        <HideOnLostFocusBehavior TargetControl="TextBoxEdit" />
         <TextBoxSelectAllOnGotFocusBehavior />
       </Interaction.Behaviors>
     </TextBox>

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -97,6 +97,9 @@
       <TabItem Header="EditableTree">
         <pages:EditableTreeViewView />
       </TabItem>
+      <TabItem Header="Editable Drag TreeView">
+        <pages:EditableDragTreeViewView />
+      </TabItem>
       <TabItem Header="Sliding Animation">
         <pages:SlidingAnimationView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDragTreeViewView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDragTreeViewView.axaml
@@ -1,0 +1,64 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.EditableDragTreeViewView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:controls="clr-namespace:BehaviorsTestApplication.Controls"
+             x:CompileBindings="True" x:DataType="vm:DragAndDropSampleViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:DragAndDropSampleViewModel />
+  </Design.DataContext>
+  <UserControl.Styles>
+    <Style Selector="TreeView.NodesEditableDrag">
+      <Style.Resources>
+        <NodesTreeViewDropHandler x:Key="NodesTreeViewDropHandler" />
+      </Style.Resources>
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDropBehavior Handler="{StaticResource NodesTreeViewDropHandler}" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="TreeView.NodesEditableDrag TreeViewItem">
+      <Setter Property="IsExpanded" Value="True" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="Margin" Value="0" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDragWithDirectionBehavior HorizontalDragThreshold="3" VerticalDragThreshold="3" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="TreeView.NodesEditableDrag TreeViewItem.DraggingUp">
+      <Setter Property="AdornerLayer.Adorner">
+        <Template>
+          <Border BorderThickness="0 2 0 0" BorderBrush="{DynamicResource SystemAccentColor}"/>
+        </Template>
+      </Setter>
+    </Style>
+    <Style Selector="TreeView.NodesEditableDrag TreeViewItem.DraggingDown">
+      <Setter Property="AdornerLayer.Adorner">
+        <Template>
+          <Border BorderThickness="0 0 0 2" BorderBrush="{DynamicResource SystemAccentColor}"/>
+        </Template>
+      </Setter>
+    </Style>
+    <Style Selector="TreeViewItem.TargetHighlight">
+      <Setter Property="Background" Value="{DynamicResource TreeViewItemBackgroundPointerOver}"/>
+    </Style>
+  </UserControl.Styles>
+  <TreeView ItemsSource="{Binding Nodes}" Classes="NodesEditableDrag">
+    <TreeView.ItemTemplate>
+      <TreeDataTemplate DataType="vm:DragNodeViewModel" ItemsSource="{Binding Nodes}">
+        <controls:EditableItem Text="{Binding Title}" />
+      </TreeDataTemplate>
+    </TreeView.ItemTemplate>
+  </TreeView>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDragTreeViewView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDragTreeViewView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class EditableDragTreeViewView : UserControl
+{
+    public EditableDragTreeViewView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Control/InlineEditBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Control/InlineEditBehavior.cs
@@ -1,0 +1,166 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Behavior that toggles visibility of display and edit controls to enable inline editing.
+/// </summary>
+public class InlineEditBehavior : StyledElementBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <see cref="EditControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> EditControlProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, Control?>(nameof(EditControl));
+
+    /// <summary>
+    /// Identifies the <see cref="DisplayControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> DisplayControlProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, Control?>(nameof(DisplayControl));
+
+    /// <summary>
+    /// Identifies the <see cref="EditKey"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Key> EditKeyProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, Key>(nameof(EditKey), Key.F2);
+
+    /// <summary>
+    /// Identifies the <see cref="AcceptKey"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Key> AcceptKeyProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, Key>(nameof(AcceptKey), Key.Enter);
+
+    /// <summary>
+    /// Identifies the <see cref="CancelKey"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Key> CancelKeyProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, Key>(nameof(CancelKey), Key.Escape);
+
+    /// <summary>
+    /// Editing control to show when editing begins.
+    /// </summary>
+    [ResolveByName]
+    public Control? EditControl
+    {
+        get => GetValue(EditControlProperty);
+        set => SetValue(EditControlProperty, value);
+    }
+
+    /// <summary>
+    /// Display control to show when not editing.
+    /// </summary>
+    [ResolveByName]
+    public Control? DisplayControl
+    {
+        get => GetValue(DisplayControlProperty);
+        set => SetValue(DisplayControlProperty, value);
+    }
+
+    /// <summary>
+    /// Key used to start editing.
+    /// </summary>
+    public Key EditKey
+    {
+        get => GetValue(EditKeyProperty);
+        set => SetValue(EditKeyProperty, value);
+    }
+
+    /// <summary>
+    /// Key used to accept editing.
+    /// </summary>
+    public Key AcceptKey
+    {
+        get => GetValue(AcceptKeyProperty);
+        set => SetValue(AcceptKeyProperty, value);
+    }
+
+    /// <summary>
+    /// Key used to cancel editing.
+    /// </summary>
+    public Key CancelKey
+    {
+        get => GetValue(CancelKeyProperty);
+        set => SetValue(CancelKeyProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        if (DisplayControl is not null)
+        {
+            DisplayControl.AddHandler(InputElement.DoubleTappedEvent, OnDisplayActivate, RoutingStrategies.Tunnel);
+            DisplayControl.AddHandler(InputElement.KeyDownEvent, OnDisplayKeyDown, RoutingStrategies.Tunnel);
+        }
+
+        if (EditControl is not null)
+        {
+            EditControl.AddHandler(InputElement.KeyDownEvent, OnEditKeyDown, RoutingStrategies.Tunnel);
+            EditControl.AddHandler(InputElement.LostFocusEvent, OnEditLostFocus, RoutingStrategies.Bubble);
+            EditControl.IsVisible = false;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        if (DisplayControl is not null)
+        {
+            DisplayControl.RemoveHandler(InputElement.DoubleTappedEvent, OnDisplayActivate);
+            DisplayControl.RemoveHandler(InputElement.KeyDownEvent, OnDisplayKeyDown);
+        }
+
+        if (EditControl is not null)
+        {
+            EditControl.RemoveHandler(InputElement.KeyDownEvent, OnEditKeyDown);
+            EditControl.RemoveHandler(InputElement.LostFocusEvent, OnEditLostFocus);
+        }
+    }
+
+    private void OnDisplayActivate(object? sender, RoutedEventArgs e) => BeginEdit();
+
+    private void OnDisplayKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == EditKey)
+        {
+            BeginEdit();
+            e.Handled = true;
+        }
+    }
+
+    private void OnEditKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == AcceptKey || e.Key == CancelKey)
+        {
+            EndEdit();
+        }
+    }
+
+    private void OnEditLostFocus(object? sender, RoutedEventArgs e) => EndEdit();
+
+    private void BeginEdit()
+    {
+        if (EditControl is null || DisplayControl is null)
+            return;
+
+        DisplayControl.IsVisible = false;
+        EditControl.IsVisible = true;
+        EditControl.Focus();
+        if (EditControl is TextBox tb)
+        {
+            tb.SelectAll();
+        }
+    }
+
+    private void EndEdit()
+    {
+        if (EditControl is null || DisplayControl is null)
+            return;
+
+        EditControl.IsVisible = false;
+        DisplayControl.IsVisible = true;
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
@@ -4,13 +4,12 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Xaml.Interactions.DragAndDrop;
 using Avalonia.Xaml.Interactivity;
 
-namespace BehaviorsTestApplication.Behaviors;
+namespace Avalonia.Xaml.Interactions.DragAndDrop;
 
 /// <summary>
-/// 
+/// Behavior that starts drag and drop with information about drag direction.
 /// </summary>
 public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Control>
 {
@@ -20,31 +19,31 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     private bool _captured;
 
     /// <summary>
-    /// 
+    /// Identifies the <see cref="Context"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<object?> ContextProperty =
-        AvaloniaProperty.Register<ContextDragBehavior, object?>(nameof(Context));
+        AvaloniaProperty.Register<ContextDragWithDirectionBehavior, object?>(nameof(Context));
 
     /// <summary>
-    /// 
+    /// Identifies the <see cref="Handler"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<IDragHandler?> HandlerProperty =
-        AvaloniaProperty.Register<ContextDragBehavior, IDragHandler?>(nameof(Handler));
+        AvaloniaProperty.Register<ContextDragWithDirectionBehavior, IDragHandler?>(nameof(Handler));
 
     /// <summary>
-    /// 
+    /// Identifies the <see cref="HorizontalDragThreshold"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<double> HorizontalDragThresholdProperty = 
-        AvaloniaProperty.Register<ContextDragBehavior, double>(nameof(HorizontalDragThreshold), 3);
+    public static readonly StyledProperty<double> HorizontalDragThresholdProperty =
+        AvaloniaProperty.Register<ContextDragWithDirectionBehavior, double>(nameof(HorizontalDragThreshold), 3);
 
     /// <summary>
-    /// 
+    /// Identifies the <see cref="VerticalDragThreshold"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<double> VerticalDragThresholdProperty =
-        AvaloniaProperty.Register<ContextDragBehavior, double>(nameof(VerticalDragThreshold), 3);
+        AvaloniaProperty.Register<ContextDragWithDirectionBehavior, double>(nameof(VerticalDragThreshold), 3);
 
     /// <summary>
-    /// 
+    /// Gets or sets the context used for drag operations.
     /// </summary>
     public object? Context
     {
@@ -53,7 +52,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     }
 
     /// <summary>
-    /// 
+    /// Gets or sets the drag handler to notify.
     /// </summary>
     public IDragHandler? Handler
     {
@@ -62,7 +61,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     }
 
     /// <summary>
-    /// 
+    /// Gets or sets the horizontal drag threshold.
     /// </summary>
     public double HorizontalDragThreshold
     {
@@ -71,7 +70,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     }
 
     /// <summary>
-    /// 
+    /// Gets or sets the vertical drag threshold.
     /// </summary>
     public double VerticalDragThreshold
     {
@@ -82,10 +81,14 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed,
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased,
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved,
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost,
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
     }
 
     /// <inheritdoc />
@@ -97,11 +100,11 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
         AssociatedObject?.RemoveHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost);
     }
 
-    private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string upOrDown)
+    private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string direction)
     {
         var data = new DataObject();
         data.Set(ContextDropBehavior.DataFormat, value!);
-        data.Set("direction", upOrDown);
+        data.Set("direction", direction);
 
         var effect = DragDropEffects.None;
 
@@ -136,8 +139,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
         if (properties.IsLeftButtonPressed)
         {
-            if (e.Source is Control control
-                && AssociatedObject?.DataContext == control.DataContext)
+            if (e.Source is Control control && AssociatedObject?.DataContext == control.DataContext)
             {
                 _dragStartPoint = e.GetPosition(null);
                 _triggerEvent = e;
@@ -151,7 +153,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     {
         if (_captured)
         {
-            if (e.InitialPressMouseButton == MouseButton.Left && _triggerEvent is { })
+            if (e.InitialPressMouseButton == MouseButton.Left && _triggerEvent is not null)
             {
                 Released();
             }
@@ -163,16 +165,14 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     private async void AssociatedObject_PointerMoved(object? sender, PointerEventArgs e)
     {
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
-        if (_captured
-            && properties.IsLeftButtonPressed &&
-            _triggerEvent is { })
+        if (_captured && properties.IsLeftButtonPressed && _triggerEvent is not null)
         {
             var point = e.GetPosition(null);
             var diff = _dragStartPoint - point;
-            var horizontalDragThreshold = HorizontalDragThreshold;
-            var verticalDragThreshold = VerticalDragThreshold;
+            var horizontal = HorizontalDragThreshold;
+            var vertical = VerticalDragThreshold;
 
-            if (Math.Abs(diff.X) > horizontalDragThreshold || Math.Abs(diff.Y) > verticalDragThreshold)
+            if (Math.Abs(diff.X) > horizontal || Math.Abs(diff.Y) > vertical)
             {
                 if (_lock)
                 {
@@ -184,7 +184,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
                 }
 
                 var context = Context ?? AssociatedObject?.DataContext;
-                    
+
                 Handler?.BeforeDragDrop(sender, _triggerEvent, context);
 
                 await DoDragDrop(_triggerEvent, context, diff.Y > 0 ? "up" : "down");


### PR DESCRIPTION
## Summary
- demo editable and draggable TreeView items
- wire sample page into main view
- add `InlineEditBehavior` and `ContextDragWithDirectionBehavior`

## Testing
- ❌ `dotnet test --no-build --verbosity minimal` (failed to run: `dotnet: command not found`)
