### PR TITLE
Add DatePickerValidationBehavior sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -72,6 +72,7 @@ public partial class MainWindowViewModel : ViewModelBase
         MyString = "";
         ValidatedText = "";
         ValidatedNumber = 0m;
+        ValidatedDate = DateTimeOffset.Now;
 
         IsLoading = true;
         Progress = 30;
@@ -131,6 +132,10 @@ public partial class MainWindowViewModel : ViewModelBase
     [Reactive] public partial decimal ValidatedNumber { get; set; }
 
     [Reactive] public partial bool IsNumberValid { get; set; }
+
+    [Reactive] public partial DateTimeOffset? ValidatedDate { get; set; }
+
+    [Reactive] public partial bool IsDateValid { get; set; }
 
     public IObservable<int> Values { get; }
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -73,6 +73,9 @@
       <TabItem Header="NumericUpDownValidationBehavior">
         <pages:NumericUpDownValidationBehaviorView />
       </TabItem>
+      <TabItem Header="DatePickerValidationBehavior">
+        <pages:DatePickerValidationBehaviorView />
+      </TabItem>
       <TabItem Header="FocusControlBehavior">
         <pages:FocusControlBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/DatePickerValidationBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DatePickerValidationBehaviorView.axaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DatePickerValidationBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="4">
+    <DatePicker SelectedDate="{Binding ValidatedDate}">
+      <Interaction.Behaviors>
+        <DatePickerValidationBehavior IsValid="{Binding IsDateValid, Mode=OneWayToSource}">
+          <RequiredDateValidationRule ErrorMessage="Date is required." />
+          <RangeValidationRule x:TypeArguments="x:DateTimeOffset"
+                               Minimum="2020-01-01"
+                               Maximum="2030-12-31"
+                               ErrorMessage="Date out of range." />
+        </DatePickerValidationBehavior>
+      </Interaction.Behaviors>
+    </DatePicker>
+    <CheckBox IsEnabled="False"
+              Content="IsDateValid "
+              IsChecked="{Binding IsDateValid}" />
+    <TextBlock Text="{Binding ValidatedDate}" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DatePickerValidationBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DatePickerValidationBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DatePickerValidationBehaviorView : UserControl
+{
+    public DatePickerValidationBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/RequiredDateValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/RequiredDateValidationRule.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Validation rule that requires a non-null date value.
+/// </summary>
+public class RequiredDateValidationRule : IValidationRule<DateTimeOffset?>
+{
+    /// <inheritdoc />
+    public string? ErrorMessage { get; set; } = "Date is required.";
+
+    /// <inheritdoc />
+    public bool Validate(DateTimeOffset? value)
+    {
+        return value is not null;
+    }
+}


### PR DESCRIPTION
## Summary
- create `RequiredDateValidationRule` for date required validation
- add DatePicker validation sample page
- register page in main sample window
- expose `ValidatedDate` and `IsDateValid` in sample view model

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*