### PR TITLE
Add missing sample pages

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -259,6 +259,27 @@
       <TabItem Header="Screens">
         <pages:ScreenView />
       </TabItem>
+      <TabItem Header="BindPointerOverBehavior">
+        <pages:BindPointerOverBehaviorView />
+      </TabItem>
+      <TabItem Header="BindTagToVisualRootDataContextBehavior">
+        <pages:BindTagToVisualRootDataContextBehaviorView />
+      </TabItem>
+      <TabItem Header="BoundsObserverBehavior">
+        <pages:BoundsObserverBehaviorView />
+      </TabItem>
+      <TabItem Header="HideAttachedFlyoutBehavior">
+        <pages:HideAttachedFlyoutBehaviorView />
+      </TabItem>
+      <TabItem Header="HideOnKeyPressedBehavior">
+        <pages:HideOnKeyPressedBehaviorView />
+      </TabItem>
+      <TabItem Header="HideOnLostFocusBehavior">
+        <pages:HideOnLostFocusBehaviorView />
+      </TabItem>
+      <TabItem Header="SizeChangedTrigger">
+        <pages:SizeChangedTriggerView />
+      </TabItem>
     </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml
@@ -13,6 +13,6 @@
     <Interaction.Behaviors>
       <BindPointerOverBehavior x:Name="Behavior" />
     </Interaction.Behaviors>
-    <TextBlock Text="{Binding IsPointerOver, Source=Behavior}" />
+    <TextBlock Text="{Binding #Behavior.IsPointerOver}" />
   </Border>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.BindPointerOverBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Border x:Name="Target" Background="LightGray" Padding="20" HorizontalAlignment="Center">
