### PR TITLE
Fix initial validation

### DIFF
--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/PropertyValidationBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/PropertyValidationBehavior.cs
@@ -101,6 +101,9 @@ public class PropertyValidationBehavior<TControl, TValue> : DisposingBehavior<TC
 
         AssociatedObject.PropertyChanged += Handler;
 
+        // Validate initial value to ensure errors are shown when the control is first displayed
+        Validate(AssociatedObject.GetValue(property));
+
         return DisposableAction.Create(() => AssociatedObject.PropertyChanged -= Handler);
     }
 

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/PropertyValidationBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/PropertyValidationBehavior.cs
@@ -102,7 +102,7 @@ public class PropertyValidationBehavior<TControl, TValue> : DisposingBehavior<TC
         AssociatedObject.PropertyChanged += Handler;
 
         // Validate initial value to ensure errors are shown when the control is first displayed
-        Validate(AssociatedObject.GetValue(property));
+        Validate(AssociatedObject.GetValue<TValue>(property));
 
         return DisposableAction.Create(() => AssociatedObject.PropertyChanged -= Handler);
     }


### PR DESCRIPTION
## Summary
- validate initial value when attaching PropertyValidationBehavior so that validation errors are visible on load

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not installed)*