### PR TITLE
Add FluidMoveBehavior sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/FluidMoveBehaviorViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/FluidMoveBehaviorViewModel.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using System.Windows.Input;
+using ReactiveUI;
+
+namespace BehaviorsTestApplication.ViewModels;
+
+public class FluidMoveBehaviorViewModel : ViewModelBase
+{
+    public FluidMoveBehaviorViewModel()
+    {
+        for (var i = 1; i <= 8; i++)
+        {
+            Items.Add(i);
+        }
+
+        ShuffleCommand = ReactiveCommand.Create(Shuffle);
+    }
+
+    public ObservableCollection<int> Items { get; } = new();
+
+    public ICommand ShuffleCommand { get; }
+
+    private void Shuffle()
+    {
+        var rnd = new Random();
+        var array = Items.ToList();
+        Items.Clear();
+        foreach (var value in array.OrderBy(_ => rnd.Next()))
+        {
+            Items.Add(value);
+        }
+    }
+}

--- a/samples/BehaviorsTestApplication/ViewModels/FluidMoveBehaviorViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/FluidMoveBehaviorViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reactive;
 using System.Windows.Input;
 using ReactiveUI;
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -100,6 +100,9 @@
       <TabItem Header="Sliding Animation">
         <pages:SlidingAnimationView />
       </TabItem>
+      <TabItem Header="FluidMoveBehavior">
+        <pages:FluidMoveBehaviorView />
+      </TabItem>
       <TabItem Header="BehaviorCollectionTemplate">
         <pages:BehaviorCollectionTemplateView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FluidMoveBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:local="using:Avalonia.Xaml.Interactions.Custom.Layout"
+             x:DataType="vm:FluidMoveBehaviorViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:FluidMoveBehaviorViewModel />
+  </Design.DataContext>
+  <StackPanel Margin="10" Spacing="10">
+    <Button Content="Shuffle" Width="100" Command="{Binding ShuffleCommand}" />
+    <ItemsControl Items="{Binding Items}">
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <WrapPanel />
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+          <Border Width="40" Height="40" Margin="4" Background="LightBlue">
+            <TextBlock Text="{Binding .}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+          </Border>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+      <Interaction.Behaviors>
+        <local:FluidMoveBehavior AppliesTo="Children" Duration="0:0:0.3" />
+      </Interaction.Behaviors>
+    </ItemsControl>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:local="using:Avalonia.Xaml.Interactions.Custom.Layout"
              x:DataType="vm:FluidMoveBehaviorViewModel"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
   <Design.DataContext>
@@ -12,7 +11,7 @@
   </Design.DataContext>
   <StackPanel Margin="10" Spacing="10">
     <Button Content="Shuffle" Width="100" Command="{Binding ShuffleCommand}" />
-    <ItemsControl Items="{Binding Items}">
+    <ItemsControl ItemsSource="{Binding Items}">
       <ItemsControl.ItemsPanel>
         <ItemsPanelTemplate>
           <WrapPanel />
@@ -26,7 +25,7 @@
         </DataTemplate>
       </ItemsControl.ItemTemplate>
       <Interaction.Behaviors>
-        <local:FluidMoveBehavior AppliesTo="Children" Duration="0:0:0.3" />
+        <FluidMoveBehavior AppliesTo="Children" Duration="0:0:0.3" />
       </Interaction.Behaviors>
     </ItemsControl>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using BehaviorsTestApplication.ViewModels;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FluidMoveBehaviorView : UserControl
