### PR TITLE
Add DragDropCommandsBehavior and sample

### DIFF
--- a/samples/BehaviorsTestApplication/ViewModels/DragDropCommandsViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/DragDropCommandsViewModel.cs
@@ -1,0 +1,29 @@
+using System.Windows.Input;
+using Avalonia.Input;
+using ReactiveUI;
+
+namespace BehaviorsTestApplication.ViewModels;
+
+public class DragDropCommandsViewModel : ViewModelBase
+{
+    private string _status = "Waiting";
+
+    public string Status
+    {
+        get => _status;
+        set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    public ICommand EnterCommand { get; }
+    public ICommand OverCommand { get; }
+    public ICommand LeaveCommand { get; }
+    public ICommand DropCommand { get; }
+
+    public DragDropCommandsViewModel()
+    {
+        EnterCommand = ReactiveCommand.Create<DragEventArgs>(_ => Status = "DragEnter");
+        OverCommand = ReactiveCommand.Create<DragEventArgs>(_ => Status = "DragOver");
+        LeaveCommand = ReactiveCommand.Create<DragEventArgs>(_ => Status = "DragLeave");
+        DropCommand = ReactiveCommand.Create<DragEventArgs>(_ => Status = "Dropped");
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -297,6 +297,9 @@
       <TabItem Header="Drag and Drop">
         <pages:DragAndDropView />
       </TabItem>
+      <TabItem Header="DragDrop Commands">
+        <pages:DragDropCommandsView />
+      </TabItem>
       <TabItem Header="Files Preview">
         <pages:FilesPreviewView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/DragDropCommandsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DragDropCommandsView.axaml
@@ -1,0 +1,31 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:Class="BehaviorsTestApplication.Views.Pages.DragDropCommandsView"
+             x:DataType="vm:DragDropCommandsViewModel"
+             x:CompileBindings="True"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200">
+  <Design.DataContext>
+    <vm:DragDropCommandsViewModel />
+  </Design.DataContext>
+
+  <StackPanel Spacing="12" Margin="5">
+    <Border Background="LightGray" Height="100" CornerRadius="4">
+      <Interaction.Behaviors>
+        <DragDropCommandsBehavior DragEnterCommand="{Binding EnterCommand}"
+                                   DragOverCommand="{Binding OverCommand}"
+                                   DragLeaveCommand="{Binding LeaveCommand}"
+                                   DropCommand="{Binding DropCommand}" />
+      </Interaction.Behaviors>
+      <TextBlock Text="{Binding Status}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Border>
+
+    <Rectangle Fill="SkyBlue" Width="80" Height="40" HorizontalAlignment="Center">
+      <Interaction.Behaviors>
+        <ContextDragBehavior Context="DragMe" />
+      </Interaction.Behaviors>
+    </Rectangle>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/DragDropCommandsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DragDropCommandsView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using BehaviorsTestApplication.ViewModels;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class DragDropCommandsView : UserControl
+{
+    public DragDropCommandsView()
+    {
+        InitializeComponent();
+        DataContext = new DragDropCommandsViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DragDropCommandsBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DragDropCommandsBehavior.cs
@@ -1,0 +1,102 @@
+using System.Windows.Input;
+using Avalonia.Input;
+
+namespace Avalonia.Xaml.Interactions.DragAndDrop;
+
+/// <summary>
+/// Behavior that exposes commands for drag-and-drop events.
+/// </summary>
+public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
+{
+    /// <summary>
+    /// Identifies the <see cref="DragEnterCommand"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> DragEnterCommandProperty =
+        AvaloniaProperty.Register<DragDropCommandsBehavior, ICommand?>(nameof(DragEnterCommand));
+
+    /// <summary>
+    /// Identifies the <see cref="DragOverCommand"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> DragOverCommandProperty =
+        AvaloniaProperty.Register<DragDropCommandsBehavior, ICommand?>(nameof(DragOverCommand));
+
+    /// <summary>
+    /// Identifies the <see cref="DragLeaveCommand"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> DragLeaveCommandProperty =
+        AvaloniaProperty.Register<DragDropCommandsBehavior, ICommand?>(nameof(DragLeaveCommand));
+
+    /// <summary>
+    /// Identifies the <see cref="DropCommand"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> DropCommandProperty =
+        AvaloniaProperty.Register<DragDropCommandsBehavior, ICommand?>(nameof(DropCommand));
+
+    /// <summary>
+    /// Gets or sets the command invoked on drag enter.
+    /// </summary>
+    public ICommand? DragEnterCommand
+    {
+        get => GetValue(DragEnterCommandProperty);
+        set => SetValue(DragEnterCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command invoked on drag over.
+    /// </summary>
+    public ICommand? DragOverCommand
+    {
+        get => GetValue(DragOverCommandProperty);
+        set => SetValue(DragOverCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command invoked on drag leave.
+    /// </summary>
+    public ICommand? DragLeaveCommand
+    {
+        get => GetValue(DragLeaveCommandProperty);
+        set => SetValue(DragLeaveCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command invoked on drop.
+    /// </summary>
+    public ICommand? DropCommand
+    {
+        get => GetValue(DropCommandProperty);
+        set => SetValue(DropCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Specifies whether the event args should be passed to the command.
+    /// </summary>
+    public bool PassEventArgsToCommand { get; set; } = true;
+
+    private void ExecuteCommand(ICommand? command, DragEventArgs e)
+    {
+        if (command is null)
+        {
+            return;
+        }
+
+        var parameter = PassEventArgsToCommand ? (object?)e : null;
+
+        if (command.CanExecute(parameter))
+        {
+            command.Execute(parameter);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDragEnter(object? sender, DragEventArgs e) => ExecuteCommand(DragEnterCommand, e);
+
+    /// <inheritdoc />
+    protected override void OnDragOver(object? sender, DragEventArgs e) => ExecuteCommand(DragOverCommand, e);
+
+    /// <inheritdoc />
+    protected override void OnDragLeave(object? sender, DragEventArgs e) => ExecuteCommand(DragLeaveCommand, e);
+
+    /// <inheritdoc />
+    protected override void OnDrop(object? sender, DragEventArgs e) => ExecuteCommand(DropCommand, e);
+}


### PR DESCRIPTION
## Summary
- implement **DragDropCommandsBehavior** to expose commands for drag/drop events
- demonstrate usage in new `DragDropCommandsView` sample page
- wire new page into the sample app

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687abce7a1dc8321ae45262a98df7753