### PR TITLE
Add DataStateBehavior for Avalonia

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -40,6 +40,9 @@
       <TabItem Header="DataTriggerBehavior">
         <pages:DataTriggerBehaviorView />
       </TabItem>
+      <TabItem Header="DataStateBehavior">
+        <pages:DataStateBehaviorView />
+      </TabItem>
       <TabItem Header="DataTriggerBehavior Advanced">
         <pages:DataTriggerBehaviorAdvancedView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/DataStateBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataStateBehaviorView.axaml
@@ -1,0 +1,44 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DataStateBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vsm="clr-namespace:Avalonia.Styling;assembly=Avalonia.Styling"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Grid RowDefinitions="*,Auto">
+    <Border x:Name="StateBorder"
+            Grid.Row="0" Margin="5"
+            BorderBrush="{DynamicResource GrayBrush}"
+            BorderThickness="5">
+      <vsm:VisualStateManager.VisualStateGroups>
+        <vsm:VisualStateGroup x:Name="DataStates">
+          <vsm:VisualState x:Name="False">
+            <vsm:VisualState.Setters>
+              <Setter Target="StateBorder.Background" Value="{DynamicResource BlueBrush}" />
+            </vsm:VisualState.Setters>
+          </vsm:VisualState>
+          <vsm:VisualState x:Name="True">
+            <vsm:VisualState.Setters>
+              <Setter Target="StateBorder.Background" Value="{DynamicResource YellowBrush}" />
+            </vsm:VisualState.Setters>
+          </vsm:VisualState>
+        </vsm:VisualStateGroup>
+      </vsm:VisualStateManager.VisualStateGroups>
+      <Interaction.Behaviors>
+        <DataStateBehavior Binding="{Binding #ToggleSwitch.IsChecked}"
+                           Value="True"
+                           TrueState="True"
+                           FalseState="False" />
+      </Interaction.Behaviors>
+    </Border>
+    <ToggleSwitch x:Name="ToggleSwitch"
+                  Grid.Row="1" Margin="5"
+                  HorizontalAlignment="Center"
+                  Content="Toggle" />
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DataStateBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataStateBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DataStateBehaviorView : UserControl
+{
+    public DataStateBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions/Core/DataStateBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/DataStateBehavior.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics.CodeAnalysis;
+using Avalonia.Controls;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Toggles between two visual states based on a conditional statement.
+/// </summary>
+[RequiresUnreferencedCode("This functionality is not compatible with trimming.")]
+public class DataStateBehavior : StyledElementBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <seealso cref="Binding"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> BindingProperty =
+        AvaloniaProperty.Register<DataStateBehavior, object?>(nameof(Binding));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Value"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> ValueProperty =
+        AvaloniaProperty.Register<DataStateBehavior, object?>(nameof(Value));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TrueState"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> TrueStateProperty =
+        AvaloniaProperty.Register<DataStateBehavior, string?>(nameof(TrueState));
+
+    /// <summary>
+    /// Identifies the <seealso cref="FalseState"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> FalseStateProperty =
+        AvaloniaProperty.Register<DataStateBehavior, string?>(nameof(FalseState));
+
+    /// <summary>
+    /// Gets or sets the bound object that the <see cref="DataStateBehavior"/> listens to. This is an avalonia property.
+    /// </summary>
+    public object? Binding
+    {
+        get => GetValue(BindingProperty);
+        set => SetValue(BindingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the value to be compared with the <see cref="Binding"/>. This is an avalonia property.
+    /// </summary>
+    public object? Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the visual state to transition to when the condition is met. This is an avalonia property.
+    /// </summary>
+    public string? TrueState
+    {
+        get => GetValue(TrueStateProperty);
+        set => SetValue(TrueStateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the visual state to transition to when the condition is not met. This is an avalonia property.
+    /// </summary>
+    public string? FalseState
+    {
+        get => GetValue(FalseStateProperty);
+        set => SetValue(FalseStateProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == BindingProperty ||
+            change.Property == ValueProperty ||
+            change.Property == TrueStateProperty ||
+            change.Property == FalseStateProperty)
+        {
+            OnValueChanged(change);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnInitializedEvent()
+    {
+        base.OnInitializedEvent();
+
+        Evaluate();
+    }
+
+    private void OnValueChanged(AvaloniaPropertyChangedEventArgs args)
+    {
+        if (args.Sender is not DataStateBehavior behavior)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(behavior.Evaluate);
+    }
+
+    private void Evaluate()
+    {
+        if (AssociatedObject is not Control control)
+        {
+            return;
+        }
+
+        var isTrue = ComparisonConditionTypeHelper.Compare(Binding, ComparisonConditionType.Equal, Value);
+        var stateName = isTrue ? TrueState : FalseState;
+
+        if (!string.IsNullOrEmpty(stateName))
+        {
+            VisualStateManager.GoToState(control, stateName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DataStateBehavior` that toggles visual states using `VisualStateManager`
- create `DataStateBehaviorView` sample page demonstrating the new behavior
- expose the sample page via `MainView`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*