### PR TITLE
Add StyledElementTrigger tests

### DIFF
--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StubTrigger.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StubTrigger.cs
@@ -1,0 +1,21 @@
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StubTrigger : StyledElementTrigger
+{
+    public int AttachCount { get; private set; }
+    public int DetachCount { get; private set; }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AttachCount++;
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        DetachCount++;
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerOfTTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerOfTTests.cs
@@ -1,6 +1,32 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class TriggerOfTTests
 {
-    // TODO:
+    private class ButtonTrigger : StyledElementTrigger<Button>
+    {
+    }
+
+    [AvaloniaFact]
+    public void Attach_WrongType_Throws()
+    {
+        var trigger = new ButtonTrigger();
+
+        Assert.Throws<InvalidOperationException>(() => trigger.Attach(new TextBox()));
+    }
+
+    [AvaloniaFact]
+    public void Attach_CorrectType_SetsAssociatedObject()
+    {
+        var trigger = new ButtonTrigger();
+        var button = new Button();
+
+        trigger.Attach(button);
+
+        Assert.Equal(button, trigger.AssociatedObject);
+    }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerTests.cs
@@ -1,6 +1,82 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class TriggerTests
 {
-    // TODO:
+    [AvaloniaFact]
+    public void Constructor_InitializesActionCollection()
+    {
+        var trigger = new StubTrigger();
+
+        Assert.NotNull(trigger.Actions);
+        Assert.Empty(trigger.Actions!);
+    }
+
+    [AvaloniaFact]
+    public void Initialize_InitializesActions()
+    {
+        var trigger = new StubTrigger();
+        var action = new StubAction();
+        trigger.Actions!.Add(action);
+
+        trigger.Initialize();
+
+        Assert.True(action.IsInitialized);
+    }
+
+    [AvaloniaFact]
+    public void Attach_ToTopLevel_AttachesActions()
+    {
+        var window = new Window();
+        var trigger = new StubTrigger();
+        var action = new StubAction();
+        trigger.Actions!.Add(action);
+
+        trigger.Initialize();
+        trigger.Attach(window);
+
+        Assert.Equal(window, action.Parent);
+        Assert.Equal(1, trigger.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Detach_FromTopLevel_DetachesActions()
+    {
+        var window = new Window();
+        var trigger = new StubTrigger();
+        var action = new StubAction();
+        trigger.Actions!.Add(action);
+
+        trigger.Initialize();
+        trigger.Attach(window);
+        trigger.DetachBehaviorFromLogicalTree();
+
+        Assert.Null(action.Parent);
+    }
+
+    [AvaloniaFact]
+    public void ActionsPropertyChange_DetachesOldAndAttachesNew()
+    {
+        var window = new Window();
+        var trigger = new StubTrigger();
+        var oldAction = new StubAction();
+        trigger.Actions!.Add(oldAction);
+
+        trigger.Initialize();
+        trigger.Attach(window);
+
+        Assert.Equal(window, oldAction.Parent);
+
+        var newAction = new StubAction();
+        var collection = new ActionCollection { newAction };
+
+        trigger.Actions = collection;
+
+        Assert.Null(oldAction.Parent);
+        Assert.Equal(window, newAction.Parent);
+        Assert.True(newAction.IsInitialized);
+    }
 }


### PR DESCRIPTION
## Summary
- add `StubTrigger` test helper
- test initialization and attachment logic of `StyledElementTrigger`
- verify type safety of `StyledElementTrigger<T>`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685bbb3042548321995a606fb8f11e9a