### PR TITLE
Add ActionCollectionTemplate unit tests

### DIFF
--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/ActionCollectionTemplate001.axaml
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/ActionCollectionTemplate001.axaml
@@ -1,0 +1,40 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:generic="clr-namespace:System.Collections.Generic;assembly=System.Collections"
+        xmlns:system="clr-namespace:System;assembly=System.Runtime"
+        x:Class="Avalonia.Xaml.Interactivity.UnitTests.ActionCollectionTemplate001"
+        Title="ActionCollectionTemplate001">
+  <Window.Resources>
+    <SolidColorBrush x:Key="RedBrush" Color="Red" />
+  </Window.Resources>
+  <Window.Styles>
+    <Style Selector="ListBox.red > ListBoxItem">
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <EventTriggerBehavior EventName="KeyDown">
+              <EventTriggerBehavior.Actions>
+                <ActionCollectionTemplate>
+                  <ActionCollection>
+                    <ChangePropertyAction PropertyName="Background"
+                                          Value="{StaticResource RedBrush}" />
+                  </ActionCollection>
+                </ActionCollectionTemplate>
+              </EventTriggerBehavior.Actions>
+            </EventTriggerBehavior>
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+  </Window.Styles>
+  <ListBox Name="TargetListBox"
+           Classes="red">
+    <ListBox.ItemsSource>
+      <generic:List x:TypeArguments="x:String">
+        <system:String>Item1</system:String>
+        <system:String>Item2</system:String>
+        <system:String>Item3</system:String>
+      </generic:List>
+    </ListBox.ItemsSource>
+  </ListBox>
+</Window>

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/ActionCollectionTemplate001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/ActionCollectionTemplate001.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public partial class ActionCollectionTemplate001 : Window
+{
+    public ActionCollectionTemplate001()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/ActionCollectionTemplateTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/ActionCollectionTemplateTests.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Xaml.Interactions.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class ActionCollectionTemplateTests
+{
+    [AvaloniaFact]
+    public void ActionCollectionTemplate_001()
+    {
+        var window = new ActionCollectionTemplate001();
+
+        window.Show();
+
+        var containers = window.TargetListBox.GetRealizedContainers().Cast<ListBoxItem>().ToList();
+
+        foreach (var container in containers)
+        {
+            var behaviors = container.GetValue(Interaction.BehaviorsProperty);
+            Assert.NotNull(behaviors);
+            Assert.Single(behaviors);
+            var trigger = Assert.IsType<EventTriggerBehavior>(behaviors![0]);
+            var actions = trigger.Actions;
+            Assert.NotNull(actions);
+            Assert.Single(actions!);
+            Assert.IsType<ChangePropertyAction>(actions![0]);
+        }
+
+        Assert.Equal(containers[0].Background, Brushes.Transparent);
+        Assert.Equal(containers[1].Background, Brushes.Transparent);
+        Assert.Equal(containers[2].Background, Brushes.Transparent);
+
+        containers[0].Focus();
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Assert.Equal(window.Resources["RedBrush"], containers[0].Background);
+
+        containers[1].Focus();
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Assert.Equal(window.Resources["RedBrush"], containers[1].Background);
+
+        containers[2].Focus();
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Assert.Equal(window.Resources["RedBrush"], containers[2].Background);
+    }
+}


### PR DESCRIPTION
## Summary
- add test page for `ActionCollectionTemplate`
- add test verifying actions generated from the template are executed

## Testing
- `dotnet test` *(fails: `dotnet` not found)*