### PR TITLE
Add event triggers sample pages

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -337,6 +337,18 @@
       <TabItem Header="Events Behaviors">
         <pages:EventsBehaviorsView />
       </TabItem>
+      <TabItem Header="Focus Event Triggers">
+        <pages:FocusEventTriggersView />
+      </TabItem>
+      <TabItem Header="Key Event Triggers">
+        <pages:KeyEventTriggersView />
+      </TabItem>
+      <TabItem Header="Pointer Event Triggers">
+        <pages:PointerEventTriggersView />
+      </TabItem>
+      <TabItem Header="Gesture Event Triggers">
+        <pages:GestureEventTriggersView />
+      </TabItem>
     </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/EventsBehaviorsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EventsBehaviorsView.axaml
@@ -3,18 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
   <StackPanel Margin="5">
     <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
     <Border Width="200" Height="100" Background="LightGray" Margin="5">
       <Interaction.Behaviors>
-        <events:PointerPressedEventBehavior>
-          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pressed Behavior" />
-        </events:PointerPressedEventBehavior>
-        <events:PointerPressedEventTrigger>
+        <PointerPressedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pressed Trigger" />
-        </events:PointerPressedEventTrigger>
+        </PointerPressedEventTrigger>
       </Interaction.Behaviors>
     </Border>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml
@@ -3,18 +3,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
   <StackPanel Margin="5">
     <TextBlock x:Name="InfoText" Text="Focus the TextBox" Margin="5" />
     <TextBox Width="200" Margin="5">
       <Interaction.Behaviors>
-        <events:GotFocusEventTrigger>
+        <GotFocusEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Got Focus" />
-        </events:GotFocusEventTrigger>
-        <events:LostFocusEventTrigger>
+        </GotFocusEventTrigger>
+        <LostFocusEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Lost Focus" />
-        </events:LostFocusEventTrigger>
+        </LostFocusEventTrigger>
       </Interaction.Behaviors>
     </TextBox>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FocusEventTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Focus the TextBox" Margin="5" />