+{
+    public FluidMoveBehaviorView()
+    {
+        InitializeComponent();
+        DataContext = new FluidMoveBehaviorViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Layout/FluidMoveBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Layout/FluidMoveBehavior.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom.Layout;
+
+/// <summary>
+/// Determines if the behavior applies to the associated element or its children.
+/// </summary>
+public enum FluidMoveScope
+{
+    /// <summary>
+    /// Apply behavior to the element itself.
+    /// </summary>
+    Self,
+    /// <summary>
+    /// Apply behavior to the children of the element.
+    /// </summary>
+    Children
+}
+
+/// <summary>
+/// Behavior that animates position changes of a control or its children.
+/// </summary>
+public class FluidMoveBehavior : Behavior<Visual>
+{
+    private readonly Dictionary<Control, PixelPoint> _positions = new();
+
+    /// <summary>
+    /// Identifies the <see cref="AppliesTo"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<FluidMoveScope> AppliesToProperty =
+        AvaloniaProperty.Register<FluidMoveBehavior, FluidMoveScope>(nameof(AppliesTo), FluidMoveScope.Self);
+
+    /// <summary>
+    /// Identifies the <see cref="Duration"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TimeSpan> DurationProperty =
+        AvaloniaProperty.Register<FluidMoveBehavior, TimeSpan>(nameof(Duration), TimeSpan.FromMilliseconds(300));
+
+    /// <summary>
+    /// Gets or sets how the behavior is applied.
+    /// </summary>
+    public FluidMoveScope AppliesTo
+    {
+        get => GetValue(AppliesToProperty);
+        set => SetValue(AppliesToProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets animation duration.
+    /// </summary>
+    public TimeSpan Duration
+    {
+        get => GetValue(DurationProperty);
+        set => SetValue(DurationProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        if (AssociatedObject is Visual v)
+        {
+            v.LayoutUpdated += OnLayoutUpdated;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject is Visual v)
+        {
+            v.LayoutUpdated -= OnLayoutUpdated;
+        }
+        base.OnDetaching();
+    }
+
+    private void OnLayoutUpdated(object? sender, EventArgs e)
+    {
+        if (AssociatedObject is not Visual root)
+        {
+            return;
+        }
+
+        if (AppliesTo == FluidMoveScope.Self && root is Control c)
+        {
+            UpdateControl(c, root);
+        }
+        else if (AppliesTo == FluidMoveScope.Children && root is Panel panel)
+        {
+            foreach (var child in panel.Children.OfType<Control>())
+            {
+                UpdateControl(child, root);
+            }
+        }
+    }
+
+    private void UpdateControl(Control control, Visual root)
+    {
+        var p = control.TranslatePoint(new Point(0, 0), root);
+        if (p is null)
+        {
+            return;
+        }
+
+        var current = new PixelPoint((int)p.Value.X, (int)p.Value.Y);
+
+        if (!_positions.TryGetValue(control, out var previous))
+        {
+            _positions[control] = current;
+            return;
+        }
+
+        if (previous == current)
+        {
+            return;
+        }
+
+        var dx = previous.X - current.X;
+        var dy = previous.Y - current.Y;
+
+        if (control.RenderTransform is not TranslateTransform transform)
+        {
+            transform = new TranslateTransform();
+            control.RenderTransform = transform;
+        }
+
+        transform.X = dx;
+        transform.Y = dy;
+
+        var animation = new Animation.Animation
+        {
+            Duration = Duration,
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters =
+                    {
+                        new Setter(TranslateTransform.XProperty, dx),
+                        new Setter(TranslateTransform.YProperty, dy)
+                    }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters =
+                    {
+                        new Setter(TranslateTransform.XProperty, 0d),
+                        new Setter(TranslateTransform.YProperty, 0d)
+                    }
+                }
+            }
+        };
+
+        _ = animation.RunAsync(transform);
+
+        _positions[control] = current;
+    }
+}

--- a/src/Avalonia.Xaml.Interactions.Custom/Layout/FluidMoveBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/Layout/FluidMoveBehavior.cs
@@ -1,16 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Avalonia;
 using Avalonia.Animation;
-using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
-using Avalonia.VisualTree;
+using Avalonia.Styling;
 using Avalonia.Xaml.Interactivity;
 
-namespace Avalonia.Xaml.Interactions.Custom.Layout;
+namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Determines if the behavior applies to the associated element or its children.
@@ -38,7 +36,7 @@ public class FluidMoveBehavior : Behavior<Visual>
     /// Identifies the <see cref="AppliesTo"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<FluidMoveScope> AppliesToProperty =
-        AvaloniaProperty.Register<FluidMoveBehavior, FluidMoveScope>(nameof(AppliesTo), FluidMoveScope.Self);
+        AvaloniaProperty.Register<FluidMoveBehavior, FluidMoveScope>(nameof(AppliesTo));
 
     /// <summary>
     /// Identifies the <see cref="Duration"/> avalonia property.
@@ -68,7 +66,7 @@ public class FluidMoveBehavior : Behavior<Visual>
     protected override void OnAttached()
     {
         base.OnAttached();
-        if (AssociatedObject is Visual v)
+        if (AssociatedObject is Layoutable v)
         {
             v.LayoutUpdated += OnLayoutUpdated;
         }
@@ -77,7 +75,7 @@ public class FluidMoveBehavior : Behavior<Visual>
     /// <inheritdoc />
     protected override void OnDetaching()
     {
-        if (AssociatedObject is Visual v)
+        if (AssociatedObject is Layoutable v)
         {
             v.LayoutUpdated -= OnLayoutUpdated;
         }
@@ -86,7 +84,7 @@ public class FluidMoveBehavior : Behavior<Visual>
 
     private void OnLayoutUpdated(object? sender, EventArgs e)
     {
-        if (AssociatedObject is not Visual root)
+        if (AssociatedObject is not { } root)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- add new `FluidMoveBehavior` for Avalonia in `Layout`
- demonstrate fluid layout animation with new sample page
- hook the sample page in MainView

## Testing
- `dotnet --version` *(fails: command not found)*
- `./build.sh` *(fails due to missing .NET)*