### PR TITLE
Add additional DataTriggerBehavior tests

### DIFF
--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml
@@ -1,0 +1,24 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.DataTriggerBehavior002"
+        Title="DataTriggerBehavior002">
+  <StackPanel>
+    <Border Name="TargetBorder" IsVisible="False">
+      <StackPanel>
+        <TextBlock Name="TargetTextBlock" />
+      </StackPanel>
+      <Interaction.Behaviors>
+        <DataTriggerBehavior Binding="{Binding #InputTextBox.Text}" ComparisonCondition="Equal" Value="">
+          <ChangePropertyAction PropertyName="IsVisible" Value="False" />
+        </DataTriggerBehavior>
+        <DataTriggerBehavior Binding="{Binding #InputTextBox.Text}" ComparisonCondition="NotEqual" Value="">
+          <ChangePropertyAction PropertyName="IsVisible" Value="True" />
+        </DataTriggerBehavior>
+        <DataTriggerBehavior Binding="{Binding #InputTextBox.Text}" ComparisonCondition="NotEqual" Value="">
+          <ChangePropertyAction TargetObject="TargetTextBlock" PropertyName="Text" Value="{Binding #InputTextBox.Text}" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </Border>
+    <TextBox Name="InputTextBox" Text="" />
+  </StackPanel>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class DataTriggerBehavior002 : Window
+{
+    public DataTriggerBehavior002()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml
@@ -1,0 +1,24 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.DataTriggerBehavior003"
+        Title="DataTriggerBehavior003">
+  <StackPanel>
+    <TextBlock Name="TargetTextBlock" Text="">
+      <Interaction.Behaviors>
+        <DataTriggerBehavior Binding="{Binding #TargetSlider.Value}" ComparisonCondition="LessThan">
+          <DataTriggerBehavior.Value>
+            <x:String>25</x:String>
+          </DataTriggerBehavior.Value>
+          <ChangePropertyAction PropertyName="Text" Value="Less than 25" />
+        </DataTriggerBehavior>
+        <DataTriggerBehavior Binding="{Binding #TargetSlider.Value}" ComparisonCondition="GreaterThanOrEqual">
+          <DataTriggerBehavior.Value>
+            <x:String>25</x:String>
+          </DataTriggerBehavior.Value>
+          <ChangePropertyAction PropertyName="Text" Value="Greater or equal 25" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </TextBlock>
+    <Slider Name="TargetSlider" Minimum="0" Maximum="50" SmallChange="5" Value="0" />
+  </StackPanel>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class DataTriggerBehavior003 : Window
+{
+    public DataTriggerBehavior003()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
@@ -30,4 +30,42 @@ public class DataTriggerBehaviorTests
         Assert.Equal("75", window.TargetTextBox.Text);
         Assert.Equal(75d, window.TargetSlider.Value);
     }
+
+    [AvaloniaFact]
+    public void DataTriggerBehavior_002()
+    {
+        var window = new DataTriggerBehavior002();
+
+        window.Show();
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_002_0.png");
+
+        Assert.False(window.TargetBorder.IsVisible);
+        Assert.Equal(string.Empty, window.TargetTextBlock.Text);
+
+        window.InputTextBox.Text = "Hello";
+
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_002_1.png");
+
+        Assert.True(window.TargetBorder.IsVisible);
+        Assert.Equal("Hello", window.TargetTextBlock.Text);
+    }
+
+    [AvaloniaFact]
+    public void DataTriggerBehavior_003()
+    {
+        var window = new DataTriggerBehavior003();
+
+        window.Show();
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_003_0.png");
+
+        Assert.Equal("Less than 25", window.TargetTextBlock.Text);
+        Assert.Equal(0d, window.TargetSlider.Value);
+
+        window.TargetSlider.Value = 30d;
+
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_003_1.png");
+
+        Assert.Equal("Greater or equal 25", window.TargetTextBlock.Text);
+        Assert.Equal(30d, window.TargetSlider.Value);
+    }
 }


### PR DESCRIPTION
## Summary
- add new test windows for DataTriggerBehavior scenarios
- verify Equal/NotEqual and LessThan/GreaterThanOrEqual logic
- update test suite accordingly

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bb2319a908321a5282c66c4a83500