### PR TITLE
Add PropertyChangedTrigger for Avalonia

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -49,6 +49,9 @@
       <TabItem Header="ValueChangedTriggerBehavior">
         <pages:ValueChangedTriggerBehaviorView />
       </TabItem>
+      <TabItem Header="PropertyChangedTrigger">
+        <pages:PropertyChangedTriggerView />
+      </TabItem>
       <TabItem Header="EventTriggerBehavior">
         <pages:EventTriggerBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/PropertyChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PropertyChangedTriggerView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.PropertyChangedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <TextBox Text="{Binding MyString}" Margin="0,0,0,8" />
+    <TextBlock Name="CountText" Text="{Binding Count}" HorizontalAlignment="Center">
+      <Interaction.Behaviors>
+        <PropertyChangedTrigger Binding="{Binding MyString}">
+          <CallMethodAction TargetObject="{Binding}" MethodName="IncrementCount" />
+        </PropertyChangedTrigger>
+      </Interaction.Behaviors>
+    </TextBlock>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/PropertyChangedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/PropertyChangedTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class PropertyChangedTriggerView : UserControl
+{
+    public PropertyChangedTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Core/PropertyChangedTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Core/PropertyChangedTrigger.cs
@@ -1,7 +1,7 @@
 using Avalonia.Threading;
 using Avalonia.Xaml.Interactivity;
 
-namespace Avalonia.Xaml.Interactions.Core;
+namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Represents a trigger that performs actions when the bound data have changed.

--- a/src/Avalonia.Xaml.Interactions/Core/PropertyChangedTrigger.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/PropertyChangedTrigger.cs
@@ -1,0 +1,56 @@
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Represents a trigger that performs actions when the bound data have changed.
+/// </summary>
+public class PropertyChangedTrigger : StyledElementTrigger
+{
+    /// <summary>
+    /// Identifies the <see cref="Binding"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> BindingProperty =
+        AvaloniaProperty.Register<PropertyChangedTrigger, object?>(nameof(Binding));
+
+    /// <summary>
+    /// Gets or sets a binding object that the trigger will listen to. This is an avalonia property.
+    /// </summary>
+    public object? Binding
+    {
+        get => GetValue(BindingProperty);
+        set => SetValue(BindingProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == BindingProperty)
+        {
+            OnBindingChanged(change);
+        }
+    }
+
+    private void OnBindingChanged(AvaloniaPropertyChangedEventArgs args)
+    {
+        if (args.Sender is not PropertyChangedTrigger behavior)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() => behavior.Execute(args));
+    }
+
+    private void Execute(object? parameter)
+    {
+        if (AssociatedObject is null || !IsEnabled)
+        {
+            return;
+        }
+
+        Interaction.ExecuteActions(AssociatedObject, Actions, parameter);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PropertyChangedTrigger` for Avalonia behaviors
- provide sample page demonstrating usage
- wire sample page into the sample application

## Testing
- `dotnet test` *(fails: `dotnet` not found)*