### PR TITLE
Add Behavior tests

### DIFF
--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/BehaviorOfTTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/BehaviorOfTTests.cs
@@ -1,6 +1,44 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class BehaviorOfTTests
 {
-    // TODO:
+    [AvaloniaFact]
+    public void Attach_Correct_Type_Sets_Typed_AssociatedObject()
+    {
+        var behavior = new TestBehaviorOfT();
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.Equal(button, behavior.AssociatedObject);
+        Assert.Equal(1, behavior.AttachedCalled);
+    }
+
+    [AvaloniaFact]
+    public void Attach_Wrong_Type_Throws()
+    {
+        var behavior = new TestBehaviorOfT();
+        var textBlock = new TextBlock();
+
+        Assert.Throws<InvalidOperationException>(() => behavior.Attach(textBlock));
+    }
+
+    [AvaloniaFact]
+    public void Detach_After_Attach_Clears_AssociatedObject()
+    {
+        var behavior = new TestBehaviorOfT();
+        var button = new Button();
+
+        behavior.Attach(button);
+        behavior.Detach();
+
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(1, behavior.DetachingCalled);
+    }
 }
+

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/BehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/BehaviorTests.cs
@@ -1,6 +1,96 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class BehaviorTests
 {
-    // TODO:
+    [AvaloniaFact]
+    public void Attach_Sets_AssociatedObject()
+    {
+        var behavior = new TestBehavior();
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.Equal(button, behavior.AssociatedObject);
+        Assert.Equal(1, behavior.AttachedCalled);
+    }
+
+    [AvaloniaFact]
+    public void Attach_Same_Object_No_Op()
+    {
+        var behavior = new TestBehavior();
+        var button = new Button();
+
+        behavior.Attach(button);
+        behavior.Attach(button);
+
+        Assert.Equal(1, behavior.AttachedCalled);
+    }
+
+    [AvaloniaFact]
+    public void Attach_Null_Does_Nothing()
+    {
+        var behavior = new TestBehavior();
+
+        behavior.Attach(null);
+
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(0, behavior.AttachedCalled);
+    }
+
+    [AvaloniaFact]
+    public void Attach_Different_Object_Throws()
+    {
+        var behavior = new TestBehavior();
+        behavior.Attach(new Button());
+
+        Assert.Throws<InvalidOperationException>(() => behavior.Attach(new Button()));
+    }
+
+    [AvaloniaFact]
+    public void Detach_Clears_AssociatedObject()
+    {
+        var behavior = new TestBehavior();
+        var button = new Button();
+
+        behavior.Attach(button);
+        behavior.Detach();
+
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(1, behavior.DetachingCalled);
+    }
+
+    [AvaloniaFact]
+    public void Behavior_Event_Methods_Invoke_Overrides()
+    {
+        var behavior = new TestBehavior();
+        var handler = (IBehaviorEventsHandler)behavior;
+
+        handler.AttachedToVisualTreeEventHandler();
+        handler.DetachedFromVisualTreeEventHandler();
+        handler.AttachedToLogicalTreeEventHandler();
+        handler.DetachedFromLogicalTreeEventHandler();
+        handler.LoadedEventHandler();
+        handler.UnloadedEventHandler();
+        handler.InitializedEventHandler();
+        handler.DataContextChangedEventHandler();
+        handler.ResourcesChangedEventHandler();
+        handler.ActualThemeVariantChangedEventHandler();
+
+        Assert.Equal(1, behavior.VisualAttachCalled);
+        Assert.Equal(1, behavior.VisualDetachCalled);
+        Assert.Equal(1, behavior.LogicalAttachCalled);
+        Assert.Equal(1, behavior.LogicalDetachCalled);
+        Assert.Equal(1, behavior.LoadedCalled);
+        Assert.Equal(1, behavior.UnloadedCalled);
+        Assert.Equal(1, behavior.InitializedCalled);
+        Assert.Equal(1, behavior.DataContextChangedCalled);
+        Assert.Equal(1, behavior.ResourcesChangedCalled);
+        Assert.Equal(1, behavior.ThemeChangedCalled);
+    }
 }
+

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/TestBehaviors.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/TestBehaviors.cs
@@ -1,0 +1,100 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+internal class TestBehavior : Behavior
+{
+    public int AttachedCalled { get; private set; }
+    public int DetachingCalled { get; private set; }
+    public int VisualAttachCalled { get; private set; }
+    public int VisualDetachCalled { get; private set; }
+    public int LogicalAttachCalled { get; private set; }
+    public int LogicalDetachCalled { get; private set; }
+    public int LoadedCalled { get; private set; }
+    public int UnloadedCalled { get; private set; }
+    public int InitializedCalled { get; private set; }
+    public int DataContextChangedCalled { get; private set; }
+    public int ResourcesChangedCalled { get; private set; }
+    public int ThemeChangedCalled { get; private set; }
+
+    protected override void OnAttached()
+    {
+        AttachedCalled++;
+    }
+
+    protected override void OnDetaching()
+    {
+        DetachingCalled++;
+    }
+
+    protected override void OnAttachedToVisualTree()
+    {
+        VisualAttachCalled++;
+    }
+
+    protected override void OnDetachedFromVisualTree()
+    {
+        VisualDetachCalled++;
+    }
+
+    protected override void OnAttachedToLogicalTree()
+    {
+        LogicalAttachCalled++;
+    }
+
+    protected override void OnDetachedFromLogicalTree()
+    {
+        LogicalDetachCalled++;
+    }
+
+    protected override void OnLoaded()
+    {
+        LoadedCalled++;
+    }
+
+    protected override void OnUnloaded()
+    {
+        UnloadedCalled++;
+    }
+
+    protected override void OnInitializedEvent()
+    {
+        InitializedCalled++;
+    }
+
+    protected override void OnDataContextChangedEvent()
+    {
+        DataContextChangedCalled++;
+    }
+
+    protected override void OnResourcesChangedEvent()
+    {
+        ResourcesChangedCalled++;
+    }
+
+    protected override void OnActualThemeVariantChangedEvent()
+    {
+        ThemeChangedCalled++;
+    }
+}
+
+internal class TestBehaviorOfT : Behavior<Button>
+{
+    public int AttachedCalled { get; private set; }
+    public int DetachingCalled { get; private set; }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AttachedCalled++;
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        DetachingCalled++;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `TestBehavior` and `TestBehaviorOfT` stubs for unit testing
- add headless unit tests for `Behavior`
- add headless unit tests for `Behavior<T>`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685bbb4a24a88321bb35619521edf827