### PR TITLE
Add tests for Trigger classes

### DIFF
--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StubTrigger.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StubTrigger.cs
@@ -1,0 +1,39 @@
+using Avalonia;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StubTrigger : Trigger
+{
+    public int AttachCount { get; private set; }
+    public int DetachCount { get; private set; }
+
+    protected override void OnAttached()
+    {
+        AttachCount++;
+        base.OnAttached();
+    }
+
+    protected override void OnDetaching()
+    {
+        DetachCount++;
+        base.OnDetaching();
+    }
+}
+
+public class StubTrigger<T> : Trigger<T> where T : AvaloniaObject
+{
+    public int AttachCount { get; private set; }
+    public int DetachCount { get; private set; }
+
+    protected override void OnAttached()
+    {
+        AttachCount++;
+        base.OnAttached();
+    }
+
+    protected override void OnDetaching()
+    {
+        DetachCount++;
+        base.OnDetaching();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerOfTTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerOfTTests.cs
@@ -1,6 +1,52 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class TriggerOfTTests
 {
-    // TODO:
+    [AvaloniaFact]
+    public void Attach_CorrectType_AssociatedObjectSet()
+    {
+        var trigger = new StubTrigger<Button>();
+        var button = new Button();
+        trigger.Attach(button);
+
+        Assert.Equal(button, trigger.AssociatedObject);
+        Assert.Equal(1, trigger.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_DerivedType_AssociatedObjectSet()
+    {
+        var trigger = new StubTrigger<Button>();
+        var toggle = new ToggleButton();
+        trigger.Attach(toggle);
+
+        Assert.Equal(toggle, trigger.AssociatedObject);
+        Assert.Equal(1, trigger.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_WrongType_Throws()
+    {
+        var trigger = new StubTrigger<Button>();
+        var textBlock = new TextBlock();
+
+        TestUtilities.AssertThrowsInvalidOperationException(() => trigger.Attach(textBlock));
+    }
+
+    [AvaloniaFact]
+    public void Detach_ClearsAssociatedObject()
+    {
+        var trigger = new StubTrigger<Button>();
+        var button = new Button();
+        trigger.Attach(button);
+        trigger.Detach();
+
+        Assert.Null(trigger.AssociatedObject);
+        Assert.Equal(1, trigger.DetachCount);
+    }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/TriggerTests.cs
@@ -1,6 +1,76 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class TriggerTests
 {
-    // TODO:
+    [AvaloniaFact]
+    public void Actions_Default_NotNull()
+    {
+        var trigger = new StubTrigger();
+        Assert.NotNull(trigger.Actions);
+        Assert.Empty(trigger.Actions);
+    }
+
+    [AvaloniaFact]
+    public void Actions_MultipleCalls_ReturnSameInstance()
+    {
+        var trigger = new StubTrigger();
+        var first = trigger.Actions;
+        var second = trigger.Actions;
+        Assert.Same(first, second);
+    }
+
+    [AvaloniaFact]
+    public void Attach_SetsAssociatedObject()
+    {
+        var trigger = new StubTrigger();
+        var button = new Button();
+        trigger.Attach(button);
+
+        Assert.Equal(button, trigger.AssociatedObject);
+        Assert.Equal(1, trigger.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_SameObjectTwice_DoesNotReattach()
+    {
+        var trigger = new StubTrigger();
+        var button = new Button();
+        trigger.Attach(button);
+        trigger.Attach(button);
+
+        Assert.Equal(1, trigger.AttachCount);
+    }
+
+    [AvaloniaFact]
+    public void Attach_DifferentObject_Throws()
+    {
+        var trigger = new StubTrigger();
+        trigger.Attach(new Button());
+
+        TestUtilities.AssertThrowsInvalidOperationException(() => trigger.Attach(new Button()));
+    }
+
+    [AvaloniaFact]
+    public void Attach_Null_Throws()
+    {
+        var trigger = new StubTrigger();
+        Assert.Throws<ArgumentNullException>(() => trigger.Attach(null));
+    }
+
+    [AvaloniaFact]
+    public void Detach_ClearsAssociatedObject()
+    {
+        var trigger = new StubTrigger();
+        var button = new Button();
+        trigger.Attach(button);
+        trigger.Detach();
+
+        Assert.Null(trigger.AssociatedObject);
+        Assert.Equal(1, trigger.DetachCount);
+    }
 }


### PR DESCRIPTION
## Summary
- implement StubTrigger helpers for testing
- add TriggerTests verifying base Trigger behavior
- add TriggerOfTTests verifying typed trigger behavior

## Testing
- `dotnet test AvaloniaBehaviors.sln --no-build --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_685bbb540b2c83219c577b938833f875