### PR TITLE
Add sample pages for ItemsControl actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,15 @@ This section provides an overview of all available classes and their purpose in 
 - **ScrollToItemIndexBehavior**
   *Scrolls to a specific item index in the ItemsControl.*
 
+- **AddItemToItemsControlAction**
+  *Adds an item to an ItemsControl's collection.*
+
+- **InsertItemToItemsControlAction**
+  *Inserts an item at a specific index in an ItemsControl.*
+
+- **ClearItemsControlAction**
+  *Clears all items from an ItemsControl.*
+
 - **RemoveItemInItemsControlAction**
   *Removes the specified item from an ItemsControl.*
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -115,6 +115,15 @@
       <TabItem Header="RemoveItemInItemsControlAction">
         <pages:RemoveItemInItemsControlActionView />
       </TabItem>
+      <TabItem Header="AddItemToItemsControlAction">
+        <pages:AddItemToItemsControlActionView />
+      </TabItem>
+      <TabItem Header="InsertItemToItemsControlAction">
+        <pages:InsertItemToItemsControlActionView />
+      </TabItem>
+      <TabItem Header="ClearItemsControlAction">
+        <pages:ClearItemsControlActionView />
+      </TabItem>
       <TabItem Header="Remove Items Sample">
         <pages:RemoveItemsSampleView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/AddItemToItemsControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AddItemToItemsControlActionView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AddItemToItemsControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="10" Margin="5">
+    <Button Content="Add Item">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click">
+          <AddItemToItemsControlAction>
+            <AddItemToItemsControlAction.Item>
+              <vm:ItemViewModel Value="Added Item" />
+            </AddItemToItemsControlAction.Item>
+          </AddItemToItemsControlAction>
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <ItemsControl ItemsSource="{Binding Items}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="vm:ItemViewModel">
+          <TextBlock Text="{Binding Value}" />
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AddItemToItemsControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AddItemToItemsControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AddItemToItemsControlActionView : UserControl
+{
+    public AddItemToItemsControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ClearItemsControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClearItemsControlActionView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ClearItemsControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="10" Margin="5">
+    <Button Content="Clear Items">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click">
+          <ClearItemsControlAction />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <ItemsControl ItemsSource="{Binding Items}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="vm:ItemViewModel">
+          <TextBlock Text="{Binding Value}" />
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ClearItemsControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClearItemsControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ClearItemsControlActionView : UserControl
+{
+    public ClearItemsControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/InsertItemToItemsControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/InsertItemToItemsControlActionView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.InsertItemToItemsControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="10" Margin="5">
+    <Button Content="Insert Item At 0">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click">
+          <InsertItemToItemsControlAction Index="0">
+            <InsertItemToItemsControlAction.Item>
+              <vm:ItemViewModel Value="Inserted Item" />
+            </InsertItemToItemsControlAction.Item>
+          </InsertItemToItemsControlAction>
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <ItemsControl ItemsSource="{Binding Items}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="vm:ItemViewModel">
+          <TextBlock Text="{Binding Value}" />
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/InsertItemToItemsControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/InsertItemToItemsControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class InsertItemToItemsControlActionView : UserControl
+{
+    public InsertItemToItemsControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add AddItemToItemsControlActionView sample
- add InsertItemToItemsControlActionView sample
- add ClearItemsControlActionView sample
- hook up new samples in the MainView tabs
- document new actions in README

## Testing
- `dotnet test --no-build --configuration Release` *(fails: `dotnet` not found)*