### PR TITLE
Add InputElement trigger sample pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,17 +976,17 @@ This section provides an overview of all available classes and their purpose in 
 - **ShowToolTipAction** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml))
   *Shows the ToolTip for the associated or target control.*
 
-### InputElement Triggers
-- **DoubleTappedTrigger** (No sample available.)
+-### InputElement Triggers
+- **DoubleTappedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml))
   *Listens for a double-tap event and executes its actions.*
 
-- **GotFocusTrigger** (No sample available.)
+- **GotFocusTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml))
   *Triggers actions when the control receives focus.*
 
-- **HoldingTrigger** (No sample available.)
+- **HoldingTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml))
   *Triggers actions when a holding gesture is detected.*
 
-- **KeyDownTrigger** (No sample available.)
+- **KeyDownTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml))
   *Listens for key down events and triggers actions if the pressed key (or gesture) matches the specified criteria.*
 - **KeyGestureTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml))
   *Triggers actions based on a specified key gesture.*
@@ -994,19 +994,19 @@ This section provides an overview of all available classes and their purpose in 
 - **KeyTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/KeyTriggerView.axaml))
   *Listens for key down or key up events and triggers actions when the configured key or gesture occurs.*
 
-- **KeyUpTrigger** (No sample available.)
+- **KeyUpTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml))
   *Listens for key up events and triggers actions when conditions are met.*
 
-- **LostFocusTrigger** (No sample available.)
+- **LostFocusTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml))
   *Triggers actions when the control loses focus.*
 
-- **PointerCaptureLostTrigger** (No sample available.)
+- **PointerCaptureLostTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml))
   *Triggers actions when pointer capture is lost by the control.*
 
-- **PointerEnteredTrigger** (No sample available.)
+- **PointerEnteredTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml))
   *Triggers actions when the pointer enters the control’s area.*
 
-- **PointerExitedTrigger** (No sample available.)
+- **PointerExitedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml))
   *Triggers actions when the pointer exits the control’s area.*
 
 - **PointerMovedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml))
@@ -1018,20 +1018,20 @@ This section provides an overview of all available classes and their purpose in 
 - **PointerReleasedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml))
   *Triggers actions when the pointer is released on the control.*
 
-- **PointerWheelChangedTrigger** (No sample available.)
+- **PointerWheelChangedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml))
   *Triggers actions on mouse wheel (or equivalent) changes.*
 
-- **TappedTrigger** (No sample available.)
+- **TappedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml))
   *Triggers actions on a tap event.*
 - **ToolTipOpeningTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml))
   *Triggers actions when a tooltip is about to open.*
 - **ToolTipClosingTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml))
   *Triggers actions when a tooltip is closing.*
 
-- **TextInputMethodClientRequestedTrigger** (No sample available.)
+- **TextInputMethodClientRequestedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml))
   *Triggers actions when a text input method (virtual keyboard) is requested.*
 
-- **TextInputTrigger** (No sample available.)
+- **TextInputTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml))
   *Triggers actions on text input events.*
 
 ### WriteableBitmap

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -448,6 +448,18 @@
       <TabItem Header="Popup Event Triggers">
         <pages:PopupEventTriggersView />
       </TabItem>
+      <TabItem Header="Focus Triggers">
+        <pages:FocusTriggersView />
+      </TabItem>
+      <TabItem Header="Key Input Triggers">
+        <pages:KeyInputTriggersView />
+      </TabItem>
+      <TabItem Header="Pointer Extra Triggers">
+        <pages:PointerExtraTriggersView />
+      </TabItem>
+      <TabItem Header="Gesture Triggers">
+        <pages:GestureTriggersView />
+      </TabItem>
       <TabItem Header="Icon Sample">
         <pages:IconView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.FocusTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Focus the TextBox" Margin="5" />
+    <TextBox Width="200" Margin="5">
+      <Interaction.Behaviors>
+        <GotFocusTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Got Focus" />
+        </GotFocusTrigger>
+        <LostFocusTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Lost Focus" />
+        </LostFocusTrigger>
+      </Interaction.Behaviors>
+    </TextBox>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FocusTriggersView : UserControl
+{
+    public FocusTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.GestureTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
+    <Border Width="200" Height="100" Background="LightGray" Margin="5">
+      <Interaction.Behaviors>
+        <TappedTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Tapped" />
+        </TappedTrigger>
+        <DoubleTappedTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Double Tapped" />
+        </DoubleTappedTrigger>
+        <HoldingTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Holding" />
+        </HoldingTrigger>
+      </Interaction.Behaviors>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class GestureTriggersView : UserControl
+{
+    public GestureTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.KeyInputTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Press keys" Margin="5" />
+    <TextBox Width="200" Margin="5">
+      <Interaction.Behaviors>
+        <KeyDownTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Key Down" />
+        </KeyDownTrigger>
+        <KeyUpTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Key Up" />
+        </KeyUpTrigger>
+        <TextInputTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Text Input" />
+        </TextInputTrigger>
+        <TextInputMethodClientRequestedTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Input Method Requested" />
+        </TextInputMethodClientRequestedTrigger>
+      </Interaction.Behaviors>
+    </TextBox>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class KeyInputTriggersView : UserControl
+{
+    public KeyInputTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.PointerExtraTriggersView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="200">
+  <StackPanel Margin="5">
+    <TextBlock x:Name="InfoText" Text="Interact" Margin="5" />
+    <Border Width="200" Height="100" Background="LightGray" Margin="5">
+      <Interaction.Behaviors>
+        <PointerEnteredTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Entered" />
+        </PointerEnteredTrigger>
+        <PointerExitedTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Pointer Exited" />
+        </PointerExitedTrigger>
+        <PointerWheelChangedTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Wheel Changed" />
+        </PointerWheelChangedTrigger>
+        <PointerCaptureLostTrigger>
+          <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Capture Lost" />
+        </PointerCaptureLostTrigger>
+      </Interaction.Behaviors>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class PointerExtraTriggersView : UserControl
+{
+    public PointerExtraTriggersView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add sample pages for missing InputElement triggers
- update readme with links to the new samples
- register the pages in `MainView.axaml`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5b0d4e508321b7d5cf46fc3e99db