### PR TITLE
Add missing sample pages

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -280,6 +280,21 @@
       <TabItem Header="SizeChangedTrigger">
         <pages:SizeChangedTriggerView />
       </TabItem>
+      <TabItem Header="FadeInBehavior">
+        <pages:FadeInBehaviorView />
+      </TabItem>
+      <TabItem Header="AnimateOnAttachedBehavior">
+        <pages:AnimateOnAttachedBehaviorView />
+      </TabItem>
+      <TabItem Header="ThemeVariantTrigger">
+        <pages:ThemeVariantTriggerView />
+      </TabItem>
+      <TabItem Header="ActualThemeVariantChangedTrigger">
+        <pages:ActualThemeVariantChangedTriggerView />
+      </TabItem>
+      <TabItem Header="ToggleIsExpandedOnDoubleTappedBehavior">
+        <pages:ToggleIsExpandedOnDoubleTappedBehaviorView />
+      </TabItem>
     </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ActualThemeVariantChangedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <ThemeVariantScope x:Name="Scope">
+    <Interaction.Behaviors>
+      <ThemeVariantBehavior ThemeVariant="{Binding #Selector.SelectedItem}" />
+    </Interaction.Behaviors>
+    <Interaction.Triggers>
+      <ActualThemeVariantChangedTrigger>
+        <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Theme Changed" />
+      </ActualThemeVariantChangedTrigger>
+    </Interaction.Triggers>
+    <StackPanel Spacing="5">
+      <ComboBox x:Name="Selector" SelectedIndex="0">
+        <ComboBox.Items>
+          <ThemeVariant>Default</ThemeVariant>
+          <ThemeVariant>Dark</ThemeVariant>
+          <ThemeVariant>Light</ThemeVariant>
+        </ComboBox.Items>
+      </ComboBox>
+      <TextBlock x:Name="MessageText" Text="{Binding #Scope.ActualThemeVariant}" />
+    </StackPanel>
+  </ThemeVariantScope>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml
@@ -12,12 +12,10 @@
   <ThemeVariantScope x:Name="Scope">
     <Interaction.Behaviors>
       <ThemeVariantBehavior ThemeVariant="{Binding #Selector.SelectedItem}" />
-    </Interaction.Behaviors>
-    <Interaction.Triggers>
       <ActualThemeVariantChangedTrigger>
         <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Theme Changed" />
       </ActualThemeVariantChangedTrigger>
-    </Interaction.Triggers>
+    </Interaction.Behaviors>
     <StackPanel Spacing="5">
       <ComboBox x:Name="Selector" SelectedIndex="0">
         <ComboBox.Items>

