### PR TITLE
Add missing action sample pages

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -93,6 +93,9 @@ public partial class MainWindowViewModel : ViewModelBase
         OpenFoldersCommand = ReactiveCommand.Create<IEnumerable<IStorageFolder>>(OpenFolders);
 
         GetClipboardTextCommand = ReactiveCommand.Create<string?>(GetClipboardText);
+        GetClipboardDataCommand = ReactiveCommand.Create<object?>(GetClipboardData);
+        GetClipboardFormatsCommand = ReactiveCommand.Create<IEnumerable<string>?>(GetClipboardFormats);
+        SetClipboardDataObjectCommand = ReactiveCommand.Create<object?>(SetClipboardDataObject);
 
         Greeting = "Entered text will appear here";
         TextChangedCommand = ReactiveCommand.Create<TextChangedEventArgs>(OnTextChanged);
@@ -154,6 +157,12 @@ public partial class MainWindowViewModel : ViewModelBase
     
     public ICommand GetClipboardTextCommand { get; set; }
 
+    public ICommand GetClipboardDataCommand { get; set; }
+
+    public ICommand GetClipboardFormatsCommand { get; set; }
+
+    public ICommand SetClipboardDataObjectCommand { get; set; }
+
     public ICommand TextChangedCommand { get; }
 
     private void DataContextChanged()
@@ -201,6 +210,24 @@ public partial class MainWindowViewModel : ViewModelBase
     private void GetClipboardText(string? text)
     {
         Console.WriteLine($"GetClipboardTextCommand: {text}");
+    }
+
+    private void GetClipboardData(object? data)
+    {
+        Console.WriteLine($"GetClipboardDataCommand: {data}");
+    }
+
+    private void GetClipboardFormats(IEnumerable<string>? formats)
+    {
+        if (formats is not null)
+        {
+            Console.WriteLine($"GetClipboardFormatsCommand: {string.Join(',', formats)}");
+        }
+    }
+
+    private void SetClipboardDataObject(object? obj)
+    {
+        Console.WriteLine($"SetClipboardDataObjectCommand: {obj}");
     }
 
     public void IncrementCount() => Count++;

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -95,7 +95,6 @@ public partial class MainWindowViewModel : ViewModelBase
         GetClipboardTextCommand = ReactiveCommand.Create<string?>(GetClipboardText);
         GetClipboardDataCommand = ReactiveCommand.Create<object?>(GetClipboardData);
         GetClipboardFormatsCommand = ReactiveCommand.Create<IEnumerable<string>?>(GetClipboardFormats);
-        SetClipboardDataObjectCommand = ReactiveCommand.Create<object?>(SetClipboardDataObject);
 
         Greeting = "Entered text will appear here";
         TextChangedCommand = ReactiveCommand.Create<TextChangedEventArgs>(OnTextChanged);
@@ -161,8 +160,6 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public ICommand GetClipboardFormatsCommand { get; set; }
 
-    public ICommand SetClipboardDataObjectCommand { get; set; }
-
     public ICommand TextChangedCommand { get; }
 
     private void DataContextChanged()
@@ -223,11 +220,6 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             Console.WriteLine($"GetClipboardFormatsCommand: {string.Join(',', formats)}");
         }
-    }
-
-    private void SetClipboardDataObject(object? obj)
-    {
-        Console.WriteLine($"SetClipboardDataObjectCommand: {obj}");
     }
 
     public void IncrementCount() => Count++;

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -154,6 +154,33 @@
       <TabItem Header="Clipboard">
         <pages:ClipboardView />
       </TabItem>
