### PR TITLE
Add RemoveItemInItemsControlAction sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,8 +937,11 @@ This section provides an overview of all available classes and their purpose in 
 - **ScrollToItemBehavior**
   *Automatically scrolls the ItemsControl to make a specified item visible.*
 
-- **ScrollToItemIndexBehavior**  
+- **ScrollToItemIndexBehavior**
   *Scrolls to a specific item index in the ItemsControl.*
+
+- **RemoveItemInItemsControlAction**
+  *Removes the specified item from an ItemsControl.*
 
 ### ListBox
 - **ListBoxSelectAllBehavior**

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -112,6 +112,9 @@
       <TabItem Header="RemoveItemInListBoxAction">
         <pages:RemoveItemInListBoxActionView />
       </TabItem>
+      <TabItem Header="RemoveItemInItemsControlAction">
+        <pages:RemoveItemInItemsControlActionView />
+      </TabItem>
       <TabItem Header="Remove Items Sample">
         <pages:RemoveItemsSampleView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInItemsControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInItemsControlActionView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.RemoveItemInItemsControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <ItemsControl ItemsSource="{Binding Items}" Margin="5">
+    <ItemsControl.ItemTemplate>
+      <DataTemplate DataType="vm:ItemViewModel">
+        <StackPanel Orientation="Horizontal" Spacing="10">
+          <TextBlock Text="{Binding Value}" VerticalAlignment="Center" />
+          <Button Content="Remove">
+            <Interaction.Behaviors>
+              <EventTriggerBehavior EventName="Click">
+                <RemoveItemInItemsControlAction />
+              </EventTriggerBehavior>
+            </Interaction.Behaviors>
+          </Button>
+        </StackPanel>
+      </DataTemplate>
+    </ItemsControl.ItemTemplate>
+  </ItemsControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInItemsControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoveItemInItemsControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class RemoveItemInItemsControlActionView : UserControl
+{
+    public RemoveItemInItemsControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add RemoveItemInItemsControlAction sample page
- link the new sample in `MainView.axaml`
- document RemoveItemInItemsControlAction in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*