### PR TITLE
Add delayed load behaviors and samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ This section provides an overview of all available classes and their purpose in 
 
 - **ShowControlAction**
   *Shows a control and gives it focus when executed.*
+- **DelayedShowControlAction**
+  *Shows a control after waiting for a specified delay.*
 
 - **PopupAction**
   *Displays a popup window for showing additional UI content.*
@@ -492,6 +494,10 @@ This section provides an overview of all available classes and their purpose in 
 
 - **LoadedTrigger**  
   *Triggers actions when the control’s Loaded event fires.*
+- **DelayedLoadBehavior**
+  *Hides the control then shows it after a specified delay when attached to the visual tree.*
+- **DelayedLoadTrigger**
+  *Invokes actions after the control is loaded and a delay period expires.*
 
 - **ResourcesChangedBehavior**  
   *A base class for behaviors that respond when a control’s resources change.*

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -322,6 +322,15 @@
       <TabItem Header="FadeInBehavior">
         <pages:FadeInBehaviorView />
       </TabItem>
+      <TabItem Header="DelayedLoadBehavior">
+        <pages:DelayedLoadBehaviorView />
+      </TabItem>
+      <TabItem Header="DelayedLoadTrigger">
+        <pages:DelayedLoadTriggerView />
+      </TabItem>
+      <TabItem Header="DelayedShowControlAction">
+        <pages:DelayedShowControlActionView />
+      </TabItem>
       <TabItem Header="AnimateOnAttachedBehavior">
         <pages:AnimateOnAttachedBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadBehaviorView.axaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DelayedLoadBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Border Background="SteelBlue" Width="100" Height="100">