+    <Interaction.Behaviors>
+      <BindPointerOverBehavior x:Name="Behavior" />
+    </Interaction.Behaviors>
+    <TextBlock Text="{Binding IsPointerOver, Source=Behavior}" />
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class BindPointerOverBehaviorView : UserControl
+{
+    public BindPointerOverBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml
@@ -12,12 +12,13 @@
   <StackPanel Spacing="5" HorizontalAlignment="Center">
     <Button x:Name="IncrementButton" Content="Increment Count" />
     <TextBlock Text="Count: {Binding Count}" />
-    <TextBlock DataContext="{Binding Items[0]}">
+    <TextBlock DataContext="{Binding Items[0]}" 
+               x:DataType="vm:MainWindowViewModel">
       <Interaction.Behaviors>
         <BindTagToVisualRootDataContextBehavior />
       </Interaction.Behaviors>
       <TextBlock.Text>
-        <Binding Path="Tag.Count" RelativeSource="{RelativeSource Self}" />
+        <Binding Path="Count" />
       </TextBlock.Text>
     </TextBlock>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml
@@ -11,7 +11,7 @@
   </Design.DataContext>
   <StackPanel Spacing="5" HorizontalAlignment="Center">
     <Button x:Name="IncrementButton" Content="Increment Count" />
-    <TextBlock Text="Count: {Binding Count}" />
+    <TextBlock Text="{Binding Count, StringFormat={}Count: {0}}" />
     <TextBlock DataContext="{Binding Items[0]}" 
                x:DataType="vm:MainWindowViewModel">
       <Interaction.Behaviors>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.BindTagToVisualRootDataContextBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="180">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5" HorizontalAlignment="Center">
+    <Button x:Name="IncrementButton" Content="Increment Count" />
+    <TextBlock Text="Count: {Binding Count}" />
+    <TextBlock DataContext="{Binding Items[0]}">
+      <Interaction.Behaviors>
+        <BindTagToVisualRootDataContextBehavior />
+      </Interaction.Behaviors>
+      <TextBlock.Text>
+        <Binding Path="Tag.Count" RelativeSource="{RelativeSource Self}" />
+      </TextBlock.Text>
+    </TextBlock>
+  </StackPanel>
+  <Interaction.Behaviors>
+    <EventTriggerBehavior EventName="Click" SourceObject="IncrementButton">
+      <CallMethodAction TargetObject="{Binding}" MethodName="IncrementCount" />
+    </EventTriggerBehavior>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class BindTagToVisualRootDataContextBehaviorView : UserControl
+{
+    public BindTagToVisualRootDataContextBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml
@@ -16,7 +16,7 @@
         <BoundsObserverBehavior x:Name="Observer" Bounds="{Binding #Target.Bounds}" />
       </Interaction.Behaviors>
     </Border>
-    <TextBlock Text="Width: {Binding Width, Source=Observer}" />
-    <TextBlock Text="Height: {Binding Height, Source=Observer}" />
+    <TextBlock Text="{Binding #Observer.Width, StringFormat={}Width: {0}}" />
+    <TextBlock Text="{Binding #Observer.Height, StringFormat={}Height: {0}}" />
   </StackPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.BoundsObserverBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="180">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="10" HorizontalAlignment="Center">
+    <Slider x:Name="WidthSlider" Minimum="50" Maximum="300" Value="150" Width="200"/>
+    <Border x:Name="Target" Background="LightBlue" Height="80" Width="{Binding Value, ElementName=WidthSlider}">
+      <Interaction.Behaviors>
+        <BoundsObserverBehavior x:Name="Observer" Bounds="{Binding #Target.Bounds}" />
+      </Interaction.Behaviors>
+    </Border>
+    <TextBlock Text="Width: {Binding Width, Source=Observer}" />
+    <TextBlock Text="Height: {Binding Height, Source=Observer}" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class BoundsObserverBehaviorView : UserControl
+{
+    public BoundsObserverBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/HideAttachedFlyoutBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideAttachedFlyoutBehaviorView.axaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.HideAttachedFlyoutBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="180">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <CheckBox x:Name="IsOpenCheckBox" Content="Keep Flyout Open" IsChecked="True"/>
+    <Button x:Name="OpenButton" Content="Open Flyout" />
+    <Button x:Name="Target" Content="Target" Margin="5">
+      <Button.Flyout>
+        <Flyout>
+          <TextBlock Margin="10" Text="Flyout content" />
+        </Flyout>
+      </Button.Flyout>
+      <Interaction.Behaviors>
+        <HideAttachedFlyoutBehavior IsFlyoutOpen="{Binding IsChecked, ElementName=IsOpenCheckBox}" />
+      </Interaction.Behaviors>
+    </Button>
+  </StackPanel>
+  <Interaction.Behaviors>
+    <EventTriggerBehavior EventName="Click" SourceObject="OpenButton">
+      <ShowFlyoutAction TargetControl="Target" Flyout="{Binding #Target.Flyout}" />
+    </EventTriggerBehavior>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/HideAttachedFlyoutBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideAttachedFlyoutBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class HideAttachedFlyoutBehaviorView : UserControl
+{
+    public HideAttachedFlyoutBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/HideOnKeyPressedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideOnKeyPressedBehaviorView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.HideOnKeyPressedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="180">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <TextBlock Text="Press Escape to hide the TextBox" />
+    <TextBox x:Name="Target" Text="Hide me" Width="200" />
+    <Button x:Name="ShowButton" Content="Show TextBox" />
+  </StackPanel>
+  <Interaction.Behaviors>
+    <HideOnKeyPressedBehavior TargetControl="Target" Key="Escape" />
+    <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
+      <ShowControlAction TargetControl="{Binding ElementName=Target}" />
+    </EventTriggerBehavior>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/HideOnKeyPressedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideOnKeyPressedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class HideOnKeyPressedBehaviorView : UserControl
+{
+    public HideOnKeyPressedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/HideOnLostFocusBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideOnLostFocusBehaviorView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.HideOnLostFocusBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="180">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <TextBlock Text="Click outside to hide the TextBox" />
+    <TextBox x:Name="Target" Text="Hide me" Width="200" />
+    <Button x:Name="ShowButton" Content="Show TextBox" />
+  </StackPanel>
+  <Interaction.Behaviors>
+    <HideOnLostFocusBehavior TargetControl="Target" />
+    <EventTriggerBehavior EventName="Click" SourceObject="ShowButton">
+      <ShowControlAction TargetControl="{Binding ElementName=Target}" />
+    </EventTriggerBehavior>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/HideOnLostFocusBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/HideOnLostFocusBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class HideOnLostFocusBehaviorView : UserControl
+{
+    public HideOnLostFocusBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml
@@ -18,6 +18,6 @@
         </SizeChangedTrigger>
       </Interaction.Behaviors>
     </Border>
-    <TextBlock Text="Size changed count: {Binding Count}" />
+    <TextBlock Text="{Binding Count, StringFormat={}Size changed count: {0}}" />
   </StackPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.SizeChangedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Slider x:Name="WidthSlider" Minimum="100" Maximum="300" Value="150" Width="200" />
+    <Border x:Name="Target" Background="LightGray" Height="80" Width="{Binding Value, ElementName=WidthSlider}">
+      <Interaction.Behaviors>
+        <SizeChangedTrigger>
+          <CallMethodAction TargetObject="{Binding}" MethodName="IncrementCount" />
+        </SizeChangedTrigger>
+      </Interaction.Behaviors>
+    </Border>
+    <TextBlock Text="Size changed count: {Binding Count}" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class SizeChangedTriggerView : UserControl
+{
+    public SizeChangedTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- create sample pages for BindPointerOverBehavior, BindTagToVisualRootDataContextBehavior and BoundsObserverBehavior
- add HideAttachedFlyoutBehavior, HideOnKeyPressedBehavior, HideOnLostFocusBehavior and SizeChangedTrigger samples
- link new sample pages from the MainView

## Testing
- `dotnet test --no-build` *(fails: command not found)*