### PR TITLE
Add NumericUpDown validation sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -71,6 +71,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         MyString = "";
         ValidatedText = "";
+        ValidatedNumber = 0m;
 
         IsLoading = true;
         Progress = 30;
@@ -126,6 +127,10 @@ public partial class MainWindowViewModel : ViewModelBase
     [Reactive] public partial string ValidatedText { get; set; }
 
     [Reactive] public partial bool IsTextValid { get; set; }
+
+    [Reactive] public partial decimal ValidatedNumber { get; set; }
+
+    [Reactive] public partial bool IsNumberValid { get; set; }
 
     public IObservable<int> Values { get; }
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -70,6 +70,9 @@
       <TabItem Header="TextBoxValidationBehavior">
         <pages:TextBoxValidationBehaviorView />
       </TabItem>
+      <TabItem Header="NumericUpDownValidationBehavior">
+        <pages:NumericUpDownValidationBehaviorView />
+      </TabItem>
       <TabItem Header="FocusControlBehavior">
         <pages:FocusControlBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/NumericUpDownValidationBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/NumericUpDownValidationBehaviorView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.NumericUpDownValidationBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="4">
+    <NumericUpDown Width="200"
+                  Value="{Binding ValidatedNumber}">
+      <Interaction.Behaviors>
+        <NumericUpDownValidationBehavior IsValid="{Binding IsNumberValid, Mode=OneWayToSource}">
+          <RequiredValidationRule ErrorMessage="Value is required." />
+          <MinValueValidationRule MinValue="0" ErrorMessage="Min 0" />
+          <MaxValueValidationRule MaxValue="100" ErrorMessage="Max 100" />
+        </NumericUpDownValidationBehavior>
+      </Interaction.Behaviors>
+    </NumericUpDown>
+    <CheckBox IsEnabled="False"
+              Content="IsNumberValid "
+              IsChecked="{Binding IsNumberValid}" />
+    <TextBlock Text="{Binding ValidatedNumber}" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/NumericUpDownValidationBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/NumericUpDownValidationBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class NumericUpDownValidationBehaviorView : UserControl
+{
+    public NumericUpDownValidationBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/MaxValueValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/MaxValueValidationRule.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation rule that checks that a numeric value is less than or equal to a maximum value.
+/// </summary>
+public class MaxValueValidationRule : IValidationRule<decimal?>
+{
+    /// <summary>
+    /// Gets or sets the maximum value.
+    /// </summary>
+    public decimal MaxValue { get; set; }
+
+    /// <inheritdoc />
+    public string? ErrorMessage { get; set; } = "Value is above maximum.";
+
+    /// <inheritdoc />
+    public bool Validate(decimal? value)
+    {
+        return value is decimal v && v <= MaxValue;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/MinValueValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/MinValueValidationRule.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation rule that checks that a numeric value is greater than or equal to a minimum value.
+/// </summary>
+public class MinValueValidationRule : IValidationRule<decimal?>
+{
+    /// <summary>
+    /// Gets or sets the minimum value.
+    /// </summary>
+    public decimal MinValue { get; set; }
+
+    /// <inheritdoc />
+    public string? ErrorMessage { get; set; } = "Value is below minimum.";
+
+    /// <inheritdoc />
+    public bool Validate(decimal? value)
+    {
+        return value is decimal v && v >= MinValue;
+    }
+}


### PR DESCRIPTION
## Summary
- add `MinValueValidationRule` and `MaxValueValidationRule`
- add new sample page demonstrating `NumericUpDownValidationBehavior`
- expose `ValidatedNumber` and `IsNumberValid` in the main view model
- show the new page in `MainView`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*