+    <Interaction.Behaviors>
+      <DelayedLoadBehavior Delay="0:0:1" />
+    </Interaction.Behaviors>
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DelayedLoadBehaviorView : UserControl
+{
+    public DelayedLoadBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadTriggerView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DelayedLoadTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Border Background="SteelBlue" Width="150" Height="100">
+    <Interaction.Behaviors>
+      <DelayedLoadTrigger Delay="0:0:1">
+        <ChangePropertyAction TargetObject="Message" PropertyName="IsVisible" Value="True" />
+      </DelayedLoadTrigger>
+    </Interaction.Behaviors>
+    <TextBlock x:Name="Message" Text="Loaded" IsVisible="False"
+               HorizontalAlignment="Center" VerticalAlignment="Center" />
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DelayedLoadTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DelayedLoadTriggerView : UserControl
+{
+    public DelayedLoadTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DelayedShowControlActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DelayedShowControlActionView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DelayedShowControlActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Button x:Name="ShowButton" Content="Show after delay" />
+    <TextBlock x:Name="Target" Text="Visible later" IsVisible="False" />
+  </StackPanel>
+  <Interaction.Behaviors>
+    <EventTriggerBehavior SourceObject="ShowButton" EventName="Click">
+      <DelayedShowControlAction TargetControl="Target" Delay="0:0:1" />
+    </EventTriggerBehavior>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DelayedShowControlActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DelayedShowControlActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DelayedShowControlActionView : UserControl
+{
+    public DelayedShowControlActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Actions/DelayedShowControlAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Actions/DelayedShowControlAction.cs
@@ -1,0 +1,72 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Shows the associated or target control after a specified delay when executed.
+/// </summary>
+public sealed class DelayedShowControlAction : StyledElementAction
+{
+    /// <summary>
+    /// Identifies the <see cref="TargetControl"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> TargetControlProperty =
+        AvaloniaProperty.Register<DelayedShowControlAction, Control?>(nameof(TargetControl));
+
+    /// <summary>
+    /// Identifies the <see cref="Delay"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TimeSpan> DelayProperty =
+        AvaloniaProperty.Register<DelayedShowControlAction, TimeSpan>(nameof(Delay), TimeSpan.FromMilliseconds(500));
+
+    /// <summary>
+    /// Gets or sets the target control. This is an avalonia property.
+    /// </summary>
+    [ResolveByName]
+    public Control? TargetControl
+    {
+        get => GetValue(TargetControlProperty);
+        set => SetValue(TargetControlProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the delay before the control is shown.
+    /// </summary>
+    public TimeSpan Delay
+    {
+        get => GetValue(DelayProperty);
+        set => SetValue(DelayProperty, value);
+    }
+
+    /// <inheritdoc />
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        var control = TargetControl ?? sender as Control;
+        if (control is null)
+        {
+            return false;
+        }
+
+        DispatcherTimer? timer = null;
+        void OnTick(object? s, EventArgs e)
+        {
+            timer!.Tick -= OnTick;
+            timer.Stop();
+            control.SetCurrentValue(Visual.IsVisibleProperty, true);
+        }
+
+        timer = new DispatcherTimer { Interval = Delay };
+        timer.Tick += OnTick;
+        timer.Start();
+
+        return true;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Actions/DelayedShowControlAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Actions/DelayedShowControlAction.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
 using Avalonia.Controls;
 using Avalonia.Threading;

--- a/src/Xaml.Behaviors.Interactions.Custom/Control/DelayedLoadBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Control/DelayedLoadBehavior.cs
@@ -1,0 +1,65 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Delays the visibility of the associated control when it is attached to the visual tree.
+/// </summary>
+public sealed class DelayedLoadBehavior : AttachedToVisualTreeBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <see cref="Delay"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TimeSpan> DelayProperty =
+        AvaloniaProperty.Register<DelayedLoadBehavior, TimeSpan>(nameof(Delay), TimeSpan.FromMilliseconds(500));
+
+    private DispatcherTimer? _timer;
+
+    /// <summary>
+    /// Gets or sets the delay before the control becomes visible.
+    /// </summary>
+    public TimeSpan Delay
+    {
+        get => GetValue(DelayProperty);
+        set => SetValue(DelayProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override IDisposable OnAttachedToVisualTreeOverride()
+    {
+        if (AssociatedObject is null)
+        {
+            return DisposableAction.Empty;
+        }
+
+        AssociatedObject.IsVisible = false;
+
+        _timer = new DispatcherTimer { Interval = Delay };
+        _timer.Tick += OnTick;
+        _timer.Start();
+
+        return new DisposableAction(DisposeTimer);
+    }
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.SetCurrentValue(Visual.IsVisibleProperty, true);
+        }
+        DisposeTimer();
+    }
+
+    private void DisposeTimer()
+    {
+        if (_timer is not null)
+        {
+            _timer.Tick -= OnTick;
+            _timer.Stop();
+            _timer = null;
+        }
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Control/DelayedLoadBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Control/DelayedLoadBehavior.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
 using Avalonia.Controls;
 using Avalonia.Threading;

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/DelayedLoadTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/DelayedLoadTrigger.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
 using Avalonia.Controls;
 using Avalonia.Threading;

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/DelayedLoadTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/DelayedLoadTrigger.cs
@@ -1,0 +1,69 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Invokes its actions after the associated control is attached to the visual tree and a delay elapses.
+/// </summary>
+public sealed class DelayedLoadTrigger : StyledElementTrigger<Control>
+{
+    /// <summary>
+    /// Identifies the <see cref="Delay"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<TimeSpan> DelayProperty =
+        AvaloniaProperty.Register<DelayedLoadTrigger, TimeSpan>(nameof(Delay), TimeSpan.FromMilliseconds(500));
+
+    private DispatcherTimer? _timer;
+
+    /// <summary>
+    /// Gets or sets the delay before actions are executed.
+    /// </summary>
+    public TimeSpan Delay
+    {
+        get => GetValue(DelayProperty);
+        set => SetValue(DelayProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        _timer = new DispatcherTimer { Interval = Delay };
+        _timer.Tick += OnTick;
+        _timer.Start();
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        DisposeTimer();
+    }
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        Execute(parameter: null);
+        DisposeTimer();
+    }
+
+    private void Execute(object? parameter)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        Interaction.ExecuteActions(AssociatedObject, Actions, parameter);
+    }
+
+    private void DisposeTimer()
+    {
+        if (_timer is not null)
+        {
+            _timer.Tick -= OnTick;
+            _timer.Stop();
+            _timer = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DelayedLoadBehavior` to show controls after a delay
- add `DelayedLoadTrigger` for delayed execution of actions
- add `DelayedShowControlAction` to reveal a control after waiting
- showcase new features with sample pages
- link new pages from `MainView`
- document new API in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*