### PR TITLE
Add sorting option to SelectingItemsControlSearchBehavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,9 +1143,9 @@ This section provides an overview of all available classes and their purpose in 
 ### SelectingItemsControl
 - **SelectingItemsControlEventsBehavior** (No sample available.)
   *Handles selection-changed events in controls that support item selection (like ListBox) to trigger custom actions.*
-- **SelectingItemsControlSearchBehavior** ([Sample](samples/BehaviorsTestApplication/Views/MainView.axaml))
-  *Enables searching and highlights matching items within a SelectingItemsControl.*
-  Supports sorting results using the `SortOrder` property (ascending by default).
+  - **SelectingItemsControlSearchBehavior** ([Sample](samples/BehaviorsTestApplication/Views/MainView.axaml))
+    *Enables searching and highlights matching items within a SelectingItemsControl.*
+    Sorting can be enabled with `EnableSorting` and configured using the `SortOrder` property (ascending by default).
 
 ### Show
 - **ShowBehaviorBase** (No sample available.)

--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ This section provides an overview of all available classes and their purpose in 
   *Handles selection-changed events in controls that support item selection (like ListBox) to trigger custom actions.*
 - **SelectingItemsControlSearchBehavior** ([Sample](samples/BehaviorsTestApplication/Views/MainView.axaml))
   *Enables searching and highlights matching items within a SelectingItemsControl.*
+  Supports sorting results using the `SortOrder` property (ascending by default).
 
 ### Show
 - **ShowBehaviorBase** (No sample available.)

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -30,6 +30,7 @@
       <Interaction.Behaviors>
         <SelectingItemsControlSearchBehavior SearchBox="SearchBox"
                                              NoMatchesControl="NoMatchesText"
+                                             EnableSorting="True"
                                              SortOrder="Ascending" />
       </Interaction.Behaviors>
       <TabItem Header="CallMethodAction">

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -29,7 +29,8 @@
     <SingleSelectionTabControl x:Name="PagesTabControl" SelectedIndex="0" Classes="sidebar">
       <Interaction.Behaviors>
         <SelectingItemsControlSearchBehavior SearchBox="SearchBox"
-                                             NoMatchesControl="NoMatchesText" />
+                                             NoMatchesControl="NoMatchesText"
+                                             SortOrder="Ascending" />
       </Interaction.Behaviors>
       <TabItem Header="CallMethodAction">
         <pages:CallMethodActionView />

--- a/src/Xaml.Behaviors.Interactions.Custom/SelectingItemsControl/SelectingItemsControlSearchBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/SelectingItemsControl/SelectingItemsControlSearchBehavior.cs
@@ -102,6 +102,8 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
             SearchBox.AddHandler(InputElement.TextInputEvent, SearchBox_TextChanged, RoutingStrategies.Bubble);
             SearchBox.AddHandler(TextBox.TextChangedEvent, SearchBox_TextChanged, RoutingStrategies.Bubble);
         }
+
+        SortItems();
     }
 
     /// <inheritdoc />
@@ -114,6 +116,33 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
         }
     }
 
+    private void SortItems()
+    {
+        if (AssociatedObject is null || !EnableSorting)
+        {
+            return;
+        }
+
+        var tabItems = AssociatedObject.Items.OfType<TabItem>().ToList();
+        tabItems = SortOrder == SortDirection.Ascending
+            ? tabItems.OrderBy(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList()
+            : tabItems.OrderByDescending(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList();
+
+        if (AssociatedObject.Items is IList list)
+        {
+            for (var i = 0; i < tabItems.Count; i++)
+            {
+                var item = tabItems[i];
+                var currentIndex = list.IndexOf(item);
+                if (currentIndex != i)
+                {
+                    list.RemoveAt(currentIndex);
+                    list.Insert(i, item);
+                }
+            }
+        }
+    }
+
     private void SearchBox_TextChanged(object? sender, RoutedEventArgs e)
     {
         if (AssociatedObject is null)
@@ -123,28 +152,10 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
 
         var query = SearchBox?.Text?.ToLowerInvariant() ?? string.Empty;
         var visibleCount = 0;
+
+        SortItems();
+
         var tabItems = AssociatedObject.Items.OfType<TabItem>().ToList();
-
-        if (EnableSorting)
-        {
-            tabItems = SortOrder == SortDirection.Ascending
-                ? tabItems.OrderBy(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList()
-                : tabItems.OrderByDescending(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList();
-
-            if (AssociatedObject.Items is IList list)
-            {
-                for (var i = 0; i < tabItems.Count; i++)
-                {
-                    var item = tabItems[i];
-                    var currentIndex = list.IndexOf(item);
-                    if (currentIndex != i)
-                    {
-                        list.RemoveAt(currentIndex);
-                        list.Insert(i, item);
-                    }
-                }
-            }
-        }
 
         foreach (var item in tabItems)
         {

--- a/src/Xaml.Behaviors.Interactions.Custom/SelectingItemsControl/SelectingItemsControlSearchBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/SelectingItemsControl/SelectingItemsControlSearchBehavior.cs
@@ -45,6 +45,12 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
         AvaloniaProperty.Register<SelectingItemsControlSearchBehavior, TextBlock?>(nameof(NoMatchesControl));
 
     /// <summary>
+    /// Identifies the <seealso cref="EnableSorting"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> EnableSortingProperty =
+        AvaloniaProperty.Register<SelectingItemsControlSearchBehavior, bool>(nameof(EnableSorting));
+
+    /// <summary>
     /// Identifies the <seealso cref="SortOrder"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<SortDirection> SortOrderProperty =
@@ -68,6 +74,15 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
     {
         get => GetValue(NoMatchesControlProperty);
         set => SetValue(NoMatchesControlProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether items should be sorted.
+    /// </summary>
+    public bool EnableSorting
+    {
+        get => GetValue(EnableSortingProperty);
+        set => SetValue(EnableSortingProperty, value);
     }
 
     /// <summary>
@@ -110,20 +125,23 @@ public sealed class SelectingItemsControlSearchBehavior : StyledElementBehavior<
         var visibleCount = 0;
         var tabItems = AssociatedObject.Items.OfType<TabItem>().ToList();
 
-        tabItems = SortOrder == SortDirection.Ascending
-            ? tabItems.OrderBy(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList()
-            : tabItems.OrderByDescending(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList();
-
-        if (AssociatedObject.Items is IList list)
+        if (EnableSorting)
         {
-            for (var i = 0; i < tabItems.Count; i++)
+            tabItems = SortOrder == SortDirection.Ascending
+                ? tabItems.OrderBy(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList()
+                : tabItems.OrderByDescending(x => x.Header?.ToString(), StringComparer.OrdinalIgnoreCase).ToList();
+
+            if (AssociatedObject.Items is IList list)
             {
-                var item = tabItems[i];
-                var currentIndex = list.IndexOf(item);
-                if (currentIndex != i)
+                for (var i = 0; i < tabItems.Count; i++)
                 {
-                    list.RemoveAt(currentIndex);
-                    list.Insert(i, item);
+                    var item = tabItems[i];
+                    var currentIndex = list.IndexOf(item);
+                    if (currentIndex != i)
+                    {
+                        list.RemoveAt(currentIndex);
+                        list.Insert(i, item);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- implement `SortDirection` enum and add `SortOrder` property
- sort tab items and reorder the control's items
- document new property in README and sample

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5ab66e088321adbcdb04782c2fe6