### PR TITLE
Add LaunchUriOrFileAction and sample

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -157,6 +157,9 @@
       <TabItem Header="KeyTrigger">
         <pages:KeyTriggerView />
       </TabItem>
+      <TabItem Header="LaunchUriOrFileAction">
+        <pages:LaunchUriOrFileActionView />
+      </TabItem>
       <TabItem Header="Reactive Navigation">
         <pages:ReactiveNavigationView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/LaunchUriOrFileActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/LaunchUriOrFileActionView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.LaunchUriOrFileActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Margin="5" Spacing="5">
+    <TextBox x:Name="PathTextBox" Text="https://www.avaloniaui.net" />
+    <Button Content="Launch">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click">
+          <LaunchUriOrFileAction Path="{Binding #PathTextBox.Text}" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/LaunchUriOrFileActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/LaunchUriOrFileActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class LaunchUriOrFileActionView : UserControl
+{
+    public LaunchUriOrFileActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Core/LaunchUriOrFileAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Core/LaunchUriOrFileAction.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using Avalonia.Xaml.Interactivity;
 
-namespace Avalonia.Xaml.Interactions.Core;
+namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// An action that will launch a process to open a file or URI. For files, this action will launch the

--- a/src/Avalonia.Xaml.Interactions/Core/LaunchUriOrFileAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/LaunchUriOrFileAction.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Diagnostics;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// An action that will launch a process to open a file or URI. For files, this action will launch the
+/// default program for the given file extension. A URI will open in a web browser.
+/// </summary>
+public class LaunchUriOrFileAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="Path"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> PathProperty =
+        AvaloniaProperty.Register<LaunchUriOrFileAction, string?>(nameof(Path));
+
+    /// <summary>
+    /// Gets or sets the file or URI to open. This is an avalonia property.
+    /// </summary>
+    public string? Path
+    {
+        get => GetValue(PathProperty);
+        set => SetValue(PathProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (IsEnabled != true)
+        {
+            return false;
+        }
+
+        var target = GetValue(PathProperty);
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return false;
+        }
+
+        try
+        {
+            var processStartInfo = new ProcessStartInfo(target)
+            {
+                UseShellExecute = true
+            };
+            Process.Start(processStartInfo);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `LaunchUriOrFileAction` for Avalonia
- show it in the sample app

## Testing
- `dotnet test` *(fails: `dotnet` not found)*