### PR TITLE
Add RemoveItemInListBoxAction for Avalonia

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -85,6 +85,9 @@
       <TabItem Header="RemoveElementAction">
         <pages:RemoveElementActionView />
       </TabItem>
+      <TabItem Header="RemoveItemInListBoxAction">
+        <pages:RemoveItemInListBoxActionView />
+      </TabItem>
       <TabItem Header="AdaptiveBehavior">
         <pages:AdaptiveBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.RemoveItemInListBoxActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <ListBox ItemsSource="{Binding Items}" Margin="5">
+    <ListBox.ItemTemplate>
+      <DataTemplate DataType="vm:ItemViewModel" x:CompileBindings="False">
+        <StackPanel Orientation="Horizontal" Spacing="10">
+          <TextBlock Text="{Binding Value}" VerticalAlignment="Center" />
+          <Button Content="Remove">
+            <Interaction.Behaviors>
+              <EventTriggerBehavior EventName="Click">
+                <RemoveItemInListBoxAction />
+              </EventTriggerBehavior>
+            </Interaction.Behaviors>
+          </Button>
+        </StackPanel>
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml
@@ -11,7 +11,7 @@
   </Design.DataContext>
   <ListBox ItemsSource="{Binding Items}" Margin="5">
     <ListBox.ItemTemplate>
-      <DataTemplate DataType="vm:ItemViewModel" x:CompileBindings="False">
+      <DataTemplate DataType="vm:ItemViewModel">
         <StackPanel Orientation="Horizontal" Spacing="10">
           <TextBlock Text="{Binding Value}" VerticalAlignment="Center" />
           <Button Content="Remove">

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class RemoveItemInListBoxActionView : UserControl
+{
+    public RemoveItemInListBoxActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/ListBox/RemoveItemInListBoxAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ListBox/RemoveItemInListBoxAction.cs
@@ -4,7 +4,7 @@ using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Xaml.Interactivity;
 
-namespace Avalonia.Xaml.Interactions.Core;
+namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Allows a user to remove the item from a <see cref="ListBox"/> ItemTemplate.
@@ -12,14 +12,14 @@ namespace Avalonia.Xaml.Interactions.Core;
 public sealed class RemoveItemInListBoxAction : StyledElementAction
 {
     /// <inheritdoc />
-    public override object? Execute(object? sender, object? parameter)
+    public override object Execute(object? sender, object? parameter)
     {
         if (!IsEnabled)
         {
             return false;
         }
 
-        if (sender is not IControl control)
+        if (sender is not Control control)
         {
             return false;
         }
@@ -30,12 +30,12 @@ public sealed class RemoveItemInListBoxAction : StyledElementAction
             return false;
         }
 
-        if (itemsControl.ItemsSource is IList list && !list.IsReadOnly)
+        if (itemsControl.ItemsSource is IList listItemsSource && !listItemsSource.IsReadOnly)
         {
             var data = control.DataContext;
-            if (list.Contains(data))
+            if (listItemsSource.Contains(data))
             {
-                list.Remove(data);
+                listItemsSource.Remove(data);
                 return true;
             }
         }
@@ -44,9 +44,9 @@ public sealed class RemoveItemInListBoxAction : StyledElementAction
             var listBoxItem = control.GetSelfAndLogicalAncestors().OfType<ListBoxItem>().FirstOrDefault();
             if (listBoxItem is not null)
             {
-                if (listBox.Items is IList list && list.Contains(listBoxItem.DataContext))
+                if (listBox.Items is IList listItems && listItems.Contains(listBoxItem.DataContext))
                 {
-                    list.Remove(listBoxItem.DataContext);
+                    listItems.Remove(listBoxItem.DataContext);
                     return true;
                 }
             }

--- a/src/Avalonia.Xaml.Interactions/Core/RemoveItemInListBoxAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/RemoveItemInListBoxAction.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Core;
+
+/// <summary>
+/// Allows a user to remove the item from a <see cref="ListBox"/> ItemTemplate.
+/// </summary>
+public sealed class RemoveItemInListBoxAction : StyledElementAction
+{
+    /// <inheritdoc />
+    public override object? Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        if (sender is not IControl control)
+        {
+            return false;
+        }
+
+        var itemsControl = control.GetSelfAndLogicalAncestors().OfType<ItemsControl>().FirstOrDefault();
+        if (itemsControl is null)
+        {
+            return false;
+        }
+
+        if (itemsControl.ItemsSource is IList list && !list.IsReadOnly)
+        {
+            var data = control.DataContext;
+            if (list.Contains(data))
+            {
+                list.Remove(data);
+                return true;
+            }
+        }
+        else if (itemsControl is ListBox listBox)
+        {
+            var listBoxItem = control.GetSelfAndLogicalAncestors().OfType<ListBoxItem>().FirstOrDefault();
+            if (listBoxItem is not null)
+            {
+                if (listBox.Items is IList list && list.Contains(listBoxItem.DataContext))
+                {
+                    list.Remove(listBoxItem.DataContext);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- port RemoveItemInListBoxAction to Avalonia
- add sample page demonstrating how to remove a listbox item
- link the sample in the samples application's `MainView`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*