### PR TITLE
Add AutoSelectBehavior for Avalonia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,10 +1080,12 @@ This section provides an overview of all available classes and their purpose in 
   *Subscribes to an `IObservable` and executes actions whenever the observable emits a value.*
 
 ### TextBox
-- **TextBoxSelectAllOnGotFocusBehavior**  
+- **AutoSelectBehavior**
+  *Selects all text in a TextBox when it is loaded.*
+- **TextBoxSelectAllOnGotFocusBehavior**
   *Selects all text in a TextBox when it gains focus.*
 
-- **TextBoxSelectAllTextBehavior**  
+- **TextBoxSelectAllTextBehavior**
   *Selects all text in a TextBox immediately upon attachment.*
 
 ### TreeViewItem

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -64,6 +64,9 @@
       <TabItem Header="AutoFocusBehavior">
         <pages:AutoFocusBehaviorView />
       </TabItem>
+      <TabItem Header="AutoSelectBehavior">
+        <pages:AutoSelectBehaviorView />
+      </TabItem>
       <TabItem Header="FocusControlBehavior">
         <pages:FocusControlBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/AutoSelectBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AutoSelectBehaviorView.axaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AutoSelectBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <TextBox Text="Auto select" Width="200">
+    <Interaction.Behaviors>
+      <AutoSelectBehavior />
+    </Interaction.Behaviors>
+  </TextBox>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AutoSelectBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AutoSelectBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AutoSelectBehaviorView : UserControl
+{
+    public AutoSelectBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/TextBox/AutoSelectBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/TextBox/AutoSelectBehavior.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Automatically selects the entire content of the associated <see cref="TextBox"/> when it is loaded.
+/// </summary>
+public sealed class AutoSelectBehavior : StyledElementBehavior<TextBox>
+{
+    /// <inheritdoc/>
+    protected override void OnLoaded()
+    {
+        base.OnLoaded();
+
+        Dispatcher.UIThread.Post(() => AssociatedObject?.SelectAll());
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/TextBox/AutoSelectBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/TextBox/AutoSelectBehavior.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 


### PR DESCRIPTION
## Summary
- implement `AutoSelectBehavior` for Avalonia
- add sample page to demonstrate the behavior
- wire the page into the sample app navigation
- document new behavior in the README

## Testing
- `dotnet test --no-restore` *(fails: command not found)*