### PR TITLE
Add additional sample pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,18 +520,18 @@ This section provides an overview of all available classes and their purpose in 
 - **ViewModelPropertyChangedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml))
   *Invokes actions when a DataContext property changes.*
 
-- **DetachedFromLogicalTreeTrigger** (No sample available.)
+- **DetachedFromLogicalTreeTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml))
   *Triggers actions when the control is removed from the logical tree.*
 
-- **DetachedFromVisualTreeTrigger** (No sample available.)
+- **DetachedFromVisualTreeTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml))
   *Triggers actions when the control is removed from the visual tree.*
 
-- **DisposingBehavior** (No sample available.)
+- **DisposingBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DisposingBehaviorView.axaml))
   *A base class for behaviors that manage disposable resources automatically.*
 
-- **DisposingTrigger** (No sample available.)
+- **DisposingTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml))
   *A base class for triggers that need to dispose of resources when detached.*
-- **DisposableAction** (No sample available.)
+- **DisposableAction** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DisposableActionView.axaml))
   *Executes a delegate when the object is disposed.*
 
 - **EventTriggerBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/EventTriggerBehaviorView.axaml))
@@ -541,19 +541,19 @@ This section provides an overview of all available classes and their purpose in 
 - **TimerTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/TimerTriggerView.axaml))
   *Invokes actions repeatedly after a set interval.*
 
-- **InitializedBehavior** (No sample available.)
+- **InitializedBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/InitializedBehaviorView.axaml))
   *A base class for behaviors that execute code when the associated object is initialized.*
 
-- **InitializedTrigger** (No sample available.)
+- **InitializedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml))
   *Triggers actions once the control is initialized.*
 
 - **InvokeCommandAction** ([Sample](samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionView.axaml))
   *Executes a bound ICommand when the action is invoked.*
 
-- **InvokeCommandActionBase** (No sample available.)
+- **InvokeCommandActionBase** ([Sample](samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionBaseView.axaml))
   *The base class for actions that invoke commands, with support for parameter conversion.*
 
-- **LoadedBehavior** (No sample available.)
+- **LoadedBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml))
   *A base class for behaviors that run when a control is loaded into the visual tree.*
 - **SetViewModelPropertyOnLoadBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml))
   *Sets a view model property when the associated control is loaded.*
@@ -565,13 +565,13 @@ This section provides an overview of all available classes and their purpose in 
 - **DelayedLoadTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/DelayedLoadTriggerView.axaml))
   *Invokes actions after the control is loaded and a delay period expires.*
 
-- **ResourcesChangedBehavior** (No sample available.)
+- **ResourcesChangedBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml))
   *A base class for behaviors that respond when a control’s resources change.*
 
-- **ResourcesChangedTrigger** (No sample available.)
+- **ResourcesChangedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml))
   *Triggers actions when the control’s resources are modified.*
 
-- **RoutedEventTriggerBase** (No sample available.)
+- **RoutedEventTriggerBase** ([Sample](samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBaseView.axaml))
   *A base class for triggers that listen for a routed event and execute actions.*
 
 - **RoutedEventTriggerBase<T>** (No sample available.)
@@ -580,7 +580,7 @@ This section provides an overview of all available classes and their purpose in 
 - **RoutedEventTriggerBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBehaviorView.axaml))
   *Listens for a routed event on the associated object and triggers its actions.*
 
-- **UnloadedTrigger** (No sample available.)
+- **UnloadedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml))
   *Triggers actions when the control is unloaded from the visual tree.*
 
 - **ValueChangedTriggerBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ValueChangedTriggerBehaviorView.axaml))