+      <TabItem Header="GetClipboardDataAction">
+        <pages:GetClipboardDataActionView />
+      </TabItem>
+      <TabItem Header="GetClipboardFormatsAction">
+        <pages:GetClipboardFormatsActionView />
+      </TabItem>
+      <TabItem Header="SetClipboardDataObjectAction">
+        <pages:SetClipboardDataObjectActionView />
+      </TabItem>
+      <TabItem Header="FocusControlAction">
+        <pages:FocusControlActionView />
+      </TabItem>
+      <TabItem Header="Hide/ShowControlAction">
+        <pages:HideShowControlActionView />
+      </TabItem>
+      <TabItem Header="ShowHideFlyoutAction">
+        <pages:ShowHideFlyoutActionView />
+      </TabItem>
+      <TabItem Header="ShowContextMenuAction">
+        <pages:ShowContextMenuActionView />
+      </TabItem>
+      <TabItem Header="SetEnabledAction">
+        <pages:SetEnabledActionView />
+      </TabItem>
+      <TabItem Header="ShowNotificationAction">
+        <pages:ShowNotificationActionView />
+      </TabItem>
       <TabItem Header="File Drop Handler">
         <pages:FileDropHandlerView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusControlActionView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FocusControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <TextBox x:Name="TargetBox" Margin="5" Watermark="Focus me" />