--- a/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ActualThemeVariantChangedTriggerView : UserControl
+{
+    public ActualThemeVariantChangedTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AnimateOnAttachedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Border Background="LightGreen" Width="100" Height="100">
+    <Interaction.Behaviors>
+      <AnimateOnAttachedBehavior>
+        <AnimateOnAttachedBehavior.Animation>
+          <Animation Duration="0:0:1">
+            <KeyFrame Cue="0%">
+              <Setter Property="Opacity" Value="0" />
+            </KeyFrame>
+            <KeyFrame Cue="100%">
+              <Setter Property="Opacity" Value="1" />
+            </KeyFrame>
+          </Animation>
+        </AnimateOnAttachedBehavior.Animation>
+      </AnimateOnAttachedBehavior>
+    </Interaction.Behaviors>
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml
@@ -12,16 +12,18 @@
   <Border Background="LightGreen" Width="100" Height="100">
     <Interaction.Behaviors>
       <AnimateOnAttachedBehavior>
+        <!-- TODO: Error AVLN2200 Avalonia: Could not determine target type of Setter
         <AnimateOnAttachedBehavior.Animation>
           <Animation Duration="0:0:1">
             <KeyFrame Cue="0%">
-              <Setter Property="Opacity" Value="0" />
+              <Setter Property="{x:Static Visual.OpacityProperty}" Value="0" />
             </KeyFrame>
             <KeyFrame Cue="100%">
-              <Setter Property="Opacity" Value="1" />
+              <Setter Property="{x:Static Visual.OpacityProperty}" Value="1" />
             </KeyFrame>
           </Animation>
         </AnimateOnAttachedBehavior.Animation>
+        -->
       </AnimateOnAttachedBehavior>
     </Interaction.Behaviors>
   </Border>

--- a/samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AnimateOnAttachedBehaviorView : UserControl
+{
+    public AnimateOnAttachedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/FadeInBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FadeInBehaviorView.axaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FadeInBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Border Background="SteelBlue" Width="100" Height="100">
+    <Interaction.Behaviors>
+      <FadeInBehavior Duration="0:0:1" InitialDelay="0:0:0.5" />
+    </Interaction.Behaviors>
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FadeInBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FadeInBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FadeInBehaviorView : UserControl
+{
+    public FadeInBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml
@@ -1,0 +1,38 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ThemeVariantTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <ThemeVariantScope x:Name="Scope">
+    <Interaction.Behaviors>
+      <ThemeVariantBehavior ThemeVariant="{Binding #VariantSelector.SelectedItem}" />
+    </Interaction.Behaviors>
+    <Border x:Name="TargetBorder" Width="120" Height="80" Background="Gray">
+      <Interaction.Triggers>
+        <ThemeVariantTrigger ThemeVariant="Dark">
+          <ChangeAvaloniaPropertyAction TargetObject="TargetBorder"
+                                        TargetProperty="{x:Static Border.BackgroundProperty}"
+                                        Value="Black" />
+        </ThemeVariantTrigger>
+        <ThemeVariantTrigger ThemeVariant="Light">
+          <ChangeAvaloniaPropertyAction TargetObject="TargetBorder"
+                                        TargetProperty="{x:Static Border.BackgroundProperty}"
+                                        Value="White" />
+        </ThemeVariantTrigger>
+      </Interaction.Triggers>
+    </Border>
+    <ComboBox x:Name="VariantSelector" SelectedIndex="0" Margin="0,10,0,0">
+      <ComboBox.Items>
+        <ThemeVariant>Default</ThemeVariant>
+        <ThemeVariant>Dark</ThemeVariant>
+        <ThemeVariant>Light</ThemeVariant>
+      </ComboBox.Items>
+    </ComboBox>
+  </ThemeVariantScope>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml
@@ -13,26 +13,28 @@
     <Interaction.Behaviors>
       <ThemeVariantBehavior ThemeVariant="{Binding #VariantSelector.SelectedItem}" />
     </Interaction.Behaviors>
-    <Border x:Name="TargetBorder" Width="120" Height="80" Background="Gray">
-      <Interaction.Triggers>
-        <ThemeVariantTrigger ThemeVariant="Dark">
-          <ChangeAvaloniaPropertyAction TargetObject="TargetBorder"
-                                        TargetProperty="{x:Static Border.BackgroundProperty}"
-                                        Value="Black" />
-        </ThemeVariantTrigger>
-        <ThemeVariantTrigger ThemeVariant="Light">
-          <ChangeAvaloniaPropertyAction TargetObject="TargetBorder"
-                                        TargetProperty="{x:Static Border.BackgroundProperty}"
-                                        Value="White" />
-        </ThemeVariantTrigger>
-      </Interaction.Triggers>
-    </Border>
-    <ComboBox x:Name="VariantSelector" SelectedIndex="0" Margin="0,10,0,0">
-      <ComboBox.Items>
-        <ThemeVariant>Default</ThemeVariant>
-        <ThemeVariant>Dark</ThemeVariant>
-        <ThemeVariant>Light</ThemeVariant>
-      </ComboBox.Items>
-    </ComboBox>
+    <StackPanel Spacing="">
+      <Border x:Name="TargetBorder" Width="120" Height="80" Background="Gray">
+        <Interaction.Behaviors>
+          <ThemeVariantTrigger ThemeVariant="Dark">
+            <ChangeAvaloniaPropertyAction TargetObject="TargetBorder"
+                                          TargetProperty="{x:Static Border.BackgroundProperty}"
+                                          Value="Black" />
+          </ThemeVariantTrigger>
+          <ThemeVariantTrigger ThemeVariant="Light">
+            <ChangeAvaloniaPropertyAction TargetObject="TargetBorder"
+                                          TargetProperty="{x:Static Border.BackgroundProperty}"
+                                          Value="White" />
+          </ThemeVariantTrigger>
+        </Interaction.Behaviors>
+      </Border>
+      <ComboBox x:Name="VariantSelector" SelectedIndex="0" Margin="0,10,0,0">
+        <ComboBox.Items>
+          <ThemeVariant>Default</ThemeVariant>
+          <ThemeVariant>Dark</ThemeVariant>
+          <ThemeVariant>Light</ThemeVariant>
+        </ComboBox.Items>
+      </ComboBox>
+    </StackPanel>
   </ThemeVariantScope>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ThemeVariantTriggerView : UserControl
+{
+    public ThemeVariantTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ToggleIsExpandedOnDoubleTappedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ToggleIsExpandedOnDoubleTappedBehaviorView.axaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ToggleIsExpandedOnDoubleTappedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="250">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <TreeView>
+    <TreeView.Styles>
+      <Style Selector="TreeViewItem">
+        <Setter Property="(Interaction.Behaviors)">
+          <BehaviorCollectionTemplate>
+            <BehaviorCollection>
+              <ToggleIsExpandedOnDoubleTappedBehavior />
+            </BehaviorCollection>
+          </BehaviorCollectionTemplate>
+        </Setter>
+      </Style>
+    </TreeView.Styles>
+    <TreeViewItem Header="Root">
+      <TreeViewItem Header="Child 1" />
+      <TreeViewItem Header="Child 2" />
+    </TreeViewItem>
+    <TreeViewItem Header="Root 2">
+      <TreeViewItem Header="Child A" />
+      <TreeViewItem Header="Child B" />
+    </TreeViewItem>
+  </TreeView>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ToggleIsExpandedOnDoubleTappedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ToggleIsExpandedOnDoubleTappedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ToggleIsExpandedOnDoubleTappedBehaviorView : UserControl
+{
+    public ToggleIsExpandedOnDoubleTappedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add sample pages for a few components that did not have one: `FadeInBehavior`,
  `AnimateOnAttachedBehavior`, `ThemeVariantTrigger`, `ActualThemeVariantChangedTrigger`
  and `ToggleIsExpandedOnDoubleTappedBehavior`
- update `MainView` to include the new samples

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*