### PR TITLE
Add slider validation sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -72,6 +72,7 @@ public partial class MainWindowViewModel : ViewModelBase
         MyString = "";
         ValidatedText = "";
         ValidatedNumber = 0m;
+        ValidatedSlider = 0.0;
 
         IsLoading = true;
         Progress = 30;
@@ -131,6 +132,10 @@ public partial class MainWindowViewModel : ViewModelBase
     [Reactive] public partial decimal ValidatedNumber { get; set; }
 
     [Reactive] public partial bool IsNumberValid { get; set; }
+
+    [Reactive] public partial double ValidatedSlider { get; set; }
+
+    [Reactive] public partial bool IsSliderValid { get; set; }
 
     public IObservable<int> Values { get; }
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -73,6 +73,9 @@
       <TabItem Header="NumericUpDownValidationBehavior">
         <pages:NumericUpDownValidationBehaviorView />
       </TabItem>
+      <TabItem Header="SliderValidationBehavior">
+        <pages:SliderValidationBehaviorView />
+      </TabItem>
       <TabItem Header="FocusControlBehavior">
         <pages:FocusControlBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.SliderValidationBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="4">
+    <Slider Width="200"
+            Minimum="0"
+            Maximum="100"
+            Value="{Binding ValidatedSlider}">
+      <Interaction.Behaviors>
+        <SliderValidationBehavior IsValid="{Binding IsSliderValid, Mode=OneWayToSource}">
+          <RangeValidationRule x:TypeArguments="x:Double" Minimum="0" Maximum="100" ErrorMessage="Range 0-100" />
+        </SliderValidationBehavior>
+      </Interaction.Behaviors>
+    </Slider>
+    <CheckBox IsEnabled="False"
+              Content="IsSliderValid "
+              IsChecked="{Binding IsSliderValid}" />
+    <TextBlock Text="{Binding ValidatedSlider}" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class SliderValidationBehaviorView : UserControl
+{
+    public SliderValidationBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `SliderValidationBehaviorView` sample page
- expose `ValidatedSlider` and `IsSliderValid` properties
- show the new sample on the main sample page

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*