### PR TITLE
Add missing trigger sample pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,9 +417,9 @@ This section provides an overview of all available classes and their purpose in 
   *Opens a context dialog using a specified behavior.*
 - **HideContextDialogAction** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml))
   *Closes a context dialog using a specified behavior.*
-- **ContextDialogOpenedTrigger** (No sample available.)
+- **ContextDialogOpenedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml))
   *Triggers actions when a context dialog is opened.*
-- **ContextDialogClosedTrigger** (No sample available.)
+- **ContextDialogClosedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml))
   *Triggers actions when a context dialog is closed.*
 
 ### Control
@@ -467,7 +467,7 @@ This section provides an overview of all available classes and their purpose in 
   *Converts pointer event arguments into a tuple (x, y) representing the pointer’s location.*
 
 ### Core (General Infrastructure)
-- **ActualThemeVariantChangedBehavior** (No sample available.)
+- **ActualThemeVariantChangedBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml))
   *A base class for behaviors that react to theme variant changes (e.g. switching from light to dark mode).*
 
 - **ActualThemeVariantChangedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml))
@@ -479,19 +479,19 @@ This section provides an overview of all available classes and their purpose in 
 - **SetThemeVariantAction** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml))
   *Sets the requested theme variant on a target control.*
 
-- **AttachedToLogicalTreeBehavior** (No sample available.)
+- **AttachedToLogicalTreeBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml))
   *A base class for behaviors that require notification when the associated object is added to the logical tree.*
 
-- **AttachedToLogicalTreeTrigger** (No sample available.)
+- **AttachedToLogicalTreeTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeTriggerView.axaml))
   *Triggers actions when an element is attached to the logical tree.*
 
 - **AttachedToVisualTreeBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/FocusOnAttachedToVisualTreeBehaviorView.axaml))
   *A base class for behaviors that depend on the control being attached to the visual tree.*
 
-- **AttachedToVisualTreeTrigger** (No sample available.)
+- **AttachedToVisualTreeTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/AttachedToVisualTreeTriggerView.axaml))
   *Triggers actions when the associated element is added to the visual tree.*
 
-- **BindingBehavior** (No sample available.)
+- **BindingBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml))
   *Establishes a binding on a target property using an Avalonia binding.*
 
 - **BindingTriggerBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/BindingTriggerBehaviorView.axaml))
@@ -505,10 +505,10 @@ This section provides an overview of all available classes and their purpose in 
 - **LaunchUriOrFileAction** ([Sample](samples/BehaviorsTestApplication/Views/Pages/LaunchUriOrFileActionView.axaml))
   *Opens a URI or file using the default associated application.*
 
-- **DataContextChangedBehavior** (No sample available.)
+- **DataContextChangedBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml))
   *A base class for behaviors that react to changes in the DataContext.*
 
-- **DataContextChangedTrigger** (No sample available.)
+- **DataContextChangedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DataContextChangedTriggerView.axaml))
   *Triggers actions when the DataContext of a control changes.*
 
 - **DataTriggerBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DataTriggerBehaviorView.axaml))

