### PR TITLE
Add documentation table of contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Documentation
+
+Welcome to the project documentation. Below is the table of contents that mirrors the structure of the main README.
+
+## Table of Contents
+
+- [Building Avalonia XAML Behaviors](../README.md#building-avalonia-xaml-behaviors)
+  - [Build on Windows using script](../README.md#build-on-windows-using-script)
+  - [Build on Linux using script](../README.md#build-on-linux-using-script)
+  - [Build on OSX using script](../README.md#build-on-osx-using-script)
+- [NuGet](../README.md#nuget)
+  - [Package Sources](../README.md#package-sources)
+  - [Available Packages](../README.md#available-packages)
+- [Getting Started](../README.md#getting-started)
+  - [Adding Behaviors in XAML](../README.md#adding-behaviors-in-xaml)
+  - [Basic Examples](../README.md#basic-examples)
+  - [How It Works](../README.md#how-it-works)
+  - [Advanced Usage](../README.md#advanced-usage)
+- [Docs](../README.md#docs)
+- [Interactions](../README.md#interactions)
+- [Interactivity (Infrastructure)](../README.md#interactivity-infrastructure)
+- [Resources](../README.md#resources)
+- [License](../README.md#license)
+
+For detailed information about each section, refer to the [project README](../README.md).


### PR DESCRIPTION
## Summary
- create `docs` folder
- add `docs/README.md` with a table of contents referencing main README

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_68795fef7c388321a0550d10c6e237ca