+    <TextBox Width="200" Margin="5">
+      <Interaction.Behaviors>
+        <events:GotFocusEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Got Focus" />
+        </events:GotFocusEventTrigger>
+        <events:LostFocusEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Lost Focus" />
+        </events:LostFocusEventTrigger>
+      </Interaction.Behaviors>
+    </TextBox>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FocusEventTriggersView : UserControl
+{
+    public FocusEventTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml
@@ -3,27 +3,26 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
   <StackPanel Margin="5">
     <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
     <Border Width="200" Height="100" Background="LightGray" Margin="5">
       <Interaction.Behaviors>
-        <events:TappedEventTrigger>
+        <TappedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Tapped" />
-        </events:TappedEventTrigger>
-        <events:DoubleTappedEventTrigger>
+        </TappedEventTrigger>
+        <DoubleTappedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Double Tapped" />
-        </events:DoubleTappedEventTrigger>
-        <events:RightTappedEventTrigger>
+        </DoubleTappedEventTrigger>
+        <RightTappedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Right Tapped" />
-        </events:RightTappedEventTrigger>
-        <events:ScrollGestureEventTrigger>
+        </RightTappedEventTrigger>
+        <ScrollGestureEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Scroll Gesture" />
-        </events:ScrollGestureEventTrigger>
-        <events:ScrollGestureEndedEventTrigger>
+        </ScrollGestureEventTrigger>
+        <ScrollGestureEndedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Scroll Gesture Ended" />
-        </events:ScrollGestureEndedEventTrigger>
+        </ScrollGestureEndedEventTrigger>
       </Interaction.Behaviors>
     </Border>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml
@@ -1,0 +1,30 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.GestureEventTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
+    <Border Width="200" Height="100" Background="LightGray" Margin="5">
+      <Interaction.Behaviors>
+        <events:TappedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Tapped" />
+        </events:TappedEventTrigger>
+        <events:DoubleTappedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Double Tapped" />
+        </events:DoubleTappedEventTrigger>
+        <events:RightTappedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Right Tapped" />
+        </events:RightTappedEventTrigger>
+        <events:ScrollGestureEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Scroll Gesture" />
+        </events:ScrollGestureEventTrigger>
+        <events:ScrollGestureEndedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Scroll Gesture Ended" />
+        </events:ScrollGestureEndedEventTrigger>
+      </Interaction.Behaviors>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class GestureEventTriggersView : UserControl
+{
+    public GestureEventTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml
@@ -3,24 +3,23 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
   <StackPanel Margin="5">
     <TextBlock x:Name="InfoText" Text="Press keys" Margin="5" />
     <TextBox Width="200" Margin="5">
       <Interaction.Behaviors>
-        <events:KeyDownEventTrigger>
+        <KeyDownEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Key Down" />
-        </events:KeyDownEventTrigger>
-        <events:KeyUpEventTrigger>
+        </KeyDownEventTrigger>
+        <KeyUpEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Key Up" />
-        </events:KeyUpEventTrigger>
-        <events:TextInputEventTrigger>
+        </KeyUpEventTrigger>
+        <TextInputEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Text Input" />
-        </events:TextInputEventTrigger>
-        <events:TextInputMethodClientRequestedEventTrigger>
+        </TextInputEventTrigger>
+        <TextInputMethodClientRequestedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Input Method Requested" />
-        </events:TextInputMethodClientRequestedEventTrigger>
+        </TextInputMethodClientRequestedEventTrigger>
       </Interaction.Behaviors>
     </TextBox>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.KeyEventTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Press keys" Margin="5" />
+    <TextBox Width="200" Margin="5">
+      <Interaction.Behaviors>
+        <events:KeyDownEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Key Down" />
+        </events:KeyDownEventTrigger>
+        <events:KeyUpEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Key Up" />
+        </events:KeyUpEventTrigger>
+        <events:TextInputEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Text Input" />
+        </events:TextInputEventTrigger>
+        <events:TextInputMethodClientRequestedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Input Method Requested" />
+        </events:TextInputMethodClientRequestedEventTrigger>
+      </Interaction.Behaviors>
+    </TextBox>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class KeyEventTriggersView : UserControl
+{
+    public KeyEventTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml
@@ -1,0 +1,36 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.PointerEventTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
+    <Border Width="200" Height="100" Background="LightGray" Margin="5">
+      <Interaction.Behaviors>
+        <events:PointerEnteredEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Entered" />
+        </events:PointerEnteredEventTrigger>
+        <events:PointerExitedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Exited" />
+        </events:PointerExitedEventTrigger>
+        <events:PointerPressedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Pressed" />
+        </events:PointerPressedEventTrigger>
+        <events:PointerReleasedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Released" />
+        </events:PointerReleasedEventTrigger>
+        <events:PointerMovedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Moved" />
+        </events:PointerMovedEventTrigger>
+        <events:PointerWheelChangedEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Wheel Changed" />
+        </events:PointerWheelChangedEventTrigger>
+        <events:PointerCaptureLostEventTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Capture Lost" />
+        </events:PointerCaptureLostEventTrigger>
+      </Interaction.Behaviors>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml
@@ -3,33 +3,32 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:events="clr-namespace:Avalonia.Xaml.Interactions.Events"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
   <StackPanel Margin="5">
     <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
     <Border Width="200" Height="100" Background="LightGray" Margin="5">
       <Interaction.Behaviors>
-        <events:PointerEnteredEventTrigger>
+        <PointerEnteredEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Entered" />
-        </events:PointerEnteredEventTrigger>
-        <events:PointerExitedEventTrigger>
+        </PointerEnteredEventTrigger>
+        <PointerExitedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Exited" />
-        </events:PointerExitedEventTrigger>
-        <events:PointerPressedEventTrigger>
+        </PointerExitedEventTrigger>
+        <PointerPressedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Pressed" />
-        </events:PointerPressedEventTrigger>
-        <events:PointerReleasedEventTrigger>
+        </PointerPressedEventTrigger>
+        <PointerReleasedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Released" />
-        </events:PointerReleasedEventTrigger>
-        <events:PointerMovedEventTrigger>
+        </PointerReleasedEventTrigger>
+        <PointerMovedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Moved" />
-        </events:PointerMovedEventTrigger>
-        <events:PointerWheelChangedEventTrigger>
+        </PointerMovedEventTrigger>
+        <PointerWheelChangedEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Wheel Changed" />
-        </events:PointerWheelChangedEventTrigger>
-        <events:PointerCaptureLostEventTrigger>
+        </PointerWheelChangedEventTrigger>
+        <PointerCaptureLostEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Capture Lost" />
-        </events:PointerCaptureLostEventTrigger>
+        </PointerCaptureLostEventTrigger>
       </Interaction.Behaviors>
     </Border>
   </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class PointerEventTriggersView : UserControl
+{
+    public PointerEventTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Events/LostFocusEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Events/LostFocusEventTrigger.cs
@@ -1,4 +1,5 @@
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Events;
 


### PR DESCRIPTION
## Summary
- demo how to use each new event trigger
- show focus, key, pointer and gesture event triggers
- hook up pages from MainView

## Testing
- `dotnet --version` *(fails: command not found)*