### PR TITLE
Add validation behaviors for common controls

### DIFF
--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/ComboBoxValidationBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/ComboBoxValidationBehavior.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation behavior for <see cref="ComboBox"/> selected item.
+/// </summary>
+public class ComboBoxValidationBehavior : PropertyValidationBehavior<ComboBox, object?>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComboBoxValidationBehavior"/> class.
+    /// </summary>
+    public ComboBoxValidationBehavior()
+    {
+        Property = SelectingItemsControl.SelectedItemProperty;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/DatePickerValidationBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/DatePickerValidationBehavior.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation behavior for <see cref="DatePicker"/> selected date.
+/// </summary>
+public class DatePickerValidationBehavior : PropertyValidationBehavior<DatePicker, DateTimeOffset?>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatePickerValidationBehavior"/> class.
+    /// </summary>
+    public DatePickerValidationBehavior()
+    {
+        Property = DatePicker.SelectedDateProperty;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/MinLengthValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/MinLengthValidationRule.cs
@@ -1,0 +1,21 @@
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation rule that requires a string with a minimal length.
+/// </summary>
+public class MinLengthValidationRule : IValidationRule<string?>
+{
+    /// <summary>
+    /// Gets or sets the minimal allowed length.
+    /// </summary>
+    public int Length { get; set; }
+
+    /// <inheritdoc />
+    public string? ErrorMessage { get; set; } = "Value is too short.";
+
+    /// <inheritdoc />
+    public bool Validate(string? value)
+    {
+        return value is not null && value.Length >= Length;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/NotNullValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/NotNullValidationRule.cs
@@ -1,0 +1,17 @@
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation rule that requires a non-null value.
+/// </summary>
+/// <typeparam name="T">Type of value to validate.</typeparam>
+public class NotNullValidationRule<T> : IValidationRule<T>
+{
+    /// <inheritdoc />
+    public string? ErrorMessage { get; set; } = "Value is required.";
+
+    /// <inheritdoc />
+    public bool Validate(T? value)
+    {
+        return value is not null;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/RangeValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/RangeValidationRule.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation rule that checks whether a value is within a specified range.
+/// </summary>
+/// <typeparam name="T">Type of value to validate.</typeparam>
+public class RangeValidationRule<T> : IValidationRule<T>
+    where T : IComparable<T>
+{
+    /// <summary>
+    /// Gets or sets the minimum allowed value.
+    /// </summary>
+    public T? Minimum { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum allowed value.
+    /// </summary>
+    public T? Maximum { get; set; }
+
+    /// <inheritdoc />
+    public string? ErrorMessage { get; set; } = "Value is out of range.";
+
+    /// <inheritdoc />
+    public bool Validate(T? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (Minimum is not null && value.CompareTo(Minimum) < 0)
+        {
+            return false;
+        }
+
+        if (Maximum is not null && value.CompareTo(Maximum) > 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/SliderValidationBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/SliderValidationBehavior.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls.Primitives;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation behavior for range based controls like <see cref="Slider"/> value.
+/// </summary>
+public class SliderValidationBehavior : PropertyValidationBehavior<RangeBase, double>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SliderValidationBehavior"/> class.
+    /// </summary>
+    public SliderValidationBehavior()
+    {
+        Property = RangeBase.ValueProperty;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ComboBoxValidationBehavior`
- add `DatePickerValidationBehavior`
- add `SliderValidationBehavior`
- add `NotNullValidationRule` and `MinLengthValidationRule`
- add generic `RangeValidationRule`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*