--- a/samples/BehaviorsTestApplication/Behaviors/ActualThemeVariantChangedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/ActualThemeVariantChangedMessageBehavior.cs
@@ -1,0 +1,22 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class ActualThemeVariantChangedMessageBehavior : ActualThemeVariantChangedBehavior<ThemeVariantScope>
+{
+    [ResolveByName]
+    public TextBlock? Target { get; set; }
+
+    protected override IDisposable OnActualThemeVariantChangedEventOverride()
+    {
+        if (Target is not null)
+        {
+            Target.Text = "Theme Changed";
+        }
+
+        return DisposableAction.Empty;
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/ActualThemeVariantChangedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/ActualThemeVariantChangedMessageBehavior.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Xaml.Interactivity;
 using Avalonia.Xaml.Interactions.Custom;
@@ -7,8 +8,15 @@ namespace BehaviorsTestApplication.Behaviors;
 
 public class ActualThemeVariantChangedMessageBehavior : ActualThemeVariantChangedBehavior<ThemeVariantScope>
 {
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<ActualThemeVariantChangedMessageBehavior, TextBlock?>(nameof(Target));
+
     [ResolveByName]
-    public TextBlock? Target { get; set; }
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
 
     protected override IDisposable OnActualThemeVariantChangedEventOverride()
     {

--- a/samples/BehaviorsTestApplication/Behaviors/AttachedToLogicalTreeMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/AttachedToLogicalTreeMessageBehavior.cs
@@ -1,0 +1,22 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class AttachedToLogicalTreeMessageBehavior : AttachedToLogicalTreeBehavior<StyledElement>
+{
+    [ResolveByName]
+    public TextBlock? Target { get; set; }
+
+    protected override IDisposable OnAttachedToLogicalTreeOverride()
+    {
+        if (Target is not null)
+        {
+            Target.Text = "Attached";
+        }
+
+        return DisposableAction.Empty;
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/AttachedToLogicalTreeMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/AttachedToLogicalTreeMessageBehavior.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Xaml.Interactivity;
 using Avalonia.Xaml.Interactions.Custom;
@@ -7,8 +8,15 @@ namespace BehaviorsTestApplication.Behaviors;
 
 public class AttachedToLogicalTreeMessageBehavior : AttachedToLogicalTreeBehavior<StyledElement>
 {
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<AttachedToLogicalTreeMessageBehavior, TextBlock?>(nameof(Target));
+
     [ResolveByName]
-    public TextBlock? Target { get; set; }
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
 
     protected override IDisposable OnAttachedToLogicalTreeOverride()
     {

--- a/samples/BehaviorsTestApplication/Behaviors/DataContextChangedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/DataContextChangedMessageBehavior.cs
@@ -1,0 +1,22 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class DataContextChangedMessageBehavior : DataContextChangedBehavior<StyledElement>
+{
+    [ResolveByName]
+    public TextBlock? Target { get; set; }
+
+    protected override IDisposable OnDataContextChangedEventOverride()
+    {
+        if (Target is not null)
+        {
+            Target.Text = "DataContext Changed";
+        }
+
+        return DisposableAction.Empty;
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/DataContextChangedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/DataContextChangedMessageBehavior.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Xaml.Interactivity;
 using Avalonia.Xaml.Interactions.Custom;
@@ -7,8 +8,15 @@ namespace BehaviorsTestApplication.Behaviors;
 
 public class DataContextChangedMessageBehavior : DataContextChangedBehavior<StyledElement>
 {
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<DataContextChangedMessageBehavior, TextBlock?>(nameof(Target));
+
     [ResolveByName]
-    public TextBlock? Target { get; set; }
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
 
     protected override IDisposable OnDataContextChangedEventOverride()
     {

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -468,6 +468,27 @@
       <TabItem Header="Automation">
         <pages:AutomationView />
       </TabItem>
+      <TabItem Header="ActualThemeVariantChangedBehavior">
+        <pages:ActualThemeVariantChangedBehaviorView />
+      </TabItem>
+      <TabItem Header="AttachedToLogicalTreeBehavior">
+        <pages:AttachedToLogicalTreeBehaviorView />
+      </TabItem>
+      <TabItem Header="AttachedToLogicalTreeTrigger">
+        <pages:AttachedToLogicalTreeTriggerView />
+      </TabItem>
+      <TabItem Header="AttachedToVisualTreeTrigger">
+        <pages:AttachedToVisualTreeTriggerView />
+      </TabItem>
+      <TabItem Header="BindingBehavior">
+        <pages:BindingBehaviorView />
+      </TabItem>
+      <TabItem Header="DataContextChangedBehavior">
+        <pages:DataContextChangedBehaviorView />
+      </TabItem>
+      <TabItem Header="DataContextChangedTrigger">
+        <pages:DataContextChangedTriggerView />
+      </TabItem>
     </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ActualThemeVariantChangedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <ThemeVariantScope x:Name="Scope">
+    <Interaction.Behaviors>
+      <ThemeVariantBehavior ThemeVariant="{Binding #Selector.SelectedItem}" />
+      <b:ActualThemeVariantChangedMessageBehavior Target="{Binding #MessageText}" />
+    </Interaction.Behaviors>
+    <StackPanel Spacing="5">
+      <ComboBox x:Name="Selector" SelectedIndex="0">
+        <ComboBox.Items>
+          <ThemeVariant>Default</ThemeVariant>
+          <ThemeVariant>Dark</ThemeVariant>
+          <ThemeVariant>Light</ThemeVariant>
+        </ComboBox.Items>
+      </ComboBox>
+      <TextBlock x:Name="MessageText" Text="{Binding #Scope.ActualThemeVariant}" />
+    </StackPanel>
+  </ThemeVariantScope>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:b="using:BehaviorsTestApplication.Behaviors"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200">
   <Design.DataContext>
@@ -13,7 +12,7 @@
   <ThemeVariantScope x:Name="Scope">
     <Interaction.Behaviors>
       <ThemeVariantBehavior ThemeVariant="{Binding #Selector.SelectedItem}" />
-      <b:ActualThemeVariantChangedMessageBehavior Target="{Binding #MessageText}" />
+      <ActualThemeVariantChangedMessageBehavior Target="{Binding #MessageText}" />
     </Interaction.Behaviors>
     <StackPanel Spacing="5">
       <ComboBox x:Name="Selector" SelectedIndex="0">

--- a/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ActualThemeVariantChangedBehaviorView : UserControl
+{
+    public ActualThemeVariantChangedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AttachedToLogicalTreeBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <b:AttachedToLogicalTreeMessageBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Target" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:b="using:BehaviorsTestApplication.Behaviors"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
   <Design.DataContext>
@@ -13,7 +12,7 @@
   <StackPanel Spacing="5">
     <Border x:Name="Target" Background="LightGray" Padding="20">
       <Interaction.Behaviors>
-        <b:AttachedToLogicalTreeMessageBehavior Target="{Binding #MessageText}" />
+        <AttachedToLogicalTreeMessageBehavior Target="{Binding #MessageText}" />
       </Interaction.Behaviors>
       <TextBlock Text="Target" />
     </Border>

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AttachedToLogicalTreeBehaviorView : UserControl
+{
+    public AttachedToLogicalTreeBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeTriggerView.axaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AttachedToLogicalTreeTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <TextBlock x:Name="MessageText" Text="Waiting" />
+  <Interaction.Behaviors>
+    <AttachedToLogicalTreeTrigger>
+      <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Attached" />
+    </AttachedToLogicalTreeTrigger>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AttachedToLogicalTreeTriggerView : UserControl
+{
+    public AttachedToLogicalTreeTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToVisualTreeTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToVisualTreeTriggerView.axaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AttachedToVisualTreeTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <TextBlock x:Name="MessageText" Text="Waiting" />
+  <Interaction.Behaviors>
+    <AttachedToVisualTreeTrigger>
+      <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Attached" />
+    </AttachedToVisualTreeTrigger>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AttachedToVisualTreeTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttachedToVisualTreeTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AttachedToVisualTreeTriggerView : UserControl
+{
+    public AttachedToVisualTreeTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml
@@ -15,7 +15,7 @@
   </StackPanel>
   <Interaction.Behaviors>
     <BindingBehavior TargetObject="{Binding #TargetText}"
-                     TargetProperty="Text"
+                     TargetProperty="{x:Static TextBlock.TextProperty}"
                      Binding="{Binding Text, ElementName=SourceBox}" />
   </Interaction.Behaviors>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.BindingBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <TextBox x:Name="SourceBox" Width="200" Text="{Binding Greeting}" />
+    <TextBlock x:Name="TargetText" />
+  </StackPanel>
+  <Interaction.Behaviors>
+    <BindingBehavior TargetObject="{Binding #TargetText}"
+                     TargetProperty="Text"
+                     Binding="{Binding Text, ElementName=SourceBox}" />
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class BindingBehaviorView : UserControl
+{
+    public BindingBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml
@@ -10,6 +10,7 @@
     <vm:MainWindowViewModel />
   </Design.DataContext>
   <StackPanel>
+    <TextBlock x:Name="Status" Margin="5" />
     <Button x:Name="OpenButton" Content="Open Context Dialog" Margin="5" />
     <Button x:Name="CloseButton" Content="Close Context Dialog" Margin="5" />
     <Border x:Name="Target" Margin="5" Padding="20" Background="{DynamicResource GrayBrush}">
@@ -32,5 +33,11 @@
     <EventTriggerBehavior EventName="Click" SourceObject="CloseButton">
       <HideContextDialogAction TargetDialog="{Binding #Dialog}" />
     </EventTriggerBehavior>
+    <ContextDialogOpenedTrigger SourceObject="{Binding #Dialog}">
+      <ChangePropertyAction TargetObject="Status" PropertyName="Text" Value="Opened" />
+    </ContextDialogOpenedTrigger>
+    <ContextDialogClosedTrigger SourceObject="{Binding #Dialog}">
+      <ChangePropertyAction TargetObject="Status" PropertyName="Text" Value="Closed" />
+    </ContextDialogClosedTrigger>
   </Interaction.Behaviors>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:b="using:BehaviorsTestApplication.Behaviors"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100">
   <Design.DataContext>
@@ -13,7 +12,7 @@
   <StackPanel Spacing="5">
     <Border x:Name="Target" Background="LightGray" Padding="20">
       <Interaction.Behaviors>
-        <b:DataContextChangedMessageBehavior Target="{Binding #MessageText}" />
+        <DataContextChangedMessageBehavior Target="{Binding #MessageText}" />
       </Interaction.Behaviors>
       <TextBlock Text="Target" />
     </Border>

--- a/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DataContextChangedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <b:DataContextChangedMessageBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Target" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DataContextChangedBehaviorView : UserControl
+{
+    public DataContextChangedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedTriggerView.axaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DataContextChangedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <TextBlock x:Name="MessageText" Text="Waiting" />
+  <Interaction.Behaviors>
+    <DataContextChangedTrigger>
+      <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Changed" />
+    </DataContextChangedTrigger>
+  </Interaction.Behaviors>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DataContextChangedTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DataContextChangedTriggerView : UserControl
+{
+    public DataContextChangedTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- show context dialog triggers in ContextDialogView
- add sample pages for more behaviors and triggers
- link new samples from README

## Testing
- `./build.sh --target Test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a761fd4908321a89cf14523e7b031