### PR TITLE
Add ExecuteCommand behaviors sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/ExecuteCommandBehaviorsViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/ExecuteCommandBehaviorsViewModel.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Windows.Input;
+using ReactiveUI;
+
+namespace BehaviorsTestApplication.ViewModels;
+
+public partial class ExecuteCommandBehaviorsViewModel : ViewModelBase
+{
+    public ExecuteCommandBehaviorsViewModel()
+    {
+        PointerEnteredCommand = ReactiveCommand.Create(() => Console.WriteLine("PointerEntered"));
+        PointerPressedCommand = ReactiveCommand.Create(() => Console.WriteLine("PointerPressed"));
+        DoubleTappedCommand = ReactiveCommand.Create(() => Console.WriteLine("DoubleTapped"));
+        KeyDownCommand = ReactiveCommand.Create(() => Console.WriteLine("KeyDown"));
+    }
+
+    public ICommand PointerEnteredCommand { get; }
+    public ICommand PointerPressedCommand { get; }
+    public ICommand DoubleTappedCommand { get; }
+    public ICommand KeyDownCommand { get; }
+}

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -15,11 +15,6 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public MainWindowViewModel()
     {
-        PointerTriggersViewModel = new PointerTriggersViewModel();
-        KeyGestureTriggerViewModel = new KeyGestureTriggerViewModel();
-        CustomAnimatorViewModel = new CustomAnimatorViewModel();
-        ExecuteCommandBehaviorsViewModel = new ExecuteCommandBehaviorsViewModel();
-        
         Count = 0;
         Position = 100.0;
 
@@ -100,18 +95,6 @@ public partial class MainWindowViewModel : ViewModelBase
         Greeting = "Entered text will appear here";
         TextChangedCommand = ReactiveCommand.Create<TextChangedEventArgs>(OnTextChanged);
     }
-
-    [Reactive]
-    public partial PointerTriggersViewModel PointerTriggersViewModel { get; set; }
-
-    [Reactive]
-    public partial KeyGestureTriggerViewModel KeyGestureTriggerViewModel { get; set; }
-
-    [Reactive]
-    public partial CustomAnimatorViewModel CustomAnimatorViewModel { get; set; }
-
-    [Reactive]
-    public partial ExecuteCommandBehaviorsViewModel ExecuteCommandBehaviorsViewModel { get; set; }
 
     [Reactive]
     public partial int Count { get; set; }

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,7 @@ public partial class MainWindowViewModel : ViewModelBase
         PointerTriggersViewModel = new PointerTriggersViewModel();
         KeyGestureTriggerViewModel = new KeyGestureTriggerViewModel();
         CustomAnimatorViewModel = new CustomAnimatorViewModel();
+        ExecuteCommandBehaviorsViewModel = new ExecuteCommandBehaviorsViewModel();
         
         Count = 0;
         Position = 100.0;
@@ -108,6 +109,9 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [Reactive]
     public partial CustomAnimatorViewModel CustomAnimatorViewModel { get; set; }
+
+    [Reactive]
+    public partial ExecuteCommandBehaviorsViewModel ExecuteCommandBehaviorsViewModel { get; set; }
 
     [Reactive]
     public partial int Count { get; set; }

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -143,13 +143,13 @@
         <pages:OneTimeBinding />
       </TabItem>
       <TabItem Header="Pointer Triggers">
-        <pages:PointerTriggersView DataContext="{Binding PointerTriggersViewModel}" />
+        <pages:PointerTriggersView />
       </TabItem>
       <TabItem Header="KeyGestureTrigger">
-        <pages:KeyGestureTriggerView DataContext="{Binding KeyGestureTriggerViewModel}" />
+        <pages:KeyGestureTriggerView />
       </TabItem>
       <TabItem Header="ExecuteCommand Behaviors">
-        <pages:ExecuteCommandBehaviorsView DataContext="{Binding ExecuteCommandBehaviorsViewModel}" />
+        <pages:ExecuteCommandBehaviorsView />
       </TabItem>
       <TabItem Header="Storage Provider">
         <pages:StorageProviderView />

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -148,6 +148,9 @@
       <TabItem Header="KeyGestureTrigger">
         <pages:KeyGestureTriggerView DataContext="{Binding KeyGestureTriggerViewModel}" />
       </TabItem>
+      <TabItem Header="ExecuteCommand Behaviors">
+        <pages:ExecuteCommandBehaviorsView DataContext="{Binding ExecuteCommandBehaviorsViewModel}" />
+      </TabItem>
       <TabItem Header="Storage Provider">
         <pages:StorageProviderView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ExecuteCommandBehaviorsView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:ExecuteCommandBehaviorsViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300">
+  <Design.DataContext>
+    <vm:ExecuteCommandBehaviorsViewModel />
+  </Design.DataContext>
+
+  <StackPanel Spacing="10">
+    <Border Background="LightGray" Padding="20" Focusable="True">
+      <TextBlock Text="Interact with me" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+      <Interaction.Behaviors>
+        <ExecuteCommandOnPointerEnteredBehavior Command="{Binding PointerEnteredCommand}" />
+        <ExecuteCommandOnPointerPressedBehavior Command="{Binding PointerPressedCommand}" />
+        <ExecuteCommandOnDoubleTappedBehavior Command="{Binding DoubleTappedCommand}" />
+      </Interaction.Behaviors>
+    </Border>
+    <TextBox Width="200" Watermark="Press Enter" Focusable="True">
+      <Interaction.Behaviors>
+        <ExecuteCommandOnKeyDownBehavior Command="{Binding KeyDownCommand}" Key="Enter" />
+      </Interaction.Behaviors>
+    </TextBox>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using BehaviorsTestApplication.ViewModels;
 
 namespace BehaviorsTestApplication.Views.Pages;
 
@@ -8,6 +9,7 @@ public partial class ExecuteCommandBehaviorsView : UserControl
     public ExecuteCommandBehaviorsView()
     {
         InitializeComponent();
+        DataContext = new ExecuteCommandBehaviorsViewModel();
     }
 
     private void InitializeComponent()

--- a/samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ExecuteCommandBehaviorsView : UserControl
+{
+    public ExecuteCommandBehaviorsView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using BehaviorsTestApplication.ViewModels;
 
 namespace BehaviorsTestApplication.Views.Pages;
 
@@ -8,6 +9,7 @@ public partial class KeyGestureTriggerView : UserControl
     public KeyGestureTriggerView()
     {
         InitializeComponent();
+        DataContext = new KeyGestureTriggerViewModel();
     }
 
     private void InitializeComponent()

--- a/samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using BehaviorsTestApplication.ViewModels;
 
 namespace BehaviorsTestApplication.Views.Pages;
 
@@ -8,6 +9,7 @@ public partial class PointerTriggersView : UserControl
     public PointerTriggersView()
     {
         InitializeComponent();
+        DataContext = new PointerTriggersViewModel();
     }
 
     private void InitializeComponent()


### PR DESCRIPTION
## Summary
- add ExecuteCommandBehaviorsViewModel with event-command helpers
- create ExecuteCommandBehaviorsView page
- expose ExecuteCommandBehaviorsViewModel from main view model
- link the new sample page in MainView

## Testing
- `dotnet build` *(fails: `dotnet` not found)*
- `dotnet test -c Release -nologo` *(fails: `dotnet` not found)*