### PR TITLE
Add more DataTriggerBehavior headless tests

### DIFF
--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml
@@ -1,0 +1,27 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.DataTriggerBehavior002"
+        Title="DataTriggerBehavior002">
+  <StackPanel>
+    <TextBlock Name="TargetTextBlock"
+               Text="">
+      <Interaction.Behaviors>
+        <DataTriggerBehavior Binding="{Binding #TargetCheckBox.IsChecked}"
+                             ComparisonCondition="Equal"
+                             Value="True">
+          <ChangePropertyAction PropertyName="Text"
+                                Value="Checked" />
+        </DataTriggerBehavior>
+        <DataTriggerBehavior Binding="{Binding #TargetCheckBox.IsChecked}"
+                             ComparisonCondition="Equal"
+                             Value="False">
+          <ChangePropertyAction PropertyName="Text"
+                                Value="Unchecked" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </TextBlock>
+    <CheckBox Name="TargetCheckBox"
+              Content="Check"
+              IsChecked="False" />
+  </StackPanel>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior002.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class DataTriggerBehavior002 : Window
+{
+    public DataTriggerBehavior002()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml
@@ -1,0 +1,33 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.DataTriggerBehavior003"
+        Title="DataTriggerBehavior003">
+  <StackPanel>
+    <TextBlock Name="TargetTextBlock"
+               Text="">
+      <Interaction.Behaviors>
+        <DataTriggerBehavior Binding="{Binding #TargetSlider.Value}"
+                             ComparisonCondition="LessThan">
+          <DataTriggerBehavior.Value>
+            <x:String>50</x:String>
+          </DataTriggerBehavior.Value>
+          <ChangePropertyAction PropertyName="Text"
+                                Value="Less than 50" />
+        </DataTriggerBehavior>
+        <DataTriggerBehavior Binding="{Binding #TargetSlider.Value}"
+                             ComparisonCondition="GreaterThanOrEqual">
+          <DataTriggerBehavior.Value>
+            <x:String>50</x:String>
+          </DataTriggerBehavior.Value>
+          <ChangePropertyAction PropertyName="Text"
+                                Value="50 or more" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </TextBlock>
+    <Slider Name="TargetSlider"
+            Minimum="0"
+            Maximum="100"
+            SmallChange="25"
+            Value="0" />
+  </StackPanel>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior003.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class DataTriggerBehavior003 : Window
+{
+    public DataTriggerBehavior003()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
@@ -30,4 +30,44 @@ public class DataTriggerBehaviorTests
         Assert.Equal("75", window.TargetTextBox.Text);
         Assert.Equal(75d, window.TargetSlider.Value);
     }
+
+    [AvaloniaFact]
+    public void DataTriggerBehavior_002()
+    {
+        var window = new DataTriggerBehavior002();
+
+        window.Show();
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_002_0.png");
+
+        Assert.Equal("Unchecked", window.TargetTextBlock.Text);
+        Assert.False(window.TargetCheckBox.IsChecked);
+
+        window.Click(window.TargetCheckBox);
+
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_002_1.png");
+
+        Assert.Equal("Checked", window.TargetTextBlock.Text);
+        Assert.True(window.TargetCheckBox.IsChecked);
+    }
+
+    [AvaloniaFact]
+    public void DataTriggerBehavior_003()
+    {
+        var window = new DataTriggerBehavior003();
+
+        window.Show();
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_003_0.png");
+
+        Assert.Equal("Less than 50", window.TargetTextBlock.Text);
+        Assert.Equal(0d, window.TargetSlider.Value);
+
+        window.TargetSlider.Focus();
+        window.KeyPressQwerty(PhysicalKey.ArrowRight, RawInputModifiers.None);
+        window.KeyPressQwerty(PhysicalKey.ArrowRight, RawInputModifiers.None);
+
+        window.CaptureRenderedFrame()?.Save("DataTriggerBehavior_003_1.png");
+
+        Assert.Equal("50 or more", window.TargetTextBlock.Text);
+        Assert.Equal(50d, window.TargetSlider.Value);
+    }
 }


### PR DESCRIPTION
## Summary
- create additional headless windows for DataTriggerBehavior
- test checkbox and string comparison scenarios

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_685bb665d2808321886de70be258133a