### PR TITLE
Add double-tap inline edit samples

### DIFF
--- a/samples/BehaviorsTestApplication/Controls/EditableItem.axaml
+++ b/samples/BehaviorsTestApplication/Controls/EditableItem.axaml
@@ -7,7 +7,9 @@
              Name="EditableItemUserControl">
   <Panel Background="Transparent">
     <Interaction.Behaviors>
-      <InlineEditBehavior EditControl="TextBoxEdit" DisplayControl="TextStackPanel" />
+      <InlineEditBehavior EditControl="TextBoxEdit"
+                          DisplayControl="TextStackPanel"
+                          EditOnAssociatedObjectDoubleTapped="True" />
     </Interaction.Behaviors>
     <TextBox x:Name="TextBoxEdit"
              IsVisible="False"

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -145,8 +145,14 @@
       <TabItem Header="EditableDraggableListBox">
         <pages:EditableDraggableListBoxView />
       </TabItem>
+      <TabItem Header="EditableListBox DoubleTap">
+        <pages:EditableDoubleTappedListBoxView />
+      </TabItem>
       <TabItem Header="EditableTree">
         <pages:EditableTreeViewView />
+      </TabItem>
+      <TabItem Header="EditableTree DoubleTap">
+        <pages:EditableDoubleTappedTreeViewView />
       </TabItem>
       <TabItem Header="Editable Drag TreeView">
         <pages:EditableDragTreeViewView />

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedListBoxView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedListBoxView.axaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.EditableDoubleTappedListBoxView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:controls="clr-namespace:BehaviorsTestApplication.Controls"
+             x:CompileBindings="True" x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <ListBox ItemsSource="{Binding Items}">
+    <ListBox.Styles>
+      <Style Selector="ListBoxItem">
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Padding" Value="0" />
+      </Style>
+    </ListBox.Styles>
+    <ListBox.ItemTemplate>
+      <DataTemplate DataType="vm:ItemViewModel">
+        <controls:EditableItem Text="{Binding Value}" />
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedListBoxView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedListBoxView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class EditableDoubleTappedListBoxView : UserControl
+{
+    public EditableDoubleTappedListBoxView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedTreeViewView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedTreeViewView.axaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.EditableDoubleTappedTreeViewView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:controls="clr-namespace:BehaviorsTestApplication.Controls"
+             x:CompileBindings="True" x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <TreeView ItemsSource="{Binding Items}">
+    <TreeView.Styles>
+      <Style Selector="TreeViewItem">
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Padding" Value="0" />
+      </Style>
+    </TreeView.Styles>
+    <TreeView.ItemTemplate>
+      <TreeDataTemplate DataType="vm:ItemViewModel" ItemsSource="{Binding Items}">
+        <controls:EditableItem Text="{Binding Value}" />
+      </TreeDataTemplate>
+    </TreeView.ItemTemplate>
+  </TreeView>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedTreeViewView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDoubleTappedTreeViewView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class EditableDoubleTappedTreeViewView : UserControl
+{
+    public EditableDoubleTappedTreeViewView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Control/InlineEditBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Control/InlineEditBehavior.cs
@@ -43,6 +43,12 @@ public class InlineEditBehavior : StyledElementBehavior<Control>
         AvaloniaProperty.Register<InlineEditBehavior, Key>(nameof(CancelKey), Key.Escape);
 
     /// <summary>
+    /// Identifies the <see cref="EditOnAssociatedObjectDoubleTapped"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> EditOnAssociatedObjectDoubleTappedProperty =
+        AvaloniaProperty.Register<InlineEditBehavior, bool>(nameof(EditOnAssociatedObjectDoubleTapped), false);
+
+    /// <summary>
     /// Editing control to show when editing begins.
     /// </summary>
     [ResolveByName]
@@ -89,6 +95,15 @@ public class InlineEditBehavior : StyledElementBehavior<Control>
         set => SetValue(CancelKeyProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether double tapping the associated object starts editing.
+    /// </summary>
+    public bool EditOnAssociatedObjectDoubleTapped
+    {
+        get => GetValue(EditOnAssociatedObjectDoubleTappedProperty);
+        set => SetValue(EditOnAssociatedObjectDoubleTappedProperty, value);
+    }
+
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
@@ -96,6 +111,11 @@ public class InlineEditBehavior : StyledElementBehavior<Control>
         {
             DisplayControl.AddHandler(InputElement.DoubleTappedEvent, OnDisplayActivate, RoutingStrategies.Tunnel);
             DisplayControl.AddHandler(InputElement.KeyDownEvent, OnDisplayKeyDown, RoutingStrategies.Tunnel);
+        }
+
+        if (EditOnAssociatedObjectDoubleTapped && AssociatedObject is not null)
+        {
+            AssociatedObject.AddHandler(InputElement.DoubleTappedEvent, OnAssociatedObjectActivate, RoutingStrategies.Tunnel);
         }
 
         if (EditControl is not null)
@@ -115,12 +135,19 @@ public class InlineEditBehavior : StyledElementBehavior<Control>
             DisplayControl.RemoveHandler(InputElement.KeyDownEvent, OnDisplayKeyDown);
         }
 
+        if (EditOnAssociatedObjectDoubleTapped && AssociatedObject is not null)
+        {
+            AssociatedObject.RemoveHandler(InputElement.DoubleTappedEvent, OnAssociatedObjectActivate);
+        }
+
         if (EditControl is not null)
         {
             EditControl.RemoveHandler(InputElement.KeyDownEvent, OnEditKeyDown);
             EditControl.RemoveHandler(InputElement.LostFocusEvent, OnEditLostFocus);
         }
     }
+
+    private void OnAssociatedObjectActivate(object? sender, RoutedEventArgs e) => BeginEdit();
 
     private void OnDisplayActivate(object? sender, RoutedEventArgs e) => BeginEdit();
 


### PR DESCRIPTION
## Summary
- expose `EditOnAssociatedObjectDoubleTapped` option in `InlineEditBehavior`
- enable double-tap edit in `EditableItem` control
- add sample pages for listbox and treeview double-tap editing
- show new samples in main view

## Testing
- `dotnet test --no-restore` *(fails: `dotnet` not found)*