+    <Button x:Name="FocusButton" Content="Focus TextBox" Margin="5">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="FocusButton">
+          <FocusControlAction TargetControl="{Binding ElementName=TargetBox}" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FocusControlActionView : UserControl
+{
+    public FocusControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/GetClipboardDataActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/GetClipboardDataActionView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.GetClipboardDataActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Grid>
+    <Button x:Name="GetDataButton" Content="Get Clipboard Data" Margin="5">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="GetDataButton">
+          <GetClipboardDataAction Command="{Binding GetClipboardDataCommand}" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/GetClipboardDataActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/GetClipboardDataActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class GetClipboardDataActionView : UserControl
+{
+    public GetClipboardDataActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/GetClipboardFormatsActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/GetClipboardFormatsActionView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.GetClipboardFormatsActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Grid>
+    <Button x:Name="GetFormatsButton" Content="Get Clipboard Formats" Margin="5">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="GetFormatsButton">
+          <GetClipboardFormatsAction Command="{Binding GetClipboardFormatsCommand}" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/GetClipboardFormatsActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/GetClipboardFormatsActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class GetClipboardFormatsActionView : UserControl
+{
+    public GetClipboardFormatsActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml
@@ -18,12 +18,12 @@
       <TextBlock Text="Target control" />
     </Border>
   </StackPanel>
-  <UserControl.Behaviors>
-    <EventTriggerBehavior EventName="Click" SourceObject="HideButton">
+  <Interaction.Behaviors>
+    <EventTriggerBehavior SourceObject="HideButton" EventName="Click">
       <HideControlAction TargetControl="{Binding ElementName=Target}" />
     </EventTriggerBehavior>
-    <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
+    <EventTriggerBehavior SourceObject="ShowButton" EventName="Click">
       <ShowControlAction TargetControl="{Binding ElementName=Target}" />
     </EventTriggerBehavior>
-  </UserControl.Behaviors>
+  </Interaction.Behaviors>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.HideShowControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <StackPanel Orientation="Horizontal" Spacing="5">
+      <Button x:Name="HideButton" Content="Hide" Margin="5" />
+      <Button x:Name="ShowButton" Content="Show" Margin="5" />
+    </StackPanel>
+    <Border x:Name="Target" Background="LightGray" Margin="5" Padding="10">
+      <TextBlock Text="Target control" />
+    </Border>
+  </StackPanel>
+  <UserControl.Behaviors>
+    <EventTriggerBehavior EventName="Click" SourceObject="HideButton">
+      <HideControlAction TargetControl="{Binding ElementName=Target}" />
+    </EventTriggerBehavior>
+    <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
+      <ShowControlAction TargetControl="{Binding ElementName=Target}" />
+    </EventTriggerBehavior>
+  </UserControl.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class HideShowControlActionView : UserControl
+{
+    public HideShowControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml
@@ -13,7 +13,7 @@
     <Button x:Name="SetDataButton" Content="Set Clipboard Data Object" Margin="5">
       <Interaction.Behaviors>
         <EventTriggerBehavior EventName="Click" SourceObject="SetDataButton">
-          <SetClipboardDataObjectAction Data="{Binding}" Command="{Binding SetClipboardDataObjectCommand}" />
+          <SetClipboardDataObjectAction DataObject="{Binding}" />
         </EventTriggerBehavior>
       </Interaction.Behaviors>
     </Button>

--- a/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.SetClipboardDataObjectActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Grid>
+    <Button x:Name="SetDataButton" Content="Set Clipboard Data Object" Margin="5">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="SetDataButton">
+          <SetClipboardDataObjectAction Data="{Binding}" Command="{Binding SetClipboardDataObjectCommand}" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class SetClipboardDataObjectActionView : UserControl
+{
+    public SetClipboardDataObjectActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml
@@ -16,12 +16,12 @@
       <Button x:Name="EnableButton" Content="Enable" Margin="5" />
     </StackPanel>
   </StackPanel>
-  <UserControl.Behaviors>
+  <Interaction.Behaviors>
     <EventTriggerBehavior EventName="Click" SourceObject="DisableButton">
       <SetEnabledAction TargetControl="{Binding ElementName=TargetBox}" IsEnabledValue="False" />
     </EventTriggerBehavior>
     <EventTriggerBehavior EventName="Click" SourceObject="EnableButton">
       <SetEnabledAction TargetControl="{Binding ElementName=TargetBox}" IsEnabledValue="True" />
     </EventTriggerBehavior>
-  </UserControl.Behaviors>
+  </Interaction.Behaviors>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.SetEnabledActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <TextBox x:Name="TargetBox" Margin="5" Watermark="Toggle enabled" />
+    <StackPanel Orientation="Horizontal" Spacing="5">
+      <Button x:Name="DisableButton" Content="Disable" Margin="5" />
+      <Button x:Name="EnableButton" Content="Enable" Margin="5" />
+    </StackPanel>
+  </StackPanel>
+  <UserControl.Behaviors>
+    <EventTriggerBehavior EventName="Click" SourceObject="DisableButton">
+      <SetEnabledAction TargetControl="{Binding ElementName=TargetBox}" IsEnabledValue="False" />
+    </EventTriggerBehavior>
+    <EventTriggerBehavior EventName="Click" SourceObject="EnableButton">
+      <SetEnabledAction TargetControl="{Binding ElementName=TargetBox}" IsEnabledValue="True" />
+    </EventTriggerBehavior>
+  </UserControl.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class SetEnabledActionView : UserControl
+{
+    public SetEnabledActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowContextMenuActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowContextMenuActionView.axaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ShowContextMenuActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Button x:Name="Target" Content="Open Context Menu" Margin="5">
+    <Button.ContextMenu>
+      <ContextMenu>
+        <MenuItem Header="Item 1" />
+        <MenuItem Header="Item 2" />
+      </ContextMenu>
+    </Button.ContextMenu>
+    <Interaction.Behaviors>
+      <EventTriggerBehavior EventName="Click">
+        <ShowContextMenuAction />
+      </EventTriggerBehavior>
+    </Interaction.Behaviors>
+  </Button>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowContextMenuActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowContextMenuActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ShowContextMenuActionView : UserControl
+{
+    public ShowContextMenuActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ShowHideFlyoutActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <Button x:Name="ShowButton" Content="Show Flyout" Margin="5" />
+    <Button x:Name="HideButton" Content="Hide Flyout" Margin="5" />
+    <Button x:Name="Target" Content="Target" Margin="5">
+      <Button.Flyout>
+        <Flyout x:Name="DemoFlyout">
+          <TextBlock Margin="10" Text="Flyout content" />
+        </Flyout>
+      </Button.Flyout>
+    </Button>
+  </StackPanel>
+  <UserControl.Behaviors>
+    <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
+      <ShowFlyoutAction TargetControl="{Binding ElementName=Target}" Flyout="{Binding ElementName=DemoFlyout}" />
+    </EventTriggerBehavior>
+    <EventTriggerBehavior EventName="Click" SourceObject="HideButton">
+      <HideFlyoutAction TargetControl="{Binding ElementName=Target}" Flyout="{Binding ElementName=DemoFlyout}" />
+    </EventTriggerBehavior>
+  </UserControl.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml
@@ -14,18 +14,18 @@
     <Button x:Name="HideButton" Content="Hide Flyout" Margin="5" />
     <Button x:Name="Target" Content="Target" Margin="5">
       <Button.Flyout>
-        <Flyout x:Name="DemoFlyout">
+        <Flyout>
           <TextBlock Margin="10" Text="Flyout content" />
         </Flyout>
       </Button.Flyout>
     </Button>
   </StackPanel>
-  <UserControl.Behaviors>
+  <Interaction.Behaviors>
     <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
-      <ShowFlyoutAction TargetControl="{Binding ElementName=Target}" Flyout="{Binding ElementName=DemoFlyout}" />
+      <ShowFlyoutAction TargetControl="Target" Flyout="{Binding #Target.Flyout}" />
     </EventTriggerBehavior>
     <EventTriggerBehavior EventName="Click" SourceObject="HideButton">
-      <HideFlyoutAction TargetControl="{Binding ElementName=Target}" Flyout="{Binding ElementName=DemoFlyout}" />
+      <HideFlyoutAction TargetControl="Target" Flyout="{Binding #Target.Flyout}" />
     </EventTriggerBehavior>
-  </UserControl.Behaviors>
+  </Interaction.Behaviors>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ShowHideFlyoutActionView : UserControl
+{
+    public ShowHideFlyoutActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ShowNotificationActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:not="clr-namespace:Avalonia.Controls.Notifications;assembly=Avalonia.Controls.Notifications"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel>
+    <Interaction.Behaviors>
+      <NotificationManagerBehavior x:Name="Manager" />
+    </Interaction.Behaviors>
+    <Button x:Name="ShowButton" Content="Show Notification" Margin="5" />
+    <not:NotificationCard x:Name="Card" Title="Closable" Message="NotificationCard" IsOpen="True" Margin="5" />
+    <Button x:Name="CloseButton" Content="Close Card" Margin="5" />
+  </StackPanel>
+  <UserControl.Behaviors>
+    <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
+      <ShowNotificationAction NotificationManager="{Binding #Manager.NotificationManager}">
+        <ShowNotificationAction.Notification>
+          <not:Notification Title="Hello" Message="Custom notification" />
+        </ShowNotificationAction.Notification>
+      </ShowNotificationAction>
+    </EventTriggerBehavior>
+    <EventTriggerBehavior EventName="Click" SourceObject="CloseButton">
+      <CloseNotificationAction NotificationCard="{Binding ElementName=Card}" />
+    </EventTriggerBehavior>
+  </UserControl.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:not="clr-namespace:Avalonia.Controls.Notifications;assembly=Avalonia.Controls.Notifications"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
   <Design.DataContext>
@@ -15,19 +14,21 @@
       <NotificationManagerBehavior x:Name="Manager" />
     </Interaction.Behaviors>
     <Button x:Name="ShowButton" Content="Show Notification" Margin="5" />
-    <not:NotificationCard x:Name="Card" Title="Closable" Message="NotificationCard" IsOpen="True" Margin="5" />
+    <!-- TODO: -->
+    <!-- <NotificationCard x:Name="Card" Title="Closable" Message="NotificationCard" IsOpen="True" Margin="5" /> -->
     <Button x:Name="CloseButton" Content="Close Card" Margin="5" />
   </StackPanel>
-  <UserControl.Behaviors>
+  <Interaction.Behaviors>
     <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
       <ShowNotificationAction NotificationManager="{Binding #Manager.NotificationManager}">
         <ShowNotificationAction.Notification>
-          <not:Notification Title="Hello" Message="Custom notification" />
+          <Notification Title="Hello" Message="Custom notification" />
         </ShowNotificationAction.Notification>
       </ShowNotificationAction>
     </EventTriggerBehavior>
-    <EventTriggerBehavior EventName="Click" SourceObject="CloseButton">
-      <CloseNotificationAction NotificationCard="{Binding ElementName=Card}" />
-    </EventTriggerBehavior>
-  </UserControl.Behaviors>
+    <!-- TODO: -->
+    <!-- <EventTriggerBehavior EventName="Click" SourceObject="CloseButton"> -->
+    <!--   <CloseNotificationAction NotificationCard="{Binding ElementName=Card}" /> -->
+    <!-- </EventTriggerBehavior> -->
+  </Interaction.Behaviors>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ShowNotificationActionView : UserControl
+{
+    public ShowNotificationActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- showcase `FocusControlAction`
- demonstrate hiding and showing controls
- add examples for flyout, context menu, enable state, and notifications
- surface the new pages in MainView

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*