### PR TITLE
Add unit tests for StyledElementBehavior

### DIFF
--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StubStyledElementBehavior.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StubStyledElementBehavior.cs
@@ -1,0 +1,92 @@
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StubStyledElementBehavior : StyledElementBehavior
+{
+    public int AttachCount { get; private set; }
+    public int DetachCount { get; private set; }
+    public int AttachedToVisualTreeCount { get; private set; }
+    public int DetachedFromVisualTreeCount { get; private set; }
+    public int AttachedToLogicalTreeCount { get; private set; }
+    public int DetachedFromLogicalTreeCount { get; private set; }
+    public int LoadedCount { get; private set; }
+    public int UnloadedCount { get; private set; }
+    public int InitializedCount { get; private set; }
+    public int DataContextChangedCount { get; private set; }
+    public int ResourcesChangedCount { get; private set; }
+    public int ActualThemeVariantChangedCount { get; private set; }
+
+    protected override void OnAttached()
+    {
+        AttachCount++;
+        base.OnAttached();
+    }
+
+    protected override void OnDetaching()
+    {
+        DetachCount++;
+        base.OnDetaching();
+    }
+
+    protected override void OnAttachedToVisualTree()
+    {
+        AttachedToVisualTreeCount++;
+        base.OnAttachedToVisualTree();
+    }
+
+    protected override void OnDetachedFromVisualTree()
+    {
+        DetachedFromVisualTreeCount++;
+        base.OnDetachedFromVisualTree();
+    }
+
+    protected override void OnAttachedToLogicalTree()
+    {
+        AttachedToLogicalTreeCount++;
+        base.OnAttachedToLogicalTree();
+    }
+
+    protected override void OnDetachedFromLogicalTree()
+    {
+        DetachedFromLogicalTreeCount++;
+        base.OnDetachedFromLogicalTree();
+    }
+
+    protected override void OnLoaded()
+    {
+        LoadedCount++;
+        base.OnLoaded();
+    }
+
+    protected override void OnUnloaded()
+    {
+        UnloadedCount++;
+        base.OnUnloaded();
+    }
+
+    protected override void OnInitializedEvent()
+    {
+        InitializedCount++;
+        base.OnInitializedEvent();
+    }
+
+    protected override void OnDataContextChangedEvent()
+    {
+        DataContextChangedCount++;
+        base.OnDataContextChangedEvent();
+    }
+
+    protected override void OnResourcesChangedEvent()
+    {
+        ResourcesChangedCount++;
+        base.OnResourcesChangedEvent();
+    }
+
+    protected override void OnActualThemeVariantChangedEvent()
+    {
+        ActualThemeVariantChangedCount++;
+        base.OnActualThemeVariantChangedEvent();
+    }
+}
+

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StubTextBlockBehavior.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StubTextBlockBehavior.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StubTextBlockBehavior : StyledElementBehavior<TextBlock>
+{
+    public int AttachCount { get; private set; }
+
+    protected override void OnAttached()
+    {
+        AttachCount++;
+        base.OnAttached();
+    }
+}
+

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorOfTTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorOfTTests.cs
@@ -1,0 +1,30 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StyledElementBehaviorOfTTests
+{
+    [AvaloniaFact]
+    public void Attach_WrongType_Throws()
+    {
+        var behavior = new StubTextBlockBehavior();
+        var button = new Button();
+
+        Assert.Throws<InvalidOperationException>(() => behavior.Attach(button));
+    }
+
+    [AvaloniaFact]
+    public void Attach_CorrectType_Succeeds()
+    {
+        var behavior = new StubTextBlockBehavior();
+        var textBlock = new TextBlock();
+
+        behavior.Attach(textBlock);
+
+        Assert.Equal(textBlock, behavior.AssociatedObject);
+        Assert.Equal(1, behavior.AttachCount);
+    }
+}
+

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
@@ -1,0 +1,116 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StyledElementBehaviorTests
+{
+    [AvaloniaFact]
+    public void Attach_WithNull_Throws()
+    {
+        var behavior = new StubStyledElementBehavior();
+
+        Assert.Throws<ArgumentNullException>(() => behavior.Attach(null));
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(0, behavior.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_SetsAssociatedObject_AndCallsOnAttached()
+    {
+        var behavior = new StubStyledElementBehavior();
+        var textBlock = new TextBlock();
+
+        behavior.Attach(textBlock);
+
+        Assert.Equal(textBlock, behavior.AssociatedObject);
+        Assert.Equal(1, behavior.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_SameObjectTwice_CallsOnce()
+    {
+        var behavior = new StubStyledElementBehavior();
+        var textBlock = new TextBlock();
+
+        behavior.Attach(textBlock);
+        behavior.Attach(textBlock);
+
+        Assert.Equal(textBlock, behavior.AssociatedObject);
+        Assert.Equal(1, behavior.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_DifferentObjects_Throws()
+    {
+        var behavior = new StubStyledElementBehavior();
+        var first = new TextBlock();
+        var second = new TextBlock();
+
+        behavior.Attach(first);
+        Assert.Throws<InvalidOperationException>(() => behavior.Attach(second));
+        Assert.Equal(first, behavior.AssociatedObject);
+        Assert.Equal(1, behavior.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Detach_ClearsAssociatedObject_AndCallsOnDetaching()
+    {
+        var behavior = new StubStyledElementBehavior();
+        var textBlock = new TextBlock();
+
+        behavior.Attach(textBlock);
+        behavior.Detach();
+
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(1, behavior.DetachCount);
+    }
+
+    [AvaloniaFact]
+    public void DataContext_IsSynchronized()
+    {
+        var behavior = new StubStyledElementBehavior();
+        var textBlock = new TextBlock { DataContext = "initial" };
+
+        behavior.Attach(textBlock);
+        Assert.Equal("initial", behavior.DataContext);
+
+        textBlock.DataContext = "updated";
+        Assert.Equal("updated", behavior.DataContext);
+    }
+
+    [AvaloniaFact]
+    public void BehaviorEvents_InvokeCorrespondingMethods()
+    {
+        var behavior = new StubStyledElementBehavior();
+        var textBlock = new TextBlock();
+
+        behavior.Attach(textBlock);
+        var handler = (IBehaviorEventsHandler)behavior;
+
+        handler.AttachedToVisualTreeEventHandler();
+        handler.DetachedFromVisualTreeEventHandler();
+        handler.AttachedToLogicalTreeEventHandler();
+        handler.DetachedFromLogicalTreeEventHandler();
+        handler.LoadedEventHandler();
+        handler.UnloadedEventHandler();
+        handler.InitializedEventHandler();
+        handler.DataContextChangedEventHandler();
+        handler.ResourcesChangedEventHandler();
+        handler.ActualThemeVariantChangedEventHandler();
+
+        Assert.Equal(1, behavior.AttachedToVisualTreeCount);
+        Assert.Equal(1, behavior.DetachedFromVisualTreeCount);
+        Assert.Equal(1, behavior.AttachedToLogicalTreeCount);
+        Assert.Equal(1, behavior.DetachedFromLogicalTreeCount);
+        Assert.Equal(1, behavior.LoadedCount);
+        Assert.Equal(1, behavior.UnloadedCount);
+        Assert.Equal(1, behavior.InitializedCount);
+        Assert.Equal(1, behavior.DataContextChangedCount);
+        Assert.Equal(1, behavior.ResourcesChangedCount);
+        Assert.Equal(1, behavior.ActualThemeVariantChangedCount);
+    }
+}
+


### PR DESCRIPTION
## Summary
- test attaching/detaching StyledElementBehavior
- test Typed StyledElementBehavior<T>
- add stub behaviors for tests

## Testing
- `dotnet test AvaloniaBehaviors.sln --no-build --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_685bbb1e32a48321bdf5a9d8ff18f6f4