--- a/samples/BehaviorsTestApplication/Behaviors/DisposableActionBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/DisposableActionBehavior.cs
@@ -1,0 +1,55 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class DisposableActionBehavior : StyledElementBehavior<Control>
+{
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<DisposableActionBehavior, TextBlock?>(nameof(Target));
+
+    [ResolveByName]
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
+
+    private IDisposable? _disposable;
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        if (AssociatedObject is null)
+        {
+            return;
+        }
+
+        void Handler(object? sender, PointerPressedEventArgs e)
+        {
+            if (Target is not null)
+            {
+                Target.Text = "Pressed";
+            }
+        }
+
+        AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Handler, RoutingStrategies.Tunnel);
+
+        _disposable = DisposableAction.Create(() =>
+        {
+            AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, Handler);
+        });
+    }
+
+    protected override void OnDetaching()
+    {
+        _disposable?.Dispose();
+        _disposable = null;
+        base.OnDetaching();
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/DisposingMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/DisposingMessageBehavior.cs
@@ -1,0 +1,44 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class DisposingMessageBehavior : DisposingBehavior<Control>
+{
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<DisposingMessageBehavior, TextBlock?>(nameof(Target));
+
+    [ResolveByName]
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
+
+    protected override IDisposable OnAttachedOverride()
+    {
+        if (AssociatedObject is null)
+        {
+            return DisposableAction.Empty;
+        }
+
+        void Handler(object? sender, PointerPressedEventArgs e)
+        {
+            if (Target is not null)
+            {
+                Target.Text = "Pressed";
+            }
+        }
+
+        AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Handler, RoutingStrategies.Tunnel);
+
+        return DisposableAction.Create(() =>
+        {
+            AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, Handler);
+        });
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/InitializedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/InitializedMessageBehavior.cs
@@ -1,0 +1,30 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class InitializedMessageBehavior : InitializedBehavior<StyledElement>
+{
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<InitializedMessageBehavior, TextBlock?>(nameof(Target));
+
+    [ResolveByName]
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
+
+    protected override IDisposable OnInitializedEventOverride()
+    {
+        if (Target is not null)
+        {
+            Target.Text = "Initialized";
+        }
+
+        return DisposableAction.Empty;
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/LoadedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/LoadedMessageBehavior.cs
@@ -1,0 +1,30 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class LoadedMessageBehavior : LoadedBehavior<Control>
+{
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<LoadedMessageBehavior, TextBlock?>(nameof(Target));
+
+    [ResolveByName]
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
+
+    protected override IDisposable OnLoadedOverride()
+    {
+        if (Target is not null)
+        {
+            Target.Text = "Loaded";
+        }
+
+        return DisposableAction.Empty;
+    }
+}

--- a/samples/BehaviorsTestApplication/Behaviors/ResourcesChangedMessageBehavior.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/ResourcesChangedMessageBehavior.cs
@@ -1,0 +1,30 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public class ResourcesChangedMessageBehavior : ResourcesChangedBehavior<StyledElement>
+{
+    public static readonly StyledProperty<TextBlock?> TargetProperty =
+        AvaloniaProperty.Register<ResourcesChangedMessageBehavior, TextBlock?>(nameof(Target));
+
+    [ResolveByName]
+    public TextBlock? Target
+    {
+        get => GetValue(TargetProperty);
+        set => SetValue(TargetProperty, value);
+    }
+
+    protected override IDisposable OnResourcesChangedEventOverride()
+    {
+        if (Target is not null)
+        {
+            Target.Text = "Resources changed";
+        }
+
+        return DisposableAction.Empty;
+    }
+}

--- a/samples/BehaviorsTestApplication/Triggers/PointerPressedDisposingTrigger.cs
+++ b/samples/BehaviorsTestApplication/Triggers/PointerPressedDisposingTrigger.cs
@@ -1,0 +1,30 @@
+using System;
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace BehaviorsTestApplication.Triggers;
+
+public class PointerPressedDisposingTrigger : DisposingTrigger<StyledElement>
+{
+    protected override IDisposable OnAttachedOverride()
+    {
+        if (AssociatedObject is null)
+        {
+            return DisposableAction.Empty;
+        }
+
+        void Handler(object? sender, PointerPressedEventArgs e)
+        {
+            Interaction.ExecuteActions(AssociatedObject, Actions, e);
+        }
+
+        AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Handler, RoutingStrategies.Tunnel);
+
+        return DisposableAction.Create(() =>
+        {
+            AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, Handler);
+        });
+    }
+}

--- a/samples/BehaviorsTestApplication/Triggers/PointerPressedDisposingTrigger.cs
+++ b/samples/BehaviorsTestApplication/Triggers/PointerPressedDisposingTrigger.cs
@@ -1,12 +1,12 @@
 using System;
-using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;
 
 namespace BehaviorsTestApplication.Triggers;
 
-public class PointerPressedDisposingTrigger : DisposingTrigger<StyledElement>
+public class PointerPressedDisposingTrigger : DisposingTrigger<Control>
 {
     protected override IDisposable OnAttachedOverride()
     {

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -516,6 +516,45 @@
       <TabItem Header="DataContextChangedTrigger">
         <pages:DataContextChangedTriggerView />
       </TabItem>
+      <TabItem Header="DetachedFromLogicalTreeTrigger">
+        <pages:DetachedFromLogicalTreeTriggerView />
+      </TabItem>
+      <TabItem Header="DetachedFromVisualTreeTrigger">
+        <pages:DetachedFromVisualTreeTriggerView />
+      </TabItem>
+      <TabItem Header="DisposingBehavior">
+        <pages:DisposingBehaviorView />
+      </TabItem>
+      <TabItem Header="DisposingTrigger">
+        <pages:DisposingTriggerView />
+      </TabItem>
+      <TabItem Header="DisposableAction">
+        <pages:DisposableActionView />
+      </TabItem>
+      <TabItem Header="InitializedBehavior">
+        <pages:InitializedBehaviorView />
+      </TabItem>
+      <TabItem Header="InitializedTrigger">
+        <pages:InitializedTriggerView />
+      </TabItem>
+      <TabItem Header="InvokeCommandActionBase">
+        <pages:InvokeCommandActionBaseView />
+      </TabItem>
+      <TabItem Header="LoadedBehavior">
+        <pages:LoadedBehaviorView />
+      </TabItem>
+      <TabItem Header="ResourcesChangedBehavior">
+        <pages:ResourcesChangedBehaviorView />
+      </TabItem>
+      <TabItem Header="ResourcesChangedTrigger">
+        <pages:ResourcesChangedTriggerView />
+      </TabItem>
+      <TabItem Header="RoutedEventTriggerBase">
+        <pages:RoutedEventTriggerBaseView />
+      </TabItem>
+      <TabItem Header="UnloadedTrigger">
+        <pages:UnloadedTriggerView />
+      </TabItem>
     </SingleSelectionTabControl>
   </DockPanel>
 </UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DetachedFromLogicalTreeTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <StackPanel x:Name="Container">
+      <Border x:Name="Target" Background="LightGray" Padding="20">
+        <Interaction.Triggers>
+          <DetachedFromLogicalTreeTrigger>
+            <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Detached" />
+          </DetachedFromLogicalTreeTrigger>
+        </Interaction.Triggers>
+        <TextBlock Text="Target" />
+      </Border>
+    </StackPanel>
+    <Button x:Name="RemoveButton" Content="Remove" Width="80">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="RemoveButton">
+          <RemoveElementAction TargetObject="Target" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <TextBlock x:Name="MessageText" Text="Waiting" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml
@@ -12,11 +12,11 @@
   <StackPanel Spacing="5">
     <StackPanel x:Name="Container">
       <Border x:Name="Target" Background="LightGray" Padding="20">
-        <Interaction.Triggers>
+        <Interaction.Behaviors>
           <DetachedFromLogicalTreeTrigger>
             <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Detached" />
           </DetachedFromLogicalTreeTrigger>
-        </Interaction.Triggers>
+        </Interaction.Behaviors>
         <TextBlock Text="Target" />
       </Border>
     </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DetachedFromLogicalTreeTriggerView : UserControl
+{
+    public DetachedFromLogicalTreeTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml
@@ -12,11 +12,11 @@
   <StackPanel Spacing="5">
     <StackPanel x:Name="Container">
       <Border x:Name="Target" Background="LightGray" Padding="20">
-        <Interaction.Triggers>
+        <Interaction.Behaviors>
           <DetachedFromVisualTreeTrigger>
             <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Detached" />
           </DetachedFromVisualTreeTrigger>
-        </Interaction.Triggers>
+        </Interaction.Behaviors>
         <TextBlock Text="Target" />
       </Border>
     </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DetachedFromVisualTreeTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <StackPanel x:Name="Container">
+      <Border x:Name="Target" Background="LightGray" Padding="20">
+        <Interaction.Triggers>
+          <DetachedFromVisualTreeTrigger>
+            <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Detached" />
+          </DetachedFromVisualTreeTrigger>
+        </Interaction.Triggers>
+        <TextBlock Text="Target" />
+      </Border>
+    </StackPanel>
+    <Button x:Name="RemoveButton" Content="Remove" Width="80">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="RemoveButton">
+          <RemoveElementAction TargetObject="Target" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <TextBlock x:Name="MessageText" Text="Waiting" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DetachedFromVisualTreeTriggerView : UserControl
+{
+    public DetachedFromVisualTreeTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposableActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposableActionView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DisposableActionView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <b:DisposableActionBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Click me" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposableActionView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposableActionView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DisposableActionView : UserControl
+{
+    public DisposableActionView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposingBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposingBehaviorView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DisposingBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <b:DisposingMessageBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Click me" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposingBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposingBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DisposingBehaviorView : UserControl
+{
+    public DisposingBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml
@@ -12,11 +12,11 @@
   </Design.DataContext>
   <StackPanel Spacing="5">
     <Border x:Name="Target" Background="LightGray" Padding="20">
-      <Interaction.Triggers>
+      <Interaction.Behaviors>
         <t:PointerPressedDisposingTrigger>
           <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Pressed" />
         </t:PointerPressedDisposingTrigger>
-      </Interaction.Triggers>
+      </Interaction.Behaviors>
       <TextBlock Text="Click me" />
     </Border>
     <TextBlock x:Name="MessageText" />

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.DisposingTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:t="using:BehaviorsTestApplication.Triggers"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Triggers>
+        <t:PointerPressedDisposingTrigger>
+          <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Pressed" />
+        </t:PointerPressedDisposingTrigger>
+      </Interaction.Triggers>
+      <TextBlock Text="Click me" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DisposingTriggerView : UserControl
+{
+    public DisposingTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/InitializedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/InitializedBehaviorView.axaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.InitializedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <b:InitializedMessageBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Target" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/InitializedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/InitializedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class InitializedBehaviorView : UserControl
+{
+    public InitializedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml
@@ -11,11 +11,11 @@
   </Design.DataContext>
   <StackPanel Spacing="5">
     <Border x:Name="Target" Background="LightGray" Padding="20">
-      <Interaction.Triggers>
+      <Interaction.Behaviors>
         <InitializedTrigger>
           <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Initialized" />
         </InitializedTrigger>
-      </Interaction.Triggers>
+      </Interaction.Behaviors>
       <TextBlock Text="Target" />
     </Border>
     <TextBlock x:Name="MessageText" />

--- a/samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.InitializedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Triggers>
+        <InitializedTrigger>
+          <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Initialized" />
+        </InitializedTrigger>
+      </Interaction.Triggers>
+      <TextBlock Text="Target" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class InitializedTriggerView : UserControl
+{
+    public InitializedTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionBaseView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionBaseView.axaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.InvokeCommandActionBaseView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Button x:Name="Button" Content="Invoke" Width="80">
+    <Interaction.Behaviors>
+      <EventTriggerBehavior EventName="Click" SourceObject="Button">
+        <InvokeCommandAction Command="{Binding InitializeCommand}" />
+      </EventTriggerBehavior>
+    </Interaction.Behaviors>
+  </Button>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionBaseView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionBaseView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class InvokeCommandActionBaseView : UserControl
+{
+    public InvokeCommandActionBaseView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.LoadedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Button x:Name="Target" Content="Load">
+      <Interaction.Behaviors>
+        <b:LoadedMessageBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+    </Button>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:b="using:BehaviorsTestApplication.Behaviors"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
   <Design.DataContext>
@@ -13,7 +12,7 @@
   <StackPanel Spacing="5">
     <Button x:Name="Target" Content="Load">
       <Interaction.Behaviors>
-        <b:LoadedMessageBehavior Target="{Binding #MessageText}" />
+        <LoadedMessageBehavior Target="{Binding #MessageText}" />
       </Interaction.Behaviors>
     </Button>
     <TextBlock x:Name="MessageText" />

--- a/samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class LoadedBehaviorView : UserControl
+{
+    public LoadedBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
-             xmlns:b="using:BehaviorsTestApplication.Behaviors"
              x:DataType="vm:MainWindowViewModel"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160">
   <Design.DataContext>
@@ -13,7 +12,7 @@
   <StackPanel Spacing="5">
     <Border x:Name="Target" Background="LightGray" Padding="20">
       <Interaction.Behaviors>
-        <b:ResourcesChangedMessageBehavior Target="{Binding #MessageText}" />
+        <ResourcesChangedMessageBehavior Target="{Binding #MessageText}" />
       </Interaction.Behaviors>
       <TextBlock Text="Target" />
     </Border>

--- a/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ResourcesChangedBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <b:ResourcesChangedMessageBehavior Target="{Binding #MessageText}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="Target" />
+    </Border>
+    <Button x:Name="ChangeButton" Content="Change Resource" Width="120" />
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ResourcesChangedBehaviorView : UserControl
+{
+    public ResourcesChangedBehaviorView()
+    {
+        InitializeComponent();
+
+        if (this.FindControl<Button>("ChangeButton") is { } button &&
+            this.FindControl<Border>("Target") is { } border)
+        {
+            button.Click += (_, _) => border.Resources["Color"] = Brushes.Red;
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ResourcesChangedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Triggers>
+        <ResourcesChangedTrigger>
+          <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Resources changed" />
+        </ResourcesChangedTrigger>
+      </Interaction.Triggers>
+      <TextBlock Text="Target" />
+    </Border>
+    <Button x:Name="ChangeButton" Content="Change Resource" Width="120" />
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml
@@ -11,11 +11,11 @@
   </Design.DataContext>
   <StackPanel Spacing="5">
     <Border x:Name="Target" Background="LightGray" Padding="20">
-      <Interaction.Triggers>
+      <Interaction.Behaviors>
         <ResourcesChangedTrigger>
           <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Resources changed" />
         </ResourcesChangedTrigger>
-      </Interaction.Triggers>
+      </Interaction.Behaviors>
       <TextBlock Text="Target" />
     </Border>
     <Button x:Name="ChangeButton" Content="Change Resource" Width="120" />

--- a/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ResourcesChangedTriggerView : UserControl
+{
+    public ResourcesChangedTriggerView()
+    {
+        InitializeComponent();
+
+        if (this.FindControl<Button>("ChangeButton") is { } button &&
+            this.FindControl<Border>("Target") is { } border)
+        {
+            button.Click += (_, _) => border.Resources["Color"] = Brushes.Blue;
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBaseView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBaseView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.RoutedEventTriggerBaseView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="120">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <Border x:Name="Target" Background="LightGray" Padding="20">
+      <Interaction.Behaviors>
+        <PointerPressedTrigger>
+          <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Pressed" />
+        </PointerPressedTrigger>
+      </Interaction.Behaviors>
+      <TextBlock Text="Press here" />
+    </Border>
+    <TextBlock x:Name="MessageText" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBaseView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBaseView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class RoutedEventTriggerBaseView : UserControl
+{
+    public RoutedEventTriggerBaseView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.UnloadedTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <StackPanel Spacing="5">
+    <StackPanel x:Name="Container">
+      <Border x:Name="Target" Background="LightGray" Padding="20">
+        <Interaction.Triggers>
+          <UnloadedTrigger>
+            <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Unloaded" />
+          </UnloadedTrigger>
+        </Interaction.Triggers>
+        <TextBlock Text="Target" />
+      </Border>
+    </StackPanel>
+    <Button x:Name="RemoveButton" Content="Remove" Width="80">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click" SourceObject="RemoveButton">
+          <RemoveElementAction TargetObject="Target" />
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <TextBlock x:Name="MessageText" Text="Waiting" />
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml
@@ -12,11 +12,11 @@
   <StackPanel Spacing="5">
     <StackPanel x:Name="Container">
       <Border x:Name="Target" Background="LightGray" Padding="20">
-        <Interaction.Triggers>
+        <Interaction.Behaviors>
           <UnloadedTrigger>
             <ChangePropertyAction TargetObject="MessageText" PropertyName="Text" Value="Unloaded" />
           </UnloadedTrigger>
-        </Interaction.Triggers>
+        </Interaction.Behaviors>
         <TextBlock Text="Target" />
       </Border>
     </StackPanel>

--- a/samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class UnloadedTriggerView : UserControl
+{
+    public UnloadedTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add new sample behaviors and triggers using DisposableAction/DisposingBehavior
- add sample pages for new behaviors and triggers
- hook up new samples in MainView
- link new samples in README

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad66d15048321b7d6bb7c45c40671