### PR TITLE
Add inline edit behavior and update sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,8 +677,10 @@ This section provides an overview of all available classes and their purpose in 
   *Clears the selection in a ListBox.*
 
 ### ListBoxItem
-- **SelectListBoxItemOnPointerMovedBehavior**  
+- **SelectListBoxItemOnPointerMovedBehavior**
   *Automatically selects a ListBoxItem when the pointer moves over it.*
+- **InlineEditBehavior**
+  *Toggles between a display element and a TextBox editor to enable inline editing (activated by double-tap or F2; ends on Enter, Escape, or losing focus).* 
 
 ### Responsive
 - **AdaptiveBehavior**

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -94,6 +94,9 @@
       <TabItem Header="EditableListBox">
         <pages:EditableListBoxView />
       </TabItem>
+      <TabItem Header="EditableDraggableListBox">
+        <pages:EditableDraggableListBoxView />
+      </TabItem>
       <TabItem Header="EditableTree">
         <pages:EditableTreeViewView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml
@@ -1,0 +1,64 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.EditableDraggableListBoxView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:CompileBindings="True" x:DataType="vm:DragAndDropSampleViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:DragAndDropSampleViewModel />
+  </Design.DataContext>
+  <UserControl.Styles>
+    <Style Selector="ListBox.EditableDragList">
+      <Style.Resources>
+        <ItemsListBoxDropHandler x:Key="ItemsListBoxDropHandler" />
+      </Style.Resources>
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDropBehavior Handler="{StaticResource ItemsListBoxDropHandler}" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="ListBox.EditableDragList ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Margin" Value="0" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDragBehavior HorizontalDragThreshold="3" VerticalDragThreshold="3" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+  </UserControl.Styles>
+  <ListBox ItemsSource="{Binding Items}" Classes="EditableDragList">
+    <ListBox.ItemTemplate>
+      <DataTemplate DataType="vm:DragItemViewModel" x:CompileBindings="False">
+        <Panel Background="Transparent">
+          <Interaction.Behaviors>
+            <InlineEditBehavior Display="DisplayPanel" Editor="EditBox" />
+          </Interaction.Behaviors>
+          <TextBox x:Name="EditBox"
+                   IsVisible="False"
+                   Height="{Binding #DisplayPanel.Bounds.Height}"
+                   VerticalContentAlignment="Center"
+                   Margin="0"
+                   Padding="6,0,6,0"
+                   BorderThickness="0"
+                   Text="{Binding Title}">
+          </TextBox>
+          <StackPanel x:Name="DisplayPanel"
+                      Orientation="Horizontal"
+                      Background="Transparent"
+                      Focusable="True">
+            <TextBlock Text="{Binding Title}" Margin="6,8,6,8" />
+          </StackPanel>
+        </Panel>
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class EditableDraggableListBoxView : UserControl
+{
+    public EditableDraggableListBoxView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Edit/InlineEditBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Edit/InlineEditBehavior.cs
@@ -1,0 +1,132 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Behavior that toggles between a display element and an editor element
+/// allowing inline editing of list items.
+/// </summary>
+public class InlineEditBehavior : AttachedToVisualTreeBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the display element.
+    /// </summary>
+    public static readonly StyledProperty<Control?> DisplayProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, Control?>(nameof(Display));
+
+    /// <summary>
+    /// Identifies the editor <see cref="TextBox"/> element.
+    /// </summary>
+    public static readonly StyledProperty<TextBox?> EditorProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, TextBox?>(nameof(Editor));
+
+    /// <summary>
+    /// Gets or sets the display element.
+    /// </summary>
+    [ResolveByName]
+    public Control? Display
+    {
+        get => GetValue(DisplayProperty);
+        set => SetValue(DisplayProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the editor element.
+    /// </summary>
+    [ResolveByName]
+    public TextBox? Editor
+    {
+        get => GetValue(EditorProperty);
+        set => SetValue(EditorProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        if (Display is not null && Editor is not null)
+        {
+            Display.IsVisible = true;
+            Editor.IsVisible = false;
+        }
+
+        var input = AssociatedObject as InputElement;
+        if (input is null || Editor is null || Display is null)
+        {
+            return DisposableAction.Empty;
+        }
+
+        input.AddHandler(Gestures.DoubleTappedEvent, OnBeginEdit, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        input.AddHandler(InputElement.KeyDownEvent, OnBeginKeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        Editor.AddHandler(InputElement.KeyDownEvent, OnEditorKeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        Editor.AddHandler(InputElement.LostFocusEvent, OnEditorLostFocus, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+
+        return DisposableAction.Create(() =>
+        {
+            input.RemoveHandler(Gestures.DoubleTappedEvent, OnBeginEdit);
+            input.RemoveHandler(InputElement.KeyDownEvent, OnBeginKeyDown);
+            Editor.RemoveHandler(InputElement.KeyDownEvent, OnEditorKeyDown);
+            Editor.RemoveHandler(InputElement.LostFocusEvent, OnEditorLostFocus);
+        });
+    }
+
+    private void OnBeginEdit(object? sender, RoutedEventArgs e)
+    {
+        BeginEdit();
+    }
+
+    private void OnBeginKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.F2)
+        {
+            BeginEdit();
+            e.Handled = true;
+        }
+    }
+
+    private void OnEditorKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key is Key.Enter or Key.Escape)
+        {
+            EndEdit();
+            e.Handled = true;
+        }
+    }
+
+    private void OnEditorLostFocus(object? sender, RoutedEventArgs e)
+    {
+        EndEdit();
+    }
+
+    private void BeginEdit()
+    {
+        if (Display is null || Editor is null)
+        {
+            return;
+        }
+
+        if (!Editor.IsVisible)
+        {
+            Display.IsVisible = false;
+            Editor.IsVisible = true;
+            Editor.Focus();
+            Editor.SelectAll();
+        }
+    }
+
+    private void EndEdit()
+    {
+        if (Display is null || Editor is null)
+        {
+            return;
+        }
+
+        if (Editor.IsVisible)
+        {
+            Display.IsVisible = true;
+            Editor.IsVisible = false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `InlineEditBehavior` for toggling between display and edit elements
- use the new behavior in `EditableDraggableListBoxView` instead of `EditableItem`
- document `InlineEditBehavior` in the README

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*