### PR TITLE
Add interactions docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the project documentation. Below is the table of contents that mirror
   - [Advanced Usage](../README.md#advanced-usage)
 - [Docs](../README.md#docs)
 - [Interactions](../README.md#interactions)
+- [Interactions Index](interactions.md)
 - [Interactivity (Infrastructure)](../README.md#interactivity-infrastructure)
 - [Resources](../README.md#resources)
 - [License](../README.md#license)

--- a/docs/actions/Action.md
+++ b/docs/actions/Action.md
@@ -1,0 +1,19 @@
+# Action
+
+Namespace: ``
+
+The base class for actions that can be executed by triggers.
+
+Example: [RemoveElementActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/RemoveElementActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <:Action/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/AddClassAction.md
+++ b/docs/actions/AddClassAction.md
@@ -1,0 +1,19 @@
+# AddClassAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Adds a style class to a control’s class collection, making it easy to change the appearance dynamically.
+
+Example: [AddRemoveClassActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/AddRemoveClassActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:AddClassAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/AddItemToItemsControlAction.md
+++ b/docs/actions/AddItemToItemsControlAction.md
@@ -1,0 +1,19 @@
+# AddItemToItemsControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Adds an item to an ItemsControl's collection.
+
+Example: [AddItemToItemsControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/AddItemToItemsControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:AddItemToItemsControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/AddRangeAction.md
+++ b/docs/actions/AddRangeAction.md
@@ -1,0 +1,19 @@
+# AddRangeAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Adds multiple items to an `IList`.
+
+Example: [AddRangeActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/AddRangeActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:AddRangeAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/AddTransitionAction.md
+++ b/docs/actions/AddTransitionAction.md
@@ -1,0 +1,19 @@
+# AddTransitionAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Adds a transition to a control's `Transitions` collection.
+
+Example: [TransitionsActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/TransitionsActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:AddTransitionAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ApplyTreeViewFilterAction.md
+++ b/docs/actions/ApplyTreeViewFilterAction.md
@@ -1,0 +1,19 @@
+# ApplyTreeViewFilterAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Filters the target TreeView using a provided query.
+
+Example: [TreeViewFilterView.axaml](samples/BehaviorsTestApplication/Views/Pages/TreeViewFilterView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ApplyTreeViewFilterAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/BeginAnimationAction.md
+++ b/docs/actions/BeginAnimationAction.md
@@ -1,0 +1,19 @@
+# BeginAnimationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Starts an animation on a specified control, allowing the target to be chosen explicitly.
+
+Example: [AnimationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AnimationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:BeginAnimationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/CallMethodAction.md
+++ b/docs/actions/CallMethodAction.md
@@ -1,0 +1,19 @@
+# CallMethodAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Invokes a method on a target object when the action is executed.
+
+Example: [CallMethodActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/CallMethodActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:CallMethodAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/CapturePointerAction.md
+++ b/docs/actions/CapturePointerAction.md
@@ -1,0 +1,19 @@
+# CapturePointerAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Captures the pointer (mouse, touch) to a target control so that subsequent pointer events are routed there.
+
+Example: [PointerTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:CapturePointerAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/CarouselNextAction.md
+++ b/docs/actions/CarouselNextAction.md
@@ -1,0 +1,19 @@
+# CarouselNextAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Advances the target Carousel to the next page.
+
+Example: [CarouselNavigationView.axaml](samples/BehaviorsTestApplication/Views/Pages/CarouselNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:CarouselNextAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/CarouselPreviousAction.md
+++ b/docs/actions/CarouselPreviousAction.md
@@ -1,0 +1,19 @@
+# CarouselPreviousAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Moves the target Carousel to the previous page.
+
+Example: [CarouselNavigationView.axaml](samples/BehaviorsTestApplication/Views/Pages/CarouselNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:CarouselPreviousAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ChangeAvaloniaPropertyAction.md
+++ b/docs/actions/ChangeAvaloniaPropertyAction.md
@@ -1,0 +1,19 @@
+# ChangeAvaloniaPropertyAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Changes the value of an Avalonia property on a target object at runtime.
+
+Example: [ChangeAvaloniaPropertyActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ChangeAvaloniaPropertyActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ChangeAvaloniaPropertyAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ChangePropertyAction.md
+++ b/docs/actions/ChangePropertyAction.md
@@ -1,0 +1,19 @@
+# ChangePropertyAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Changes a property on a target object to a new value using type conversion if needed.
+
+Example: [ChangePropertyActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ChangePropertyActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:ChangePropertyAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ClearAutoCompleteBoxSelectionAction.md
+++ b/docs/actions/ClearAutoCompleteBoxSelectionAction.md
@@ -1,0 +1,19 @@
+# ClearAutoCompleteBoxSelectionAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Clears the AutoCompleteBox selection and text.
+
+Example: [AutoCompleteBoxView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutoCompleteBoxView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ClearAutoCompleteBoxSelectionAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ClearClipboardAction.md
+++ b/docs/actions/ClearClipboardAction.md
@@ -1,0 +1,19 @@
+# ClearClipboardAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Clears all contents from the system clipboard.
+
+Example: [ClipboardView.axaml](samples/BehaviorsTestApplication/Views/Pages/ClipboardView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:ClearClipboardAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ClearCollectionAction.md
+++ b/docs/actions/ClearCollectionAction.md
@@ -1,0 +1,19 @@
+# ClearCollectionAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Clears all items from an `IList`.
+
+Example: [AddRangeActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/AddRangeActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ClearCollectionAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ClearItemsControlAction.md
+++ b/docs/actions/ClearItemsControlAction.md
@@ -1,0 +1,19 @@
+# ClearItemsControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Clears all items from an ItemsControl.
+
+Example: [ClearItemsControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ClearItemsControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ClearItemsControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ClearNavigationStackAction.md
+++ b/docs/actions/ClearNavigationStackAction.md
@@ -1,0 +1,19 @@
+# ClearNavigationStackAction
+
+Namespace: `Avalonia.Xaml.Interactions.ReactiveUI`
+
+Resets the ReactiveUI navigation stack.
+
+Example: [ReactiveNavigationView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/ReactiveNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.ReactiveUI:ClearNavigationStackAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ClearTransitionsAction.md
+++ b/docs/actions/ClearTransitionsAction.md
@@ -1,0 +1,19 @@
+# ClearTransitionsAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Clears all transitions from a control.
+
+Example: [TransitionsActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/TransitionsActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ClearTransitionsAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/CloseNotificationAction.md
+++ b/docs/actions/CloseNotificationAction.md
@@ -1,0 +1,19 @@
+# CloseNotificationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Closes an open notification, for example, from a notification control.
+
+Example: [ShowNotificationActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:CloseNotificationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/CloseWindowAction.md
+++ b/docs/actions/CloseWindowAction.md
@@ -1,0 +1,19 @@
+# CloseWindowAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Closes a window when executed.
+
+Example: [DialogActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/DialogActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:CloseWindowAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/DelayedShowControlAction.md
+++ b/docs/actions/DelayedShowControlAction.md
@@ -1,0 +1,19 @@
+# DelayedShowControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a control after waiting for a specified delay.
+
+Example: [DelayedShowControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/DelayedShowControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:DelayedShowControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/DisposableAction.md
+++ b/docs/actions/DisposableAction.md
@@ -1,0 +1,19 @@
+# DisposableAction
+
+Namespace: `Avalonia.Xaml.Interactivity`
+
+Executes a delegate when the object is disposed.
+
+Example: [DisposableActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/DisposableActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactivity:DisposableAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ExecuteScriptAction.md
+++ b/docs/actions/ExecuteScriptAction.md
@@ -1,0 +1,19 @@
+# ExecuteScriptAction
+
+Namespace: `Avalonia.Xaml.Interactions.Scripting`
+
+Executes a C# script using the Roslyn scripting API.
+
+Example: [ExecuteScriptActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ExecuteScriptActionView.axaml)
+
+## Key Properties
+- `UseDispatcher`
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Scripting:ExecuteScriptAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/FocusControlAction.md
+++ b/docs/actions/FocusControlAction.md
@@ -1,0 +1,19 @@
+# FocusControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the keyboard focus on a specified control or the associated control.
+
+Example: [FocusControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:FocusControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/GetClipboardDataAction.md
+++ b/docs/actions/GetClipboardDataAction.md
@@ -1,0 +1,19 @@
+# GetClipboardDataAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Retrieves data from the clipboard in a specified format.
+
+Example: [GetClipboardDataActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/GetClipboardDataActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:GetClipboardDataAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/GetClipboardFormatsAction.md
+++ b/docs/actions/GetClipboardFormatsAction.md
@@ -1,0 +1,19 @@
+# GetClipboardFormatsAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Retrieves the list of available formats from the clipboard.
+
+Example: [GetClipboardFormatsActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/GetClipboardFormatsActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:GetClipboardFormatsAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/GetClipboardTextAction.md
+++ b/docs/actions/GetClipboardTextAction.md
@@ -1,0 +1,19 @@
+# GetClipboardTextAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Retrieves plain text from the clipboard.
+
+Example: [ClipboardView.axaml](samples/BehaviorsTestApplication/Views/Pages/ClipboardView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:GetClipboardTextAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/HideContextDialogAction.md
+++ b/docs/actions/HideContextDialogAction.md
@@ -1,0 +1,19 @@
+# HideContextDialogAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Closes a context dialog using a specified behavior.
+
+Example: [ContextDialogView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:HideContextDialogAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/HideControlAction.md
+++ b/docs/actions/HideControlAction.md
@@ -1,0 +1,19 @@
+# HideControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides a control by setting its `IsVisible` property to false.
+
+Example: [HideShowControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:HideControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/HideFlyoutAction.md
+++ b/docs/actions/HideFlyoutAction.md
@@ -1,0 +1,19 @@
+# HideFlyoutAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides a flyout attached to a control or specified explicitly.
+
+Example: [ShowHideFlyoutActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:HideFlyoutAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/HidePopupAction.md
+++ b/docs/actions/HidePopupAction.md
@@ -1,0 +1,19 @@
+# HidePopupAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Closes an existing popup associated with a control.
+
+Example: [ShowHidePopupActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowHidePopupActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:HidePopupAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/HideToolTipAction.md
+++ b/docs/actions/HideToolTipAction.md
@@ -1,0 +1,19 @@
+# HideToolTipAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides the ToolTip of the target control.
+
+Example: [ToolTipHelpersView.axaml](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:HideToolTipAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/IAction.md
+++ b/docs/actions/IAction.md
@@ -1,0 +1,19 @@
+# IAction
+
+Namespace: ``
+
+Interface that defines the Execute method for custom actions.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <:IAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/IncrementViewModelPropertyAction.md
+++ b/docs/actions/IncrementViewModelPropertyAction.md
@@ -1,0 +1,19 @@
+# IncrementViewModelPropertyAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Adds a numeric delta to a view model property.
+
+Example: [ViewModelPropertyActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:IncrementViewModelPropertyAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/InsertItemToItemsControlAction.md
+++ b/docs/actions/InsertItemToItemsControlAction.md
@@ -1,0 +1,19 @@
+# InsertItemToItemsControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Inserts an item at a specific index in an ItemsControl.
+
+Example: [InsertItemToItemsControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/InsertItemToItemsControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:InsertItemToItemsControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/InvokeCommandAction.md
+++ b/docs/actions/InvokeCommandAction.md
@@ -1,0 +1,19 @@
+# InvokeCommandAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Executes a bound ICommand when the action is invoked.
+
+Example: [InvokeCommandActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/InvokeCommandActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:InvokeCommandAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/LaunchUriOrFileAction.md
+++ b/docs/actions/LaunchUriOrFileAction.md
@@ -1,0 +1,19 @@
+# LaunchUriOrFileAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Opens a URI or file using the default associated application.
+
+Example: [LaunchUriOrFileActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/LaunchUriOrFileActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:LaunchUriOrFileAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/MoveElementToPanelAction.md
+++ b/docs/actions/MoveElementToPanelAction.md
@@ -1,0 +1,19 @@
+# MoveElementToPanelAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Moves a control to the specified panel.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:MoveElementToPanelAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/NavigateAction.md
+++ b/docs/actions/NavigateAction.md
@@ -1,0 +1,19 @@
+# NavigateAction
+
+Namespace: `Avalonia.Xaml.Interactions.ReactiveUI`
+
+Navigates to a specified `IRoutableViewModel` using a router.
+
+Example: [ReactiveNavigationView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/ReactiveNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.ReactiveUI:NavigateAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/NavigateBackAction.md
+++ b/docs/actions/NavigateBackAction.md
@@ -1,0 +1,19 @@
+# NavigateBackAction
+
+Namespace: `Avalonia.Xaml.Interactions.ReactiveUI`
+
+Navigates back within a `RoutingState` stack.
+
+Example: [ReactiveNavigationView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/ReactiveNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.ReactiveUI:NavigateBackAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/NavigateToAction.md
+++ b/docs/actions/NavigateToAction.md
@@ -1,0 +1,19 @@
+# NavigateToAction
+
+Namespace: `Avalonia.Xaml.Interactions.ReactiveUI`
+
+Resolves and navigates to a view model type using a router.
+
+Example: [ReactiveNavigationView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/ReactiveNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.ReactiveUI:NavigateToAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/NavigateToAndResetAction.md
+++ b/docs/actions/NavigateToAndResetAction.md
@@ -1,0 +1,19 @@
+# NavigateToAndResetAction
+
+Namespace: `Avalonia.Xaml.Interactions.ReactiveUI`
+
+Resolves a view model type, clears the navigation stack, and navigates to it.
+
+Example: [ReactiveNavigationView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/ReactiveNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.ReactiveUI:NavigateToAndResetAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/OpenFilePickerAction.md
+++ b/docs/actions/OpenFilePickerAction.md
@@ -1,0 +1,19 @@
+# OpenFilePickerAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Opens a file picker dialog and passes the selected file(s) as a command parameter.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:OpenFilePickerAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/OpenFolderPickerAction.md
+++ b/docs/actions/OpenFolderPickerAction.md
@@ -1,0 +1,19 @@
+# OpenFolderPickerAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Opens a folder picker dialog and passes the selected folder(s) as a command parameter.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:OpenFolderPickerAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/PopupAction.md
+++ b/docs/actions/PopupAction.md
@@ -1,0 +1,19 @@
+# PopupAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays a popup window for showing additional UI content.
+
+Example: [ShowHidePopupActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowHidePopupActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:PopupAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ReleasePointerCaptureAction.md
+++ b/docs/actions/ReleasePointerCaptureAction.md
@@ -1,0 +1,19 @@
+# ReleasePointerCaptureAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Releases a previously captured pointer from the control.
+
+Example: [PointerTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ReleasePointerCaptureAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RemoveClassAction.md
+++ b/docs/actions/RemoveClassAction.md
@@ -1,0 +1,19 @@
+# RemoveClassAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Removes a style class from a control’s class collection.
+
+Example: [AddRemoveClassActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/AddRemoveClassActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RemoveClassAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RemoveElementAction.md
+++ b/docs/actions/RemoveElementAction.md
@@ -1,0 +1,19 @@
+# RemoveElementAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Removes a control from its parent container when executed.
+
+Example: [RemoveElementActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/RemoveElementActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RemoveElementAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RemoveItemInItemsControlAction.md
+++ b/docs/actions/RemoveItemInItemsControlAction.md
@@ -1,0 +1,19 @@
+# RemoveItemInItemsControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Removes the specified item from an ItemsControl.
+
+Example: [RemoveItemInItemsControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/RemoveItemInItemsControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RemoveItemInItemsControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RemoveItemInListBoxAction.md
+++ b/docs/actions/RemoveItemInListBoxAction.md
@@ -1,0 +1,19 @@
+# RemoveItemInListBoxAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Removes the specified item from a ListBox.
+
+Example: [RemoveItemInListBoxActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/RemoveItemInListBoxActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RemoveItemInListBoxAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RemoveTransitionAction.md
+++ b/docs/actions/RemoveTransitionAction.md
@@ -1,0 +1,19 @@
+# RemoveTransitionAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Removes a transition from a control's `Transitions` collection.
+
+Example: [TransitionsActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/TransitionsActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RemoveTransitionAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RenderRenderTargetBitmapAction.md
+++ b/docs/actions/RenderRenderTargetBitmapAction.md
@@ -1,0 +1,19 @@
+# RenderRenderTargetBitmapAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Invokes IRenderTargetBitmapRenderHost.Render on the specified target.
+
+Example: [RenderTargetBitmapView.axaml](samples/BehaviorsTestApplication/Views/Pages/RenderTargetBitmapView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RenderRenderTargetBitmapAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/RequestScreenDetailsAction.md
+++ b/docs/actions/RequestScreenDetailsAction.md
@@ -1,0 +1,19 @@
+# RequestScreenDetailsAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Requests extended screen information using a Screens instance.
+
+Example: [ScreenView.axaml](samples/BehaviorsTestApplication/Views/Pages/ScreenView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:RequestScreenDetailsAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SaveFilePickerAction.md
+++ b/docs/actions/SaveFilePickerAction.md
@@ -1,0 +1,19 @@
+# SaveFilePickerAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Opens a save file picker dialog and passes the chosen file as a command parameter.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:SaveFilePickerAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetAutomationIdAction.md
+++ b/docs/actions/SetAutomationIdAction.md
@@ -1,0 +1,19 @@
+# SetAutomationIdAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the automation ID on a target control.
+
+Example: [AutomationView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutomationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetAutomationIdAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetClipboardDataObjectAction.md
+++ b/docs/actions/SetClipboardDataObjectAction.md
@@ -1,0 +1,19 @@
+# SetClipboardDataObjectAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Places a custom data object onto the clipboard.
+
+Example: [SetClipboardDataObjectActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:SetClipboardDataObjectAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetClipboardTextAction.md
+++ b/docs/actions/SetClipboardTextAction.md
@@ -1,0 +1,19 @@
+# SetClipboardTextAction
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Places text onto the clipboard.
+
+Example: [ClipboardView.axaml](samples/BehaviorsTestApplication/Views/Pages/ClipboardView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Core:SetClipboardTextAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetCursorAction.md
+++ b/docs/actions/SetCursorAction.md
@@ -1,0 +1,19 @@
+# SetCursorAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the cursor of a control to a predefined cursor.
+
+Example: [DrawnCursorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DrawnCursorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetCursorAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetCursorFromProviderAction.md
+++ b/docs/actions/SetCursorFromProviderAction.md
@@ -1,0 +1,19 @@
+# SetCursorFromProviderAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the cursor of a control using a cursor created by an `ICursorProvider`.
+
+Example: [DrawnCursorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DrawnCursorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetCursorFromProviderAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetEnabledAction.md
+++ b/docs/actions/SetEnabledAction.md
@@ -1,0 +1,19 @@
+# SetEnabledAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Enables or disables the associated control.
+
+Example: [SetEnabledActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/SetEnabledActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetEnabledAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetPathIconDataAction.md
+++ b/docs/actions/SetPathIconDataAction.md
@@ -1,0 +1,19 @@
+# SetPathIconDataAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Changes the Data of a PathIcon when executed.
+
+Example: [IconView.axaml](samples/BehaviorsTestApplication/Views/Pages/IconView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetPathIconDataAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetThemeVariantAction.md
+++ b/docs/actions/SetThemeVariantAction.md
@@ -1,0 +1,19 @@
+# SetThemeVariantAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the requested theme variant on a target control.
+
+Example: [ThemeVariantView.axaml](samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetThemeVariantAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetToolTipTipAction.md
+++ b/docs/actions/SetToolTipTipAction.md
@@ -1,0 +1,19 @@
+# SetToolTipTipAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the ToolTip's tip text on the associated or target control.
+
+Example: [ToolTipHelpersView.axaml](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetToolTipTipAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SetViewModelPropertyAction.md
+++ b/docs/actions/SetViewModelPropertyAction.md
@@ -1,0 +1,19 @@
+# SetViewModelPropertyAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets a property on the DataContext to a specified value.
+
+Example: [ViewModelPropertyActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SetViewModelPropertyAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowContextDialogAction.md
+++ b/docs/actions/ShowContextDialogAction.md
@@ -1,0 +1,19 @@
+# ShowContextDialogAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Opens a context dialog using a specified behavior.
+
+Example: [ContextDialogView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowContextDialogAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowContextMenuAction.md
+++ b/docs/actions/ShowContextMenuAction.md
@@ -1,0 +1,19 @@
+# ShowContextMenuAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays a control's context menu programmatically.
+
+Example: [ShowContextMenuActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowContextMenuActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowContextMenuAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowControlAction.md
+++ b/docs/actions/ShowControlAction.md
@@ -1,0 +1,19 @@
+# ShowControlAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a control and gives it focus when executed.
+
+Example: [HideShowControlActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/HideShowControlActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowControlAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowDialogAction.md
+++ b/docs/actions/ShowDialogAction.md
@@ -1,0 +1,19 @@
+# ShowDialogAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a window as a dialog.
+
+Example: [DialogActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/DialogActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowDialogAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowErrorNotificationAction.md
+++ b/docs/actions/ShowErrorNotificationAction.md
@@ -1,0 +1,19 @@
+# ShowErrorNotificationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays an error notification via a manager.
+
+Example: [NotificationsView.axaml](samples/BehaviorsTestApplication/Views/Pages/NotificationsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowErrorNotificationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowFlyoutAction.md
+++ b/docs/actions/ShowFlyoutAction.md
@@ -1,0 +1,19 @@
+# ShowFlyoutAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a flyout attached to a control or specified explicitly.
+
+Example: [ShowHideFlyoutActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowHideFlyoutActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowFlyoutAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowInformationNotificationAction.md
+++ b/docs/actions/ShowInformationNotificationAction.md
@@ -1,0 +1,19 @@
+# ShowInformationNotificationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays an information notification via a manager.
+
+Example: [NotificationsView.axaml](samples/BehaviorsTestApplication/Views/Pages/NotificationsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowInformationNotificationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowNotificationAction.md
+++ b/docs/actions/ShowNotificationAction.md
@@ -1,0 +1,19 @@
+# ShowNotificationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a notification using an attached notification manager.
+
+Example: [ShowNotificationActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/ShowNotificationActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowNotificationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowPopupAction.md
+++ b/docs/actions/ShowPopupAction.md
@@ -1,0 +1,19 @@
+# ShowPopupAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Opens an existing popup for a control.
+
+Example: [PopupEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PopupEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowPopupAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowSuccessNotificationAction.md
+++ b/docs/actions/ShowSuccessNotificationAction.md
@@ -1,0 +1,19 @@
+# ShowSuccessNotificationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays a success notification via a manager.
+
+Example: [NotificationsView.axaml](samples/BehaviorsTestApplication/Views/Pages/NotificationsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowSuccessNotificationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowToolTipAction.md
+++ b/docs/actions/ShowToolTipAction.md
@@ -1,0 +1,19 @@
+# ShowToolTipAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows the ToolTip for the associated or target control.
+
+Example: [ToolTipHelpersView.axaml](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowToolTipAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ShowWarningNotificationAction.md
+++ b/docs/actions/ShowWarningNotificationAction.md
@@ -1,0 +1,19 @@
+# ShowWarningNotificationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays a warning notification via a manager.
+
+Example: [NotificationsView.axaml](samples/BehaviorsTestApplication/Views/Pages/NotificationsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ShowWarningNotificationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/SplitViewTogglePaneAction.md
+++ b/docs/actions/SplitViewTogglePaneAction.md
@@ -1,0 +1,19 @@
+# SplitViewTogglePaneAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Toggles the `IsPaneOpen` state of a `SplitView`.
+
+Example: [SplitViewStateBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SplitViewStateBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:SplitViewTogglePaneAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/StartBuiltAnimationAction.md
+++ b/docs/actions/StartBuiltAnimationAction.md
@@ -1,0 +1,19 @@
+# StartBuiltAnimationAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Creates an animation in code using an <code>IAnimationBuilder</code> and starts it.
+
+Example: [StartBuiltAnimationActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/StartBuiltAnimationActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:StartBuiltAnimationAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/StyledElementAction.md
+++ b/docs/actions/StyledElementAction.md
@@ -1,0 +1,19 @@
+# StyledElementAction
+
+Namespace: ``
+
+A base class for actions that work with StyledElement objects.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <:StyledElementAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/TabControlNextAction.md
+++ b/docs/actions/TabControlNextAction.md
@@ -1,0 +1,19 @@
+# TabControlNextAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Advances the target TabControl to the next tab.
+
+Example: [TabControlNavigationView.axaml](samples/BehaviorsTestApplication/Views/Pages/TabControlNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:TabControlNextAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/TabControlPreviousAction.md
+++ b/docs/actions/TabControlPreviousAction.md
@@ -1,0 +1,19 @@
+# TabControlPreviousAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Moves the target TabControl to the previous tab.
+
+Example: [TabControlNavigationView.axaml](samples/BehaviorsTestApplication/Views/Pages/TabControlNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:TabControlPreviousAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/ToggleViewModelBooleanAction.md
+++ b/docs/actions/ToggleViewModelBooleanAction.md
@@ -1,0 +1,19 @@
+# ToggleViewModelBooleanAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Toggles a boolean view model property.
+
+Example: [ViewModelPropertyActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:ToggleViewModelBooleanAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/UploadFileAction.md
+++ b/docs/actions/UploadFileAction.md
@@ -1,0 +1,19 @@
+# UploadFileAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Uploads a file asynchronously and invokes a command when finished.
+
+Example: [UploadFileView.axaml](samples/BehaviorsTestApplication/Views/Pages/UploadFileView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:UploadFileAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/actions/WriteableBitmapRenderAction.md
+++ b/docs/actions/WriteableBitmapRenderAction.md
@@ -1,0 +1,19 @@
+# WriteableBitmapRenderAction
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Invokes a renderer to update a writeable bitmap.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <EventTrigger>
+    <Avalonia.Xaml.Interactions.Custom:WriteableBitmapRenderAction/>
+  </EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/behaviors/ActiveScreenBehavior.md
+++ b/docs/behaviors/ActiveScreenBehavior.md
@@ -1,0 +1,19 @@
+# ActiveScreenBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Provides the currently active screen for a window.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ActiveScreenBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ActualThemeVariantChangedBehavior.md
+++ b/docs/behaviors/ActualThemeVariantChangedBehavior.md
@@ -1,0 +1,19 @@
+# ActualThemeVariantChangedBehavior
+
+Namespace: ``
+
+A base class for behaviors that react to theme variant changes (e.g. switching from light to dark mode).
+
+Example: [ActualThemeVariantChangedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:ActualThemeVariantChangedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AdaptiveBehavior.md
+++ b/docs/behaviors/AdaptiveBehavior.md
@@ -1,0 +1,19 @@
+# AdaptiveBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Responsive`
+
+Observes bounds changes of a control (or a specified source) and conditionally adds or removes CSS-style classes based on adaptive rules.
+
+Example: [AdaptiveBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AdaptiveBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Responsive:AdaptiveBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AnimateOnAttachedBehavior.md
+++ b/docs/behaviors/AnimateOnAttachedBehavior.md
@@ -1,0 +1,19 @@
+# AnimateOnAttachedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Runs a specified animation when the control appears in the visual tree.
+
+Example: [AnimateOnAttachedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AnimateOnAttachedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:AnimateOnAttachedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AspectRatioBehavior.md
+++ b/docs/behaviors/AspectRatioBehavior.md
@@ -1,0 +1,19 @@
+# AspectRatioBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Responsive`
+
+Observes bounds changes and toggles CSS-style classes when the control's aspect ratio matches specified rules.
+
+Example: [AspectRatioBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AspectRatioBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Responsive:AspectRatioBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AttachedToLogicalTreeBehavior.md
+++ b/docs/behaviors/AttachedToLogicalTreeBehavior.md
@@ -1,0 +1,19 @@
+# AttachedToLogicalTreeBehavior
+
+Namespace: ``
+
+A base class for behaviors that require notification when the associated object is added to the logical tree.
+
+Example: [AttachedToLogicalTreeBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:AttachedToLogicalTreeBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AttachedToVisualTreeBehavior.md
+++ b/docs/behaviors/AttachedToVisualTreeBehavior.md
@@ -1,0 +1,19 @@
+# AttachedToVisualTreeBehavior
+
+Namespace: ``
+
+A base class for behaviors that depend on the control being attached to the visual tree.
+
+Example: [FocusOnAttachedToVisualTreeBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusOnAttachedToVisualTreeBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:AttachedToVisualTreeBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AutoCompleteBoxOpenDropDownOnFocusBehavior.md
+++ b/docs/behaviors/AutoCompleteBoxOpenDropDownOnFocusBehavior.md
@@ -1,0 +1,19 @@
+# AutoCompleteBoxOpenDropDownOnFocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Opens the AutoCompleteBox drop-down when the control receives focus.
+
+Example: [AutoCompleteBoxView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutoCompleteBoxView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:AutoCompleteBoxOpenDropDownOnFocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AutoFocusBehavior.md
+++ b/docs/behaviors/AutoFocusBehavior.md
@@ -1,0 +1,19 @@
+# AutoFocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Automatically sets the focus on the associated control when it is loaded.
+
+Example: [AutoFocusBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutoFocusBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:AutoFocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AutoSelectBehavior.md
+++ b/docs/behaviors/AutoSelectBehavior.md
@@ -1,0 +1,19 @@
+# AutoSelectBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Selects all text in a TextBox when it is loaded.
+
+Example: [AutoSelectBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutoSelectBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:AutoSelectBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/AutomationNameBehavior.md
+++ b/docs/behaviors/AutomationNameBehavior.md
@@ -1,0 +1,19 @@
+# AutomationNameBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Applies an automation name to the associated control.
+
+Example: [AutomationView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutomationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:AutomationNameBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/Behavior.md
+++ b/docs/behaviors/Behavior.md
@@ -1,0 +1,19 @@
+# Behavior
+
+Namespace: ``
+
+The base class for behaviors that attach to Avalonia objects.
+
+Example: [CustomBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/CustomBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:Behavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/BindPointerOverBehavior.md
+++ b/docs/behaviors/BindPointerOverBehavior.md
@@ -1,0 +1,19 @@
+# BindPointerOverBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Two‑way binds a boolean property to a control’s pointer-over state.
+
+Example: [BindPointerOverBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/BindPointerOverBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:BindPointerOverBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/BindTagToVisualRootDataContextBehavior.md
+++ b/docs/behaviors/BindTagToVisualRootDataContextBehavior.md
@@ -1,0 +1,19 @@
+# BindTagToVisualRootDataContextBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Binds the control’s Tag property to the DataContext of its visual root, enabling inherited data contexts.
+
+Example: [BindTagToVisualRootDataContextBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/BindTagToVisualRootDataContextBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:BindTagToVisualRootDataContextBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/BindingBehavior.md
+++ b/docs/behaviors/BindingBehavior.md
@@ -1,0 +1,19 @@
+# BindingBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Establishes a binding on a target property using an Avalonia binding.
+
+Example: [BindingBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/BindingBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:BindingBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/BindingTriggerBehavior.md
+++ b/docs/behaviors/BindingTriggerBehavior.md
@@ -1,0 +1,19 @@
+# BindingTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Monitors a binding’s value and triggers actions when a specified condition is met.
+
+Example: [BindingTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/BindingTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:BindingTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/BoundsObserverBehavior.md
+++ b/docs/behaviors/BoundsObserverBehavior.md
@@ -1,0 +1,19 @@
+# BoundsObserverBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Observes a control’s bounds changes and updates two‑way bound Width and Height properties.
+
+Example: [BoundsObserverBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/BoundsObserverBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:BoundsObserverBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ButtonClickEventTriggerBehavior.md
+++ b/docs/behaviors/ButtonClickEventTriggerBehavior.md
@@ -1,0 +1,19 @@
+# ButtonClickEventTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Listens for a button’s click event and triggers associated actions.
+
+Example: [ButtonClickEventTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ButtonClickEventTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ButtonClickEventTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ButtonHidePopupOnClickBehavior.md
+++ b/docs/behaviors/ButtonHidePopupOnClickBehavior.md
@@ -1,0 +1,19 @@
+# ButtonHidePopupOnClickBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Automatically closes the popup containing the button when it is clicked.
+
+Example: [PopupEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PopupEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ButtonHidePopupOnClickBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ButtonOpenFilePickerBehavior.md
+++ b/docs/behaviors/ButtonOpenFilePickerBehavior.md
@@ -1,0 +1,19 @@
+# ButtonOpenFilePickerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Attaches to a Button to open a file picker dialog when clicked.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:ButtonOpenFilePickerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ButtonOpenFolderPickerBehavior.md
+++ b/docs/behaviors/ButtonOpenFolderPickerBehavior.md
@@ -1,0 +1,19 @@
+# ButtonOpenFolderPickerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Attaches to a Button to open a folder picker dialog when clicked.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:ButtonOpenFolderPickerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ButtonSaveFilePickerBehavior.md
+++ b/docs/behaviors/ButtonSaveFilePickerBehavior.md
@@ -1,0 +1,19 @@
+# ButtonSaveFilePickerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Attaches to a Button to open a save file picker dialog when clicked.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:ButtonSaveFilePickerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ButtonUploadFileBehavior.md
+++ b/docs/behaviors/ButtonUploadFileBehavior.md
@@ -1,0 +1,19 @@
+# ButtonUploadFileBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Opens a file dialog and uploads the selected file when the button is clicked.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ButtonUploadFileBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/CanvasDragBehavior.md
+++ b/docs/behaviors/CanvasDragBehavior.md
@@ -1,0 +1,19 @@
+# CanvasDragBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Draggable`
+
+Enables a control to be dragged within a Canvas by updating its RenderTransform based on pointer movements.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Draggable:CanvasDragBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/CarouselKeyNavigationBehavior.md
+++ b/docs/behaviors/CarouselKeyNavigationBehavior.md
@@ -1,0 +1,19 @@
+# CarouselKeyNavigationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Enables keyboard navigation for a Carousel using arrow keys.
+
+Example: [CarouselNavigationView.axaml](samples/BehaviorsTestApplication/Views/Pages/CarouselNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:CarouselKeyNavigationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/CollectionChangedBehavior.md
+++ b/docs/behaviors/CollectionChangedBehavior.md
@@ -1,0 +1,19 @@
+# CollectionChangedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Invokes actions based on collection change notifications.
+
+Example: [CollectionChangedTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/CollectionChangedTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:CollectionChangedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ComboBoxValidationBehavior.md
+++ b/docs/behaviors/ComboBoxValidationBehavior.md
@@ -1,0 +1,19 @@
+# ComboBoxValidationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Validates the selected item of a ComboBox.
+
+Example: [ComboBoxValidationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ComboBoxValidationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ComboBoxValidationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ContentControlFilesDropBehavior.md
+++ b/docs/behaviors/ContentControlFilesDropBehavior.md
@@ -1,0 +1,19 @@
+# ContentControlFilesDropBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Executes a command with dropped files on a ContentControl.
+
+Example: [ContentControlFilesDropBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:ContentControlFilesDropBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ContextDialogBehavior.md
+++ b/docs/behaviors/ContextDialogBehavior.md
@@ -1,0 +1,19 @@
+# ContextDialogBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Manages a popup-based context dialog for a control.
+
+Example: [ContextDialogView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ContextDialogBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ContextDragBehavior.md
+++ b/docs/behaviors/ContextDragBehavior.md
@@ -1,0 +1,19 @@
+# ContextDragBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Enables drag operations using a “context” (data payload) that is carried during the drag–drop operation.
+
+Example: [EditableDraggableListBoxView.axaml](samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:ContextDragBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ContextDragWithDirectionBehavior.md
+++ b/docs/behaviors/ContextDragWithDirectionBehavior.md
@@ -1,0 +1,19 @@
+# ContextDragWithDirectionBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Starts a drag operation and includes the drag direction in the data object.
+
+Example: [EditableDragTreeViewView.axaml](samples/BehaviorsTestApplication/Views/Pages/EditableDragTreeViewView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:ContextDragWithDirectionBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ContextDropBehavior.md
+++ b/docs/behaviors/ContextDropBehavior.md
@@ -1,0 +1,19 @@
+# ContextDropBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Handles drop events and passes context data between the drag source and drop target.
+
+Example: [TypedDragBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/TypedDragBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:ContextDropBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DataContextChangedBehavior.md
+++ b/docs/behaviors/DataContextChangedBehavior.md
@@ -1,0 +1,19 @@
+# DataContextChangedBehavior
+
+Namespace: ``
+
+A base class for behaviors that react to changes in the DataContext.
+
+Example: [DataContextChangedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DataContextChangedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:DataContextChangedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DataTriggerBehavior.md
+++ b/docs/behaviors/DataTriggerBehavior.md
@@ -1,0 +1,19 @@
+# DataTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Evaluates a data binding against a given condition and triggers actions when the condition is true.
+
+Example: [DataTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DataTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:DataTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DatePickerValidationBehavior.md
+++ b/docs/behaviors/DatePickerValidationBehavior.md
@@ -1,0 +1,19 @@
+# DatePickerValidationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Validates the selected date of a DatePicker.
+
+Example: [DatePickerValidationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DatePickerValidationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:DatePickerValidationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DelayedLoadBehavior.md
+++ b/docs/behaviors/DelayedLoadBehavior.md
@@ -1,0 +1,19 @@
+# DelayedLoadBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides the control then shows it after a specified delay when attached to the visual tree.
+
+Example: [DelayedLoadBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DelayedLoadBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:DelayedLoadBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DisposingBehavior.md
+++ b/docs/behaviors/DisposingBehavior.md
@@ -1,0 +1,19 @@
+# DisposingBehavior
+
+Namespace: ``
+
+A base class for behaviors that manage disposable resources automatically.
+
+Example: [DisposingBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DisposingBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:DisposingBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DoubleTappedEventBehavior.md
+++ b/docs/behaviors/DoubleTappedEventBehavior.md
@@ -1,0 +1,19 @@
+# DoubleTappedEventBehavior
+
+Namespace: ``
+
+Listens for double-tap events and triggers its actions when detected.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:DoubleTappedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DragAndDropEventsBehavior.md
+++ b/docs/behaviors/DragAndDropEventsBehavior.md
@@ -1,0 +1,19 @@
+# DragAndDropEventsBehavior
+
+Namespace: ``
+
+Abstract behavior used to attach handlers for drag-and-drop events.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:DragAndDropEventsBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/DragControlBehavior.md
+++ b/docs/behaviors/DragControlBehavior.md
@@ -1,0 +1,19 @@
+# DragControlBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Enables a control to be moved (dragged) around by changing its RenderTransform during pointer events.
+
+Example: [CustomBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/CustomBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:DragControlBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/EventTriggerBehavior.md
+++ b/docs/behaviors/EventTriggerBehavior.md
@@ -1,0 +1,19 @@
+# EventTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Listens for a specified event on the associated object and triggers actions accordingly.
+
+Example: [EventTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/EventTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:EventTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnActivatedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnActivatedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnActivatedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the main window (or target window) is activated.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnActivatedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnDoubleTappedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnDoubleTappedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnDoubleTappedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the associated control is double-tapped.
+
+Example: [ExecuteCommandBehaviorsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnDoubleTappedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnGotFocusBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnGotFocusBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnGotFocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the control gains focus.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnGotFocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnHoldingBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnHoldingBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnHoldingBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a holding (long press) gesture is detected.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnHoldingBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnKeyDownBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnKeyDownBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnKeyDownBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command in response to a key down event matching a specified key or gesture.
+
+Example: [ExecuteCommandBehaviorsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnKeyDownBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnKeyUpBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnKeyUpBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnKeyUpBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command in response to a key up event matching a specified key or gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnKeyUpBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnLostFocusBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnLostFocusBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnLostFocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the control loses focus.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnLostFocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPinchBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPinchBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPinchBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a pinch gesture is in progress.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPinchBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPinchEndedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPinchEndedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPinchEndedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a pinch gesture ends.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPinchEndedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerCaptureLostBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerCaptureLostBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerCaptureLostBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when pointer capture is lost from the control.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerCaptureLostBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerEnteredBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerEnteredBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerEnteredBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the pointer enters the control’s area.
+
+Example: [ExecuteCommandBehaviorsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerEnteredBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerExitedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerExitedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerExitedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the pointer exits the control’s area.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerExitedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerMovedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerMovedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerMovedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the pointer moves over the control.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerMovedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerPressedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerPressedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerPressedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the pointer is pressed on the control.
+
+Example: [ExecuteCommandBehaviorsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ExecuteCommandBehaviorsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerPressedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerReleasedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerReleasedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerReleasedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the pointer is released over the control.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerReleasedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerTouchPadGestureMagnifyBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerTouchPadGestureMagnifyBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerTouchPadGestureMagnifyBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command during a touchpad magnify gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerTouchPadGestureMagnifyBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerTouchPadGestureRotateBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerTouchPadGestureRotateBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerTouchPadGestureRotateBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command during a touchpad rotation gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerTouchPadGestureRotateBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerTouchPadGestureSwipeBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerTouchPadGestureSwipeBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerTouchPadGestureSwipeBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command during a touchpad swipe gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerTouchPadGestureSwipeBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPointerWheelChangedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPointerWheelChangedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPointerWheelChangedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the pointer wheel delta changes.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPointerWheelChangedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPullGestureBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPullGestureBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPullGestureBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a pull gesture is detected.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPullGestureBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnPullGestureEndedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnPullGestureEndedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnPullGestureEndedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a pull gesture ends.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnPullGestureEndedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnRightTappedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnRightTappedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnRightTappedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the control is right-tapped.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnRightTappedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnScrollGestureBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnScrollGestureBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnScrollGestureBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command during a scroll gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnScrollGestureBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnScrollGestureEndedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnScrollGestureEndedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnScrollGestureEndedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a scroll gesture ends.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnScrollGestureEndedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnScrollGestureInertiaStartingBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnScrollGestureInertiaStartingBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnScrollGestureInertiaStartingBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when the inertia phase of a scroll gesture starts.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnScrollGestureInertiaStartingBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnTappedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnTappedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnTappedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when a tap event occurs.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnTappedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnTextInputBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnTextInputBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnTextInputBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command in response to text input events.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnTextInputBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ExecuteCommandOnTextInputMethodClientRequestedBehavior.md
+++ b/docs/behaviors/ExecuteCommandOnTextInputMethodClientRequestedBehavior.md
@@ -1,0 +1,19 @@
+# ExecuteCommandOnTextInputMethodClientRequestedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes a command when text input method (virtual keyboard) is requested.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ExecuteCommandOnTextInputMethodClientRequestedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FadeInBehavior.md
+++ b/docs/behaviors/FadeInBehavior.md
@@ -1,0 +1,19 @@
+# FadeInBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Animates the fade-in effect for the associated element, gradually increasing its opacity.
+
+Example: [FadeInBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FadeInBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FadeInBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FilesDropBehavior.md
+++ b/docs/behaviors/FilesDropBehavior.md
@@ -1,0 +1,19 @@
+# FilesDropBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Executes a command with a collection of dropped files.
+
+Example: [ContentControlFilesDropBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContentControlFilesDropBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:FilesDropBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FluidMoveBehavior.md
+++ b/docs/behaviors/FluidMoveBehavior.md
@@ -1,0 +1,19 @@
+# FluidMoveBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Animates layout changes of a control or its children.
+
+Example: [FluidMoveBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FluidMoveBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusBehavior.md
+++ b/docs/behaviors/FocusBehavior.md
@@ -1,0 +1,19 @@
+# FocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Exposes a two‑way bindable IsFocused property to control focus state.
+
+Example: [HideOnLostFocusBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/HideOnLostFocusBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusControlBehavior.md
+++ b/docs/behaviors/FocusControlBehavior.md
@@ -1,0 +1,19 @@
+# FocusControlBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Forces focus onto a specified control when triggered.
+
+Example: [FocusControlBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusControlBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusControlBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusOnAttachedBehavior.md
+++ b/docs/behaviors/FocusOnAttachedBehavior.md
@@ -1,0 +1,19 @@
+# FocusOnAttachedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Immediately focuses the control when the behavior is attached.
+
+Example: [FocusOnAttachedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusOnAttachedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusOnAttachedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusOnAttachedToVisualTreeBehavior.md
+++ b/docs/behaviors/FocusOnAttachedToVisualTreeBehavior.md
@@ -1,0 +1,19 @@
+# FocusOnAttachedToVisualTreeBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Focuses the control as soon as it is attached to the visual tree.
+
+Example: [FocusOnAttachedToVisualTreeBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusOnAttachedToVisualTreeBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusOnAttachedToVisualTreeBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusOnPointerMovedBehavior.md
+++ b/docs/behaviors/FocusOnPointerMovedBehavior.md
@@ -1,0 +1,19 @@
+# FocusOnPointerMovedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets focus on the control when pointer movement is detected.
+
+Example: [FocusOnPointerMovedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusOnPointerMovedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusOnPointerMovedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusOnPointerPressedBehavior.md
+++ b/docs/behaviors/FocusOnPointerPressedBehavior.md
@@ -1,0 +1,19 @@
+# FocusOnPointerPressedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Focuses the control when a pointer press event occurs.
+
+Example: [FocusOnPointerPressedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusOnPointerPressedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusOnPointerPressedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/FocusSelectedItemBehavior.md
+++ b/docs/behaviors/FocusSelectedItemBehavior.md
@@ -1,0 +1,19 @@
+# FocusSelectedItemBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Focuses the currently selected item in an ItemsControl.
+
+Example: [FocusSelectedItemBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusSelectedItemBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:FocusSelectedItemBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/GotFocusEventBehavior.md
+++ b/docs/behaviors/GotFocusEventBehavior.md
@@ -1,0 +1,19 @@
+# GotFocusEventBehavior
+
+Namespace: ``
+
+Executes actions when the associated control receives focus.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:GotFocusEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/GridDragBehavior.md
+++ b/docs/behaviors/GridDragBehavior.md
@@ -1,0 +1,19 @@
+# GridDragBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Draggable`
+
+Allows grid cells (or items) to be swapped or repositioned by dragging within a Grid layout.
+
+Example: [DraggableView.axaml](samples/BehaviorsTestApplication/Views/Pages/DraggableView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Draggable:GridDragBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/HideAttachedFlyoutBehavior.md
+++ b/docs/behaviors/HideAttachedFlyoutBehavior.md
@@ -1,0 +1,19 @@
+# HideAttachedFlyoutBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides a flyout that is attached to a control when a condition is met.
+
+Example: [HideAttachedFlyoutBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/HideAttachedFlyoutBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:HideAttachedFlyoutBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/HideOnKeyPressedBehavior.md
+++ b/docs/behaviors/HideOnKeyPressedBehavior.md
@@ -1,0 +1,19 @@
+# HideOnKeyPressedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides the target control when a specified key is pressed.
+
+Example: [HideOnKeyPressedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/HideOnKeyPressedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:HideOnKeyPressedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/HideOnLostFocusBehavior.md
+++ b/docs/behaviors/HideOnLostFocusBehavior.md
@@ -1,0 +1,19 @@
+# HideOnLostFocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Hides the target control when it loses focus.
+
+Example: [HideOnLostFocusBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/HideOnLostFocusBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:HideOnLostFocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/HorizontalScrollViewerBehavior.md
+++ b/docs/behaviors/HorizontalScrollViewerBehavior.md
@@ -1,0 +1,19 @@
+# HorizontalScrollViewerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Enables horizontal scrolling via the pointer wheel. Optionally requires the Shift key and supports line or page scrolling.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:HorizontalScrollViewerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/IBehavior.md
+++ b/docs/behaviors/IBehavior.md
@@ -1,0 +1,19 @@
+# IBehavior
+
+Namespace: ``
+
+Interface for behaviors that can attach and detach from an Avalonia object.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:IBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/InitializedBehavior.md
+++ b/docs/behaviors/InitializedBehavior.md
@@ -1,0 +1,19 @@
+# InitializedBehavior
+
+Namespace: ``
+
+A base class for behaviors that execute code when the associated object is initialized.
+
+Example: [InitializedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/InitializedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:InitializedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/InlineEditBehavior.md
+++ b/docs/behaviors/InlineEditBehavior.md
@@ -1,0 +1,19 @@
+# InlineEditBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Toggles display and edit controls to enable in-place text editing.
+
+Example: [EditableDraggableListBoxView.axaml](samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:InlineEditBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/InteractionTriggerBehavior.md
+++ b/docs/behaviors/InteractionTriggerBehavior.md
@@ -1,0 +1,19 @@
+# InteractionTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.ReactiveUI`
+
+Base behavior for creating custom event-based triggers.
+
+Example: [InteractionTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/InteractionTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.ReactiveUI:InteractionTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ItemDragBehavior.md
+++ b/docs/behaviors/ItemDragBehavior.md
@@ -1,0 +1,19 @@
+# ItemDragBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Draggable`
+
+Enables reordering of items in an ItemsControl by dragging and dropping items.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Draggable:ItemDragBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ItemNudgeDropBehavior.md
+++ b/docs/behaviors/ItemNudgeDropBehavior.md
@@ -1,0 +1,19 @@
+# ItemNudgeDropBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Provides “nudge” effects for items in an ItemsControl during drag–drop reordering.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ItemNudgeDropBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ItemsControlContainerEventsBehavior.md
+++ b/docs/behaviors/ItemsControlContainerEventsBehavior.md
@@ -1,0 +1,19 @@
+# ItemsControlContainerEventsBehavior
+
+Namespace: ``
+
+A base behavior that listens for container events (prepared, index changed, clearing) on an ItemsControl.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:ItemsControlContainerEventsBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/KeyDownEventBehavior.md
+++ b/docs/behaviors/KeyDownEventBehavior.md
@@ -1,0 +1,19 @@
+# KeyDownEventBehavior
+
+Namespace: ``
+
+Monitors key down events and triggers actions when the specified key is pressed.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:KeyDownEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/KeyUpEventBehavior.md
+++ b/docs/behaviors/KeyUpEventBehavior.md
@@ -1,0 +1,19 @@
+# KeyUpEventBehavior
+
+Namespace: ``
+
+Monitors key up events and triggers actions when the specified key is released.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:KeyUpEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ListBoxSelectAllBehavior.md
+++ b/docs/behaviors/ListBoxSelectAllBehavior.md
@@ -1,0 +1,19 @@
+# ListBoxSelectAllBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Selects all items in a ListBox when the behavior is attached.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ListBoxSelectAllBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ListBoxUnselectAllBehavior.md
+++ b/docs/behaviors/ListBoxUnselectAllBehavior.md
@@ -1,0 +1,19 @@
+# ListBoxUnselectAllBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Clears the selection in a ListBox.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ListBoxUnselectAllBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/LoadedBehavior.md
+++ b/docs/behaviors/LoadedBehavior.md
@@ -1,0 +1,19 @@
+# LoadedBehavior
+
+Namespace: ``
+
+A base class for behaviors that run when a control is loaded into the visual tree.
+
+Example: [LoadedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/LoadedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:LoadedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/LostFocusEventBehavior.md
+++ b/docs/behaviors/LostFocusEventBehavior.md
@@ -1,0 +1,19 @@
+# LostFocusEventBehavior
+
+Namespace: ``
+
+Triggers actions when the control loses focus.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:LostFocusEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/MenuItemOpenFilePickerBehavior.md
+++ b/docs/behaviors/MenuItemOpenFilePickerBehavior.md
@@ -1,0 +1,19 @@
+# MenuItemOpenFilePickerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Opens a file picker dialog when a MenuItem is clicked.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:MenuItemOpenFilePickerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/MenuItemOpenFolderPickerBehavior.md
+++ b/docs/behaviors/MenuItemOpenFolderPickerBehavior.md
@@ -1,0 +1,19 @@
+# MenuItemOpenFolderPickerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Opens a folder picker dialog when a MenuItem is clicked.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:MenuItemOpenFolderPickerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/MenuItemSaveFilePickerBehavior.md
+++ b/docs/behaviors/MenuItemSaveFilePickerBehavior.md
@@ -1,0 +1,19 @@
+# MenuItemSaveFilePickerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Opens a save file picker dialog when a MenuItem is clicked.
+
+Example: [StorageProviderView.axaml](samples/BehaviorsTestApplication/Views/Pages/StorageProviderView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Core:MenuItemSaveFilePickerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/MouseDragElementBehavior.md
+++ b/docs/behaviors/MouseDragElementBehavior.md
@@ -1,0 +1,19 @@
+# MouseDragElementBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Draggable`
+
+Allows an element to be dragged using the mouse.
+
+Example: [MouseDragBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/MouseDragBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Draggable:MouseDragElementBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/MultiMouseDragElementBehavior.md
+++ b/docs/behaviors/MultiMouseDragElementBehavior.md
@@ -1,0 +1,19 @@
+# MultiMouseDragElementBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Draggable`
+
+Supports dragging multiple elements simultaneously with the mouse.
+
+Example: [MouseDragBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/MouseDragBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Draggable:MultiMouseDragElementBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/NotificationManagerBehavior.md
+++ b/docs/behaviors/NotificationManagerBehavior.md
@@ -1,0 +1,19 @@
+# NotificationManagerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Creates a notification manager for a window when attached.
+
+Example: [NotificationsView.axaml](samples/BehaviorsTestApplication/Views/Pages/NotificationsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:NotificationManagerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/NumericUpDownValidationBehavior.md
+++ b/docs/behaviors/NumericUpDownValidationBehavior.md
@@ -1,0 +1,19 @@
+# NumericUpDownValidationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Validates the value of a NumericUpDown.
+
+Example: [NumericUpDownValidationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/NumericUpDownValidationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:NumericUpDownValidationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ObservableTriggerBehavior.md
+++ b/docs/behaviors/ObservableTriggerBehavior.md
@@ -1,0 +1,19 @@
+# ObservableTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Subscribes to an `IObservable` and executes actions whenever the observable emits a value.
+
+Example: [ObservableTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/ReactiveUI/ObservableTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ObservableTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PanelDragBehavior.md
+++ b/docs/behaviors/PanelDragBehavior.md
@@ -1,0 +1,19 @@
+# PanelDragBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Starts drag operations using the dragged control as context so it can be moved between panels.
+
+Example: [DragBetweenPanelsView.axaml](samples/BehaviorsTestApplication/Views/Pages/DragBetweenPanelsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:PanelDragBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PanelDropBehavior.md
+++ b/docs/behaviors/PanelDropBehavior.md
@@ -1,0 +1,19 @@
+# PanelDropBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Accepts dragged controls and inserts them into the target panel.
+
+Example: [DragBetweenPanelsView.axaml](samples/BehaviorsTestApplication/Views/Pages/DragBetweenPanelsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:PanelDropBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PathIconDataBehavior.md
+++ b/docs/behaviors/PathIconDataBehavior.md
@@ -1,0 +1,19 @@
+# PathIconDataBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the Data property of a PathIcon when attached.
+
+Example: [IconView.axaml](samples/BehaviorsTestApplication/Views/Pages/IconView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:PathIconDataBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PlayAnimationBehavior.md
+++ b/docs/behaviors/PlayAnimationBehavior.md
@@ -1,0 +1,19 @@
+# PlayAnimationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Runs a supplied animation automatically when the control appears in the visual tree.
+
+Example: [AnimationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/AnimationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:PlayAnimationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerCaptureLostEventBehavior.md
+++ b/docs/behaviors/PointerCaptureLostEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerCaptureLostEventBehavior
+
+Namespace: ``
+
+Listens for events when pointer capture is lost and triggers associated actions.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerCaptureLostEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerEnteredEventBehavior.md
+++ b/docs/behaviors/PointerEnteredEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerEnteredEventBehavior
+
+Namespace: ``
+
+Triggers actions when the pointer enters the bounds of a control.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerEnteredEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerEventsBehavior.md
+++ b/docs/behaviors/PointerEventsBehavior.md
@@ -1,0 +1,19 @@
+# PointerEventsBehavior
+
+Namespace: ``
+
+A base class that simplifies handling of pointer events (pressed, moved, released).
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerEventsBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerExitedEventBehavior.md
+++ b/docs/behaviors/PointerExitedEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerExitedEventBehavior
+
+Namespace: ``
+
+Triggers actions when the pointer exits a control.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerExitedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerMovedEventBehavior.md
+++ b/docs/behaviors/PointerMovedEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerMovedEventBehavior
+
+Namespace: ``
+
+Triggers actions when the pointer moves over a control.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerMovedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerOverCursorBehavior.md
+++ b/docs/behaviors/PointerOverCursorBehavior.md
@@ -1,0 +1,19 @@
+# PointerOverCursorBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Changes the cursor while the pointer is over the control and resets it on exit.
+
+Example: [CursorView.axaml](samples/BehaviorsTestApplication/Views/Pages/CursorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:PointerOverCursorBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerPressedEventBehavior.md
+++ b/docs/behaviors/PointerPressedEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerPressedEventBehavior
+
+Namespace: ``
+
+Triggers actions on pointer press events.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerPressedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerReleasedEventBehavior.md
+++ b/docs/behaviors/PointerReleasedEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerReleasedEventBehavior
+
+Namespace: ``
+
+Triggers actions on pointer release events.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerReleasedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PointerWheelChangedEventBehavior.md
+++ b/docs/behaviors/PointerWheelChangedEventBehavior.md
@@ -1,0 +1,19 @@
+# PointerWheelChangedEventBehavior
+
+Namespace: ``
+
+Triggers actions when the pointer wheel (scroll) changes.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:PointerWheelChangedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/PropertyValidationBehavior.md
+++ b/docs/behaviors/PropertyValidationBehavior.md
@@ -1,0 +1,19 @@
+# PropertyValidationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Base behavior for validating an Avalonia property using rules.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:PropertyValidationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/RenderTargetBitmapBehavior.md
+++ b/docs/behaviors/RenderTargetBitmapBehavior.md
@@ -1,0 +1,19 @@
+# RenderTargetBitmapBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Creates and updates a RenderTargetBitmap via a renderer.
+
+Example: [RenderTargetBitmapView.axaml](samples/BehaviorsTestApplication/Views/Pages/RenderTargetBitmapView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:RenderTargetBitmapBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ResourcesChangedBehavior.md
+++ b/docs/behaviors/ResourcesChangedBehavior.md
@@ -1,0 +1,19 @@
+# ResourcesChangedBehavior
+
+Namespace: ``
+
+A base class for behaviors that respond when a control’s resources change.
+
+Example: [ResourcesChangedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:ResourcesChangedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/RightTappedEventBehavior.md
+++ b/docs/behaviors/RightTappedEventBehavior.md
@@ -1,0 +1,19 @@
+# RightTappedEventBehavior
+
+Namespace: ``
+
+Triggers actions when the control is right-tapped.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:RightTappedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/RoutedEventTriggerBehavior.md
+++ b/docs/behaviors/RoutedEventTriggerBehavior.md
@@ -1,0 +1,19 @@
+# RoutedEventTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Listens for a routed event on the associated object and triggers its actions.
+
+Example: [RoutedEventTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:RoutedEventTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ScrollGestureEndedEventBehavior.md
+++ b/docs/behaviors/ScrollGestureEndedEventBehavior.md
@@ -1,0 +1,19 @@
+# ScrollGestureEndedEventBehavior
+
+Namespace: ``
+
+Triggers actions when a scroll gesture ends.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:ScrollGestureEndedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ScrollGestureEventBehavior.md
+++ b/docs/behaviors/ScrollGestureEventBehavior.md
@@ -1,0 +1,19 @@
+# ScrollGestureEventBehavior
+
+Namespace: ``
+
+Monitors scroll gestures and triggers actions when they occur.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:ScrollGestureEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ScrollToItemBehavior.md
+++ b/docs/behaviors/ScrollToItemBehavior.md
@@ -1,0 +1,19 @@
+# ScrollToItemBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Automatically scrolls the ItemsControl to make a specified item visible.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ScrollToItemBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ScrollToItemIndexBehavior.md
+++ b/docs/behaviors/ScrollToItemIndexBehavior.md
@@ -1,0 +1,19 @@
+# ScrollToItemIndexBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Scrolls to a specific item index in the ItemsControl.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ScrollToItemIndexBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SelectListBoxItemOnPointerMovedBehavior.md
+++ b/docs/behaviors/SelectListBoxItemOnPointerMovedBehavior.md
@@ -1,0 +1,19 @@
+# SelectListBoxItemOnPointerMovedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Automatically selects a ListBoxItem when the pointer moves over it.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:SelectListBoxItemOnPointerMovedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SelectingItemsControlEventsBehavior.md
+++ b/docs/behaviors/SelectingItemsControlEventsBehavior.md
@@ -1,0 +1,19 @@
+# SelectingItemsControlEventsBehavior
+
+Namespace: ``
+
+Handles selection-changed events in controls that support item selection (like ListBox) to trigger custom actions.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:SelectingItemsControlEventsBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SetCursorBehavior.md
+++ b/docs/behaviors/SetCursorBehavior.md
@@ -1,0 +1,19 @@
+# SetCursorBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Applies a custom cursor to the associated control.
+
+Example: [CursorView.axaml](samples/BehaviorsTestApplication/Views/Pages/CursorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:SetCursorBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SetCursorFromProviderBehavior.md
+++ b/docs/behaviors/SetCursorFromProviderBehavior.md
@@ -1,0 +1,19 @@
+# SetCursorFromProviderBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Uses an `ICursorProvider` implementation to supply the cursor for the associated control.
+
+Example: [DrawnCursorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DrawnCursorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:SetCursorFromProviderBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SetViewModelPropertyOnLoadBehavior.md
+++ b/docs/behaviors/SetViewModelPropertyOnLoadBehavior.md
@@ -1,0 +1,19 @@
+# SetViewModelPropertyOnLoadBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets a view model property when the associated control is loaded.
+
+Example: [ViewModelPropertyActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:SetViewModelPropertyOnLoadBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ShowOnDoubleTappedBehavior.md
+++ b/docs/behaviors/ShowOnDoubleTappedBehavior.md
@@ -1,0 +1,19 @@
+# ShowOnDoubleTappedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a control when a double-tap gesture is detected.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ShowOnDoubleTappedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ShowOnKeyDownBehavior.md
+++ b/docs/behaviors/ShowOnKeyDownBehavior.md
@@ -1,0 +1,19 @@
+# ShowOnKeyDownBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows a control when a specified key (or key gesture) is pressed.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ShowOnKeyDownBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ShowOnTappedBehavior.md
+++ b/docs/behaviors/ShowOnTappedBehavior.md
@@ -1,0 +1,19 @@
+# ShowOnTappedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Shows the target control when it is tapped.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ShowOnTappedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ShowPointerPositionBehavior.md
+++ b/docs/behaviors/ShowPointerPositionBehavior.md
@@ -1,0 +1,19 @@
+# ShowPointerPositionBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Displays the current pointer position (x, y coordinates) in a TextBlock for debugging or UI feedback.
+
+Example: [CustomActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/CustomActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ShowPointerPositionBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SliderValidationBehavior.md
+++ b/docs/behaviors/SliderValidationBehavior.md
@@ -1,0 +1,19 @@
+# SliderValidationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Validates the value of a range-based control like Slider.
+
+Example: [SliderValidationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:SliderValidationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/SplitViewStateBehavior.md
+++ b/docs/behaviors/SplitViewStateBehavior.md
@@ -1,0 +1,19 @@
+# SplitViewStateBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Automatically updates `DisplayMode`, `PanePlacement`, and `IsPaneOpen` based on size conditions.
+
+Example: [SplitViewStateBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SplitViewStateBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:SplitViewStateBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/StaticRenderTargetBitmapBehavior.md
+++ b/docs/behaviors/StaticRenderTargetBitmapBehavior.md
@@ -1,0 +1,19 @@
+# StaticRenderTargetBitmapBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Draws once into a RenderTargetBitmap and assigns it to the associated Image.
+
+Example: [RenderTargetBitmapView.axaml](samples/BehaviorsTestApplication/Views/Pages/RenderTargetBitmapView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:StaticRenderTargetBitmapBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/StyledElementBehavior.md
+++ b/docs/behaviors/StyledElementBehavior.md
@@ -1,0 +1,19 @@
+# StyledElementBehavior
+
+Namespace: ``
+
+A base class for behaviors targeting StyledElement objects.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:StyledElementBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TabControlKeyNavigationBehavior.md
+++ b/docs/behaviors/TabControlKeyNavigationBehavior.md
@@ -1,0 +1,19 @@
+# TabControlKeyNavigationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Enables keyboard navigation for a TabControl using arrow keys.
+
+Example: [TabControlNavigationView.axaml](samples/BehaviorsTestApplication/Views/Pages/TabControlNavigationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:TabControlKeyNavigationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TappedEventBehavior.md
+++ b/docs/behaviors/TappedEventBehavior.md
@@ -1,0 +1,19 @@
+# TappedEventBehavior
+
+Namespace: ``
+
+Triggers actions on simple tap events.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:TappedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TextBoxSelectAllOnGotFocusBehavior.md
+++ b/docs/behaviors/TextBoxSelectAllOnGotFocusBehavior.md
@@ -1,0 +1,19 @@
+# TextBoxSelectAllOnGotFocusBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Selects all text in a TextBox when it gains focus.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:TextBoxSelectAllOnGotFocusBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TextBoxSelectAllTextBehavior.md
+++ b/docs/behaviors/TextBoxSelectAllTextBehavior.md
@@ -1,0 +1,19 @@
+# TextBoxSelectAllTextBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Selects all text in a TextBox immediately upon attachment.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:TextBoxSelectAllTextBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TextBoxValidationBehavior.md
+++ b/docs/behaviors/TextBoxValidationBehavior.md
@@ -1,0 +1,19 @@
+# TextBoxValidationBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Validates the text value of a TextBox.
+
+Example: [TextBoxValidationBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/TextBoxValidationBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:TextBoxValidationBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TextDropBehavior.md
+++ b/docs/behaviors/TextDropBehavior.md
@@ -1,0 +1,19 @@
+# TextDropBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Executes a command with dropped text.
+
+Example: [FileDropHandlerView.axaml](samples/BehaviorsTestApplication/Views/Pages/FileDropHandlerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:TextDropBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TextInputEventBehavior.md
+++ b/docs/behaviors/TextInputEventBehavior.md
@@ -1,0 +1,19 @@
+# TextInputEventBehavior
+
+Namespace: ``
+
+Listens for text input events and triggers actions accordingly.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:TextInputEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TextInputMethodClientRequestedEventBehavior.md
+++ b/docs/behaviors/TextInputMethodClientRequestedEventBehavior.md
@@ -1,0 +1,19 @@
+# TextInputMethodClientRequestedEventBehavior
+
+Namespace: ``
+
+Triggers actions when a text input method client is requested (for virtual keyboards, etc.).
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <:TextInputMethodClientRequestedEventBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ThemeVariantBehavior.md
+++ b/docs/behaviors/ThemeVariantBehavior.md
@@ -1,0 +1,19 @@
+# ThemeVariantBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Applies a specific theme variant to the associated control.
+
+Example: [ThemeVariantView.axaml](samples/BehaviorsTestApplication/Views/Pages/ThemeVariantView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ThemeVariantBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ToggleIsExpandedOnDoubleTappedBehavior.md
+++ b/docs/behaviors/ToggleIsExpandedOnDoubleTappedBehavior.md
@@ -1,0 +1,19 @@
+# ToggleIsExpandedOnDoubleTappedBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Toggles the IsExpanded property of a TreeViewItem when it is double-tapped.
+
+Example: [ToggleIsExpandedOnDoubleTappedBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ToggleIsExpandedOnDoubleTappedBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ToggleIsExpandedOnDoubleTappedBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TransitionsBehavior.md
+++ b/docs/behaviors/TransitionsBehavior.md
@@ -1,0 +1,19 @@
+# TransitionsBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Sets the `Transitions` collection on the associated control when attached.
+
+Example: [TransitionsBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/TransitionsBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:TransitionsBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TreeViewFilterBehavior.md
+++ b/docs/behaviors/TreeViewFilterBehavior.md
@@ -1,0 +1,19 @@
+# TreeViewFilterBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Filters tree view nodes based on a search box.
+
+Example: [TreeViewFilterView.axaml](samples/BehaviorsTestApplication/Views/Pages/TreeViewFilterView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:TreeViewFilterBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/TypedDragBehavior.md
+++ b/docs/behaviors/TypedDragBehavior.md
@@ -1,0 +1,19 @@
+# TypedDragBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.DragAndDrop`
+
+Provides drag behavior for items of a specified data type.
+
+Example: [TypedDragBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/TypedDragBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.DragAndDrop:TypedDragBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ValueChangedTriggerBehavior.md
+++ b/docs/behaviors/ValueChangedTriggerBehavior.md
@@ -1,0 +1,19 @@
+# ValueChangedTriggerBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the value of a bound property changes.
+
+Example: [ValueChangedTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ValueChangedTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ValueChangedTriggerBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/ViewportBehavior.md
+++ b/docs/behaviors/ViewportBehavior.md
@@ -1,0 +1,19 @@
+# ViewportBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Tracks when the associated element enters or exits a ScrollViewer's viewport.
+
+Example: [ViewportBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/ViewportBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:ViewportBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/WriteableBitmapBehavior.md
+++ b/docs/behaviors/WriteableBitmapBehavior.md
@@ -1,0 +1,19 @@
+# WriteableBitmapBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Creates a writeable bitmap and renders it once or on demand without animation.
+
+Example: [WriteableBitmapView.axaml](samples/BehaviorsTestApplication/Views/Pages/WriteableBitmapView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:WriteableBitmapBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/behaviors/WriteableBitmapRenderBehavior.md
+++ b/docs/behaviors/WriteableBitmapRenderBehavior.md
@@ -1,0 +1,19 @@
+# WriteableBitmapRenderBehavior
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Creates a writeable bitmap and updates it using a renderer on a timer.
+
+Example: [WriteableBitmapView.axaml](samples/BehaviorsTestApplication/Views/Pages/WriteableBitmapView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Control>
+  <Interaction.Behaviors>
+    <Avalonia.Xaml.Interactions.Custom:WriteableBitmapRenderBehavior/>
+  </Interaction.Behaviors>
+</Control>
+```

--- a/docs/interactions.md
+++ b/docs/interactions.md
@@ -1,0 +1,499 @@
+# Interactions Index
+
+## Actions
+
+- [AddClassAction](./actions/AddClassAction.md)
+- [ChangeAvaloniaPropertyAction](./actions/ChangeAvaloniaPropertyAction.md)
+- [CloseNotificationAction](./actions/CloseNotificationAction.md)
+- [DelayedShowControlAction](./actions/DelayedShowControlAction.md)
+- [FocusControlAction](./actions/FocusControlAction.md)
+- [HideControlAction](./actions/HideControlAction.md)
+- [HideFlyoutAction](./actions/HideFlyoutAction.md)
+- [HidePopupAction](./actions/HidePopupAction.md)
+- [IncrementViewModelPropertyAction](./actions/IncrementViewModelPropertyAction.md)
+- [MoveElementToPanelAction](./actions/MoveElementToPanelAction.md)
+- [PopupAction](./actions/PopupAction.md)
+- [RemoveClassAction](./actions/RemoveClassAction.md)
+- [RemoveElementAction](./actions/RemoveElementAction.md)
+- [SetViewModelPropertyAction](./actions/SetViewModelPropertyAction.md)
+- [ShowContextMenuAction](./actions/ShowContextMenuAction.md)
+- [ShowControlAction](./actions/ShowControlAction.md)
+- [ShowFlyoutAction](./actions/ShowFlyoutAction.md)
+- [ShowPopupAction](./actions/ShowPopupAction.md)
+- [SplitViewTogglePaneAction](./actions/SplitViewTogglePaneAction.md)
+- [ToggleViewModelBooleanAction](./actions/ToggleViewModelBooleanAction.md)
+
+## Animations
+
+- [AnimateOnAttachedBehavior](./behaviors/AnimateOnAttachedBehavior.md)
+- [AnimationCompletedTrigger](./triggers/AnimationCompletedTrigger.md)
+- [BeginAnimationAction](./actions/BeginAnimationAction.md)
+- [FadeInBehavior](./behaviors/FadeInBehavior.md)
+- [PlayAnimationBehavior](./behaviors/PlayAnimationBehavior.md)
+- [RunAnimationTrigger](./triggers/RunAnimationTrigger.md)
+- [StartBuiltAnimationAction](./actions/StartBuiltAnimationAction.md)
+
+## AutoCompleteBox
+
+- [AutoCompleteBoxOpenDropDownOnFocusBehavior](./behaviors/AutoCompleteBoxOpenDropDownOnFocusBehavior.md)
+- [AutoCompleteBoxSelectionChangedTrigger](./triggers/AutoCompleteBoxSelectionChangedTrigger.md)
+- [ClearAutoCompleteBoxSelectionAction](./actions/ClearAutoCompleteBoxSelectionAction.md)
+
+## Automation
+
+- [AutomationNameBehavior](./behaviors/AutomationNameBehavior.md)
+- [AutomationNameChangedTrigger](./triggers/AutomationNameChangedTrigger.md)
+- [SetAutomationIdAction](./actions/SetAutomationIdAction.md)
+
+## AvaloniaObject
+
+- [Action](./actions/Action.md)
+- [Behavior](./behaviors/Behavior.md)
+- [Trigger](./triggers/Trigger.md)
+
+## Button
+
+- [ButtonClickEventTriggerBehavior](./behaviors/ButtonClickEventTriggerBehavior.md)
+- [ButtonHidePopupOnClickBehavior](./behaviors/ButtonHidePopupOnClickBehavior.md)
+
+## Carousel
+
+- [CarouselKeyNavigationBehavior](./behaviors/CarouselKeyNavigationBehavior.md)
+- [CarouselNextAction](./actions/CarouselNextAction.md)
+- [CarouselPreviousAction](./actions/CarouselPreviousAction.md)
+
+## Clipboard
+
+- [ClearClipboardAction](./actions/ClearClipboardAction.md)
+- [GetClipboardDataAction](./actions/GetClipboardDataAction.md)
+- [GetClipboardFormatsAction](./actions/GetClipboardFormatsAction.md)
+- [GetClipboardTextAction](./actions/GetClipboardTextAction.md)
+- [SetClipboardDataObjectAction](./actions/SetClipboardDataObjectAction.md)
+- [SetClipboardTextAction](./actions/SetClipboardTextAction.md)
+
+## Collections
+
+- [AddRangeAction](./actions/AddRangeAction.md)
+- [ClearCollectionAction](./actions/ClearCollectionAction.md)
+- [CollectionChangedBehavior](./behaviors/CollectionChangedBehavior.md)
+- [CollectionChangedTrigger](./triggers/CollectionChangedTrigger.md)
+
+## Composition
+
+- [FluidMoveBehavior](./behaviors/FluidMoveBehavior.md)
+
+## ContextDialogs
+
+- [ContextDialogBehavior](./behaviors/ContextDialogBehavior.md)
+- [ContextDialogClosedTrigger](./triggers/ContextDialogClosedTrigger.md)
+- [ContextDialogOpenedTrigger](./triggers/ContextDialogOpenedTrigger.md)
+- [HideContextDialogAction](./actions/HideContextDialogAction.md)
+- [ShowContextDialogAction](./actions/ShowContextDialogAction.md)
+
+## Contract
+
+- [IAction](./actions/IAction.md)
+- [IBehavior](./behaviors/IBehavior.md)
+- [ITrigger](./triggers/ITrigger.md)
+
+## Control
+
+- [BindPointerOverBehavior](./behaviors/BindPointerOverBehavior.md)
+- [BindTagToVisualRootDataContextBehavior](./behaviors/BindTagToVisualRootDataContextBehavior.md)
+- [BoundsObserverBehavior](./behaviors/BoundsObserverBehavior.md)
+- [DragControlBehavior](./behaviors/DragControlBehavior.md)
+- [HideAttachedFlyoutBehavior](./behaviors/HideAttachedFlyoutBehavior.md)
+- [HideOnKeyPressedBehavior](./behaviors/HideOnKeyPressedBehavior.md)
+- [HideOnLostFocusBehavior](./behaviors/HideOnLostFocusBehavior.md)
+- [InlineEditBehavior](./behaviors/InlineEditBehavior.md)
+- [PointerOverCursorBehavior](./behaviors/PointerOverCursorBehavior.md)
+- [SetCursorBehavior](./behaviors/SetCursorBehavior.md)
+- [SetCursorFromProviderBehavior](./behaviors/SetCursorFromProviderBehavior.md)
+- [ShowPointerPositionBehavior](./behaviors/ShowPointerPositionBehavior.md)
+- [SizeChangedTrigger](./triggers/SizeChangedTrigger.md)
+
+## Core (General Infrastructure)
+
+- [ActualThemeVariantChangedBehavior](./behaviors/ActualThemeVariantChangedBehavior.md)
+- [ActualThemeVariantChangedTrigger](./triggers/ActualThemeVariantChangedTrigger.md)
+- [AttachedToLogicalTreeBehavior](./behaviors/AttachedToLogicalTreeBehavior.md)
+- [AttachedToLogicalTreeTrigger](./triggers/AttachedToLogicalTreeTrigger.md)
+- [AttachedToVisualTreeBehavior](./behaviors/AttachedToVisualTreeBehavior.md)
+- [AttachedToVisualTreeTrigger](./triggers/AttachedToVisualTreeTrigger.md)
+- [BindingBehavior](./behaviors/BindingBehavior.md)
+- [BindingTriggerBehavior](./behaviors/BindingTriggerBehavior.md)
+- [CallMethodAction](./actions/CallMethodAction.md)
+- [ChangePropertyAction](./actions/ChangePropertyAction.md)
+- [DataContextChangedBehavior](./behaviors/DataContextChangedBehavior.md)
+- [DataContextChangedTrigger](./triggers/DataContextChangedTrigger.md)
+- [DataTrigger](./triggers/DataTrigger.md)
+- [DataTriggerBehavior](./behaviors/DataTriggerBehavior.md)
+- [DelayedLoadBehavior](./behaviors/DelayedLoadBehavior.md)
+- [DelayedLoadTrigger](./triggers/DelayedLoadTrigger.md)
+- [DetachedFromLogicalTreeTrigger](./triggers/DetachedFromLogicalTreeTrigger.md)
+- [DetachedFromVisualTreeTrigger](./triggers/DetachedFromVisualTreeTrigger.md)
+- [DisposableAction](./actions/DisposableAction.md)
+- [DisposingBehavior](./behaviors/DisposingBehavior.md)
+- [DisposingTrigger](./triggers/DisposingTrigger.md)
+- [EventTrigger](./triggers/EventTrigger.md)
+- [EventTriggerBehavior](./behaviors/EventTriggerBehavior.md)
+- [IfElseTrigger](./triggers/IfElseTrigger.md)
+- [InitializedBehavior](./behaviors/InitializedBehavior.md)
+- [InitializedTrigger](./triggers/InitializedTrigger.md)
+- [InvokeCommandAction](./actions/InvokeCommandAction.md)
+- [LaunchUriOrFileAction](./actions/LaunchUriOrFileAction.md)
+- [LoadedBehavior](./behaviors/LoadedBehavior.md)
+- [LoadedTrigger](./triggers/LoadedTrigger.md)
+- [PropertyChangedTrigger](./triggers/PropertyChangedTrigger.md)
+- [ResourcesChangedBehavior](./behaviors/ResourcesChangedBehavior.md)
+- [ResourcesChangedTrigger](./triggers/ResourcesChangedTrigger.md)
+- [RoutedEventTriggerBehavior](./behaviors/RoutedEventTriggerBehavior.md)
+- [SetThemeVariantAction](./actions/SetThemeVariantAction.md)
+- [SetViewModelPropertyOnLoadBehavior](./behaviors/SetViewModelPropertyOnLoadBehavior.md)
+- [ThemeVariantBehavior](./behaviors/ThemeVariantBehavior.md)
+- [ThemeVariantTrigger](./triggers/ThemeVariantTrigger.md)
+- [TimerTrigger](./triggers/TimerTrigger.md)
+- [UnloadedTrigger](./triggers/UnloadedTrigger.md)
+- [ValueChangedTriggerBehavior](./behaviors/ValueChangedTriggerBehavior.md)
+- [ViewModelPropertyChangedTrigger](./triggers/ViewModelPropertyChangedTrigger.md)
+
+## DragAndDrop
+
+- [ContentControlFilesDropBehavior](./behaviors/ContentControlFilesDropBehavior.md)
+- [ContextDragBehavior](./behaviors/ContextDragBehavior.md)
+- [ContextDragWithDirectionBehavior](./behaviors/ContextDragWithDirectionBehavior.md)
+- [ContextDropBehavior](./behaviors/ContextDropBehavior.md)
+- [DragAndDropEventsBehavior](./behaviors/DragAndDropEventsBehavior.md)
+- [FilesDropBehavior](./behaviors/FilesDropBehavior.md)
+- [PanelDragBehavior](./behaviors/PanelDragBehavior.md)
+- [PanelDropBehavior](./behaviors/PanelDropBehavior.md)
+- [TextDropBehavior](./behaviors/TextDropBehavior.md)
+- [TypedDragBehavior](./behaviors/TypedDragBehavior.md)
+
+## Draggable
+
+- [CanvasDragBehavior](./behaviors/CanvasDragBehavior.md)
+- [GridDragBehavior](./behaviors/GridDragBehavior.md)
+- [ItemDragBehavior](./behaviors/ItemDragBehavior.md)
+- [MouseDragElementBehavior](./behaviors/MouseDragElementBehavior.md)
+- [MultiMouseDragElementBehavior](./behaviors/MultiMouseDragElementBehavior.md)
+
+## Event Triggers
+
+- [DoubleTappedEventTrigger](./triggers/DoubleTappedEventTrigger.md)
+- [DragEnterEventTrigger](./triggers/DragEnterEventTrigger.md)
+- [DragLeaveEventTrigger](./triggers/DragLeaveEventTrigger.md)
+- [DragOverEventTrigger](./triggers/DragOverEventTrigger.md)
+- [DropEventTrigger](./triggers/DropEventTrigger.md)
+- [GotFocusEventTrigger](./triggers/GotFocusEventTrigger.md)
+- [KeyDownEventTrigger](./triggers/KeyDownEventTrigger.md)
+- [KeyUpEventTrigger](./triggers/KeyUpEventTrigger.md)
+- [LostFocusEventTrigger](./triggers/LostFocusEventTrigger.md)
+- [PointerCaptureLostEventTrigger](./triggers/PointerCaptureLostEventTrigger.md)
+- [PointerEnteredEventTrigger](./triggers/PointerEnteredEventTrigger.md)
+- [PointerEventsTrigger](./triggers/PointerEventsTrigger.md)
+- [PointerExitedEventTrigger](./triggers/PointerExitedEventTrigger.md)
+- [PointerMovedEventTrigger](./triggers/PointerMovedEventTrigger.md)
+- [PointerPressedEventTrigger](./triggers/PointerPressedEventTrigger.md)
+- [PointerReleasedEventTrigger](./triggers/PointerReleasedEventTrigger.md)
+- [PointerWheelChangedEventTrigger](./triggers/PointerWheelChangedEventTrigger.md)
+- [PopupClosedTrigger](./triggers/PopupClosedTrigger.md)
+- [PopupOpenedTrigger](./triggers/PopupOpenedTrigger.md)
+- [RightTappedEventTrigger](./triggers/RightTappedEventTrigger.md)
+- [ScrollGestureEndedEventTrigger](./triggers/ScrollGestureEndedEventTrigger.md)
+- [ScrollGestureEventTrigger](./triggers/ScrollGestureEventTrigger.md)
+- [TappedEventTrigger](./triggers/TappedEventTrigger.md)
+- [TextInputEventTrigger](./triggers/TextInputEventTrigger.md)
+- [TextInputMethodClientRequestedEventTrigger](./triggers/TextInputMethodClientRequestedEventTrigger.md)
+
+## Events
+
+- [DoubleTappedEventBehavior](./behaviors/DoubleTappedEventBehavior.md)
+- [GotFocusEventBehavior](./behaviors/GotFocusEventBehavior.md)
+- [InteractionTriggerBehavior](./behaviors/InteractionTriggerBehavior.md)
+- [KeyDownEventBehavior](./behaviors/KeyDownEventBehavior.md)
+- [KeyUpEventBehavior](./behaviors/KeyUpEventBehavior.md)
+- [LostFocusEventBehavior](./behaviors/LostFocusEventBehavior.md)
+- [PointerCaptureLostEventBehavior](./behaviors/PointerCaptureLostEventBehavior.md)
+- [PointerEnteredEventBehavior](./behaviors/PointerEnteredEventBehavior.md)
+- [PointerEventsBehavior](./behaviors/PointerEventsBehavior.md)
+- [PointerExitedEventBehavior](./behaviors/PointerExitedEventBehavior.md)
+- [PointerMovedEventBehavior](./behaviors/PointerMovedEventBehavior.md)
+- [PointerPressedEventBehavior](./behaviors/PointerPressedEventBehavior.md)
+- [PointerReleasedEventBehavior](./behaviors/PointerReleasedEventBehavior.md)
+- [PointerWheelChangedEventBehavior](./behaviors/PointerWheelChangedEventBehavior.md)
+- [RightTappedEventBehavior](./behaviors/RightTappedEventBehavior.md)
+- [ScrollGestureEndedEventBehavior](./behaviors/ScrollGestureEndedEventBehavior.md)
+- [ScrollGestureEventBehavior](./behaviors/ScrollGestureEventBehavior.md)
+- [TappedEventBehavior](./behaviors/TappedEventBehavior.md)
+- [TextInputEventBehavior](./behaviors/TextInputEventBehavior.md)
+- [TextInputMethodClientRequestedEventBehavior](./behaviors/TextInputMethodClientRequestedEventBehavior.md)
+
+## ExecuteCommand
+
+- [ExecuteCommandOnActivatedBehavior](./behaviors/ExecuteCommandOnActivatedBehavior.md)
+- [ExecuteCommandOnDoubleTappedBehavior](./behaviors/ExecuteCommandOnDoubleTappedBehavior.md)
+- [ExecuteCommandOnGotFocusBehavior](./behaviors/ExecuteCommandOnGotFocusBehavior.md)
+- [ExecuteCommandOnHoldingBehavior](./behaviors/ExecuteCommandOnHoldingBehavior.md)
+- [ExecuteCommandOnKeyDownBehavior](./behaviors/ExecuteCommandOnKeyDownBehavior.md)
+- [ExecuteCommandOnKeyUpBehavior](./behaviors/ExecuteCommandOnKeyUpBehavior.md)
+- [ExecuteCommandOnLostFocusBehavior](./behaviors/ExecuteCommandOnLostFocusBehavior.md)
+- [ExecuteCommandOnPinchBehavior](./behaviors/ExecuteCommandOnPinchBehavior.md)
+- [ExecuteCommandOnPinchEndedBehavior](./behaviors/ExecuteCommandOnPinchEndedBehavior.md)
+- [ExecuteCommandOnPointerCaptureLostBehavior](./behaviors/ExecuteCommandOnPointerCaptureLostBehavior.md)
+- [ExecuteCommandOnPointerEnteredBehavior](./behaviors/ExecuteCommandOnPointerEnteredBehavior.md)
+- [ExecuteCommandOnPointerExitedBehavior](./behaviors/ExecuteCommandOnPointerExitedBehavior.md)
+- [ExecuteCommandOnPointerMovedBehavior](./behaviors/ExecuteCommandOnPointerMovedBehavior.md)
+- [ExecuteCommandOnPointerPressedBehavior](./behaviors/ExecuteCommandOnPointerPressedBehavior.md)
+- [ExecuteCommandOnPointerReleasedBehavior](./behaviors/ExecuteCommandOnPointerReleasedBehavior.md)
+- [ExecuteCommandOnPointerTouchPadGestureMagnifyBehavior](./behaviors/ExecuteCommandOnPointerTouchPadGestureMagnifyBehavior.md)
+- [ExecuteCommandOnPointerTouchPadGestureRotateBehavior](./behaviors/ExecuteCommandOnPointerTouchPadGestureRotateBehavior.md)
+- [ExecuteCommandOnPointerTouchPadGestureSwipeBehavior](./behaviors/ExecuteCommandOnPointerTouchPadGestureSwipeBehavior.md)
+- [ExecuteCommandOnPointerWheelChangedBehavior](./behaviors/ExecuteCommandOnPointerWheelChangedBehavior.md)
+- [ExecuteCommandOnPullGestureBehavior](./behaviors/ExecuteCommandOnPullGestureBehavior.md)
+- [ExecuteCommandOnPullGestureEndedBehavior](./behaviors/ExecuteCommandOnPullGestureEndedBehavior.md)
+- [ExecuteCommandOnRightTappedBehavior](./behaviors/ExecuteCommandOnRightTappedBehavior.md)
+- [ExecuteCommandOnScrollGestureBehavior](./behaviors/ExecuteCommandOnScrollGestureBehavior.md)
+- [ExecuteCommandOnScrollGestureEndedBehavior](./behaviors/ExecuteCommandOnScrollGestureEndedBehavior.md)
+- [ExecuteCommandOnScrollGestureInertiaStartingBehavior](./behaviors/ExecuteCommandOnScrollGestureInertiaStartingBehavior.md)
+- [ExecuteCommandOnTappedBehavior](./behaviors/ExecuteCommandOnTappedBehavior.md)
+- [ExecuteCommandOnTextInputBehavior](./behaviors/ExecuteCommandOnTextInputBehavior.md)
+- [ExecuteCommandOnTextInputMethodClientRequestedBehavior](./behaviors/ExecuteCommandOnTextInputMethodClientRequestedBehavior.md)
+
+## FileUpload
+
+- [ButtonUploadFileBehavior](./behaviors/ButtonUploadFileBehavior.md)
+- [UploadCompletedTrigger](./triggers/UploadCompletedTrigger.md)
+- [UploadFileAction](./actions/UploadFileAction.md)
+
+## Focus
+
+- [AutoFocusBehavior](./behaviors/AutoFocusBehavior.md)
+- [FocusBehavior](./behaviors/FocusBehavior.md)
+- [FocusControlBehavior](./behaviors/FocusControlBehavior.md)
+- [FocusOnAttachedBehavior](./behaviors/FocusOnAttachedBehavior.md)
+- [FocusOnAttachedToVisualTreeBehavior](./behaviors/FocusOnAttachedToVisualTreeBehavior.md)
+- [FocusOnPointerMovedBehavior](./behaviors/FocusOnPointerMovedBehavior.md)
+- [FocusOnPointerPressedBehavior](./behaviors/FocusOnPointerPressedBehavior.md)
+- [FocusSelectedItemBehavior](./behaviors/FocusSelectedItemBehavior.md)
+
+## Gestures
+
+- [DoubleTappedGestureTrigger](./triggers/DoubleTappedGestureTrigger.md)
+- [HoldingGestureTrigger](./triggers/HoldingGestureTrigger.md)
+- [PinchEndedGestureTrigger](./triggers/PinchEndedGestureTrigger.md)
+- [PinchGestureTrigger](./triggers/PinchGestureTrigger.md)
+- [PointerTouchPadGestureMagnifyGestureTrigger](./triggers/PointerTouchPadGestureMagnifyGestureTrigger.md)
+- [PointerTouchPadGestureRotateGestureTrigger](./triggers/PointerTouchPadGestureRotateGestureTrigger.md)
+- [PointerTouchPadGestureSwipeGestureTrigger](./triggers/PointerTouchPadGestureSwipeGestureTrigger.md)
+- [PullGestureEndedGestureTrigger](./triggers/PullGestureEndedGestureTrigger.md)
+- [PullGestureGestureTrigger](./triggers/PullGestureGestureTrigger.md)
+- [RightTappedGestureTrigger](./triggers/RightTappedGestureTrigger.md)
+- [ScrollGestureEndedGestureTrigger](./triggers/ScrollGestureEndedGestureTrigger.md)
+- [ScrollGestureGestureTrigger](./triggers/ScrollGestureGestureTrigger.md)
+- [ScrollGestureInertiaStartingGestureTrigger](./triggers/ScrollGestureInertiaStartingGestureTrigger.md)
+- [TappedGestureTrigger](./triggers/TappedGestureTrigger.md)
+
+## Icon
+
+- [PathIconDataBehavior](./behaviors/PathIconDataBehavior.md)
+- [PathIconDataChangedTrigger](./triggers/PathIconDataChangedTrigger.md)
+- [SetPathIconDataAction](./actions/SetPathIconDataAction.md)
+
+## InputElement Actions
+
+- [CapturePointerAction](./actions/CapturePointerAction.md)
+- [DoubleTappedTrigger](./triggers/DoubleTappedTrigger.md)
+- [GotFocusTrigger](./triggers/GotFocusTrigger.md)
+- [HideToolTipAction](./actions/HideToolTipAction.md)
+- [HoldingTrigger](./triggers/HoldingTrigger.md)
+- [KeyDownTrigger](./triggers/KeyDownTrigger.md)
+- [KeyGestureTrigger](./triggers/KeyGestureTrigger.md)
+- [KeyTrigger](./triggers/KeyTrigger.md)
+- [KeyUpTrigger](./triggers/KeyUpTrigger.md)
+- [LostFocusTrigger](./triggers/LostFocusTrigger.md)
+- [PointerCaptureLostTrigger](./triggers/PointerCaptureLostTrigger.md)
+- [PointerEnteredTrigger](./triggers/PointerEnteredTrigger.md)
+- [PointerExitedTrigger](./triggers/PointerExitedTrigger.md)
+- [PointerMovedTrigger](./triggers/PointerMovedTrigger.md)
+- [PointerPressedTrigger](./triggers/PointerPressedTrigger.md)
+- [PointerReleasedTrigger](./triggers/PointerReleasedTrigger.md)
+- [PointerWheelChangedTrigger](./triggers/PointerWheelChangedTrigger.md)
+- [ReleasePointerCaptureAction](./actions/ReleasePointerCaptureAction.md)
+- [SetCursorAction](./actions/SetCursorAction.md)
+- [SetCursorFromProviderAction](./actions/SetCursorFromProviderAction.md)
+- [SetEnabledAction](./actions/SetEnabledAction.md)
+- [SetToolTipTipAction](./actions/SetToolTipTipAction.md)
+- [ShowToolTipAction](./actions/ShowToolTipAction.md)
+- [TappedTrigger](./triggers/TappedTrigger.md)
+- [TextInputMethodClientRequestedTrigger](./triggers/TextInputMethodClientRequestedTrigger.md)
+- [TextInputTrigger](./triggers/TextInputTrigger.md)
+- [ToolTipClosingTrigger](./triggers/ToolTipClosingTrigger.md)
+- [ToolTipOpeningTrigger](./triggers/ToolTipOpeningTrigger.md)
+
+## ItemsControl
+
+- [AddItemToItemsControlAction](./actions/AddItemToItemsControlAction.md)
+- [ClearItemsControlAction](./actions/ClearItemsControlAction.md)
+- [InsertItemToItemsControlAction](./actions/InsertItemToItemsControlAction.md)
+- [ItemNudgeDropBehavior](./behaviors/ItemNudgeDropBehavior.md)
+- [ItemsControlContainerClearingTrigger](./triggers/ItemsControlContainerClearingTrigger.md)
+- [ItemsControlContainerEventsBehavior](./behaviors/ItemsControlContainerEventsBehavior.md)
+- [ItemsControlContainerIndexChangedTrigger](./triggers/ItemsControlContainerIndexChangedTrigger.md)
+- [ItemsControlContainerPreparedTrigger](./triggers/ItemsControlContainerPreparedTrigger.md)
+- [ItemsControlPreparingContainerTrigger](./triggers/ItemsControlPreparingContainerTrigger.md)
+- [RemoveItemInItemsControlAction](./actions/RemoveItemInItemsControlAction.md)
+- [ScrollToItemBehavior](./behaviors/ScrollToItemBehavior.md)
+- [ScrollToItemIndexBehavior](./behaviors/ScrollToItemIndexBehavior.md)
+
+## ListBox
+
+- [ListBoxSelectAllBehavior](./behaviors/ListBoxSelectAllBehavior.md)
+- [ListBoxUnselectAllBehavior](./behaviors/ListBoxUnselectAllBehavior.md)
+- [RemoveItemInListBoxAction](./actions/RemoveItemInListBoxAction.md)
+
+## ListBoxItem
+
+- [SelectListBoxItemOnPointerMovedBehavior](./behaviors/SelectListBoxItemOnPointerMovedBehavior.md)
+
+## Notifications
+
+- [NotificationManagerBehavior](./behaviors/NotificationManagerBehavior.md)
+- [ShowErrorNotificationAction](./actions/ShowErrorNotificationAction.md)
+- [ShowInformationNotificationAction](./actions/ShowInformationNotificationAction.md)
+- [ShowNotificationAction](./actions/ShowNotificationAction.md)
+- [ShowSuccessNotificationAction](./actions/ShowSuccessNotificationAction.md)
+- [ShowWarningNotificationAction](./actions/ShowWarningNotificationAction.md)
+
+## ReactiveUI
+
+- [ClearNavigationStackAction](./actions/ClearNavigationStackAction.md)
+- [NavigateAction](./actions/NavigateAction.md)
+- [NavigateBackAction](./actions/NavigateBackAction.md)
+- [NavigateToAction](./actions/NavigateToAction.md)
+- [NavigateToAndResetAction](./actions/NavigateToAndResetAction.md)
+- [ObservableTriggerBehavior](./behaviors/ObservableTriggerBehavior.md)
+
+## RenderTargetBitmap
+
+- [RenderRenderTargetBitmapAction](./actions/RenderRenderTargetBitmapAction.md)
+- [RenderTargetBitmapBehavior](./behaviors/RenderTargetBitmapBehavior.md)
+- [RenderTargetBitmapTrigger](./triggers/RenderTargetBitmapTrigger.md)
+- [StaticRenderTargetBitmapBehavior](./behaviors/StaticRenderTargetBitmapBehavior.md)
+
+## Responsive
+
+- [AdaptiveBehavior](./behaviors/AdaptiveBehavior.md)
+- [AspectRatioBehavior](./behaviors/AspectRatioBehavior.md)
+
+## Screen
+
+- [ActiveScreenBehavior](./behaviors/ActiveScreenBehavior.md)
+- [RequestScreenDetailsAction](./actions/RequestScreenDetailsAction.md)
+- [ScreensChangedTrigger](./triggers/ScreensChangedTrigger.md)
+
+## Scripting
+
+- [ExecuteScriptAction](./actions/ExecuteScriptAction.md)
+
+## ScrollViewer
+
+- [HorizontalScrollViewerBehavior](./behaviors/HorizontalScrollViewerBehavior.md)
+- [ViewportBehavior](./behaviors/ViewportBehavior.md)
+
+## SelectingItemsControl
+
+- [SelectingItemsControlEventsBehavior](./behaviors/SelectingItemsControlEventsBehavior.md)
+
+## Show
+
+- [ShowOnDoubleTappedBehavior](./behaviors/ShowOnDoubleTappedBehavior.md)
+- [ShowOnKeyDownBehavior](./behaviors/ShowOnKeyDownBehavior.md)
+- [ShowOnTappedBehavior](./behaviors/ShowOnTappedBehavior.md)
+
+## SplitView
+
+- [SplitViewPaneClosedTrigger](./triggers/SplitViewPaneClosedTrigger.md)
+- [SplitViewPaneClosingTrigger](./triggers/SplitViewPaneClosingTrigger.md)
+- [SplitViewPaneOpenedTrigger](./triggers/SplitViewPaneOpenedTrigger.md)
+- [SplitViewPaneOpeningTrigger](./triggers/SplitViewPaneOpeningTrigger.md)
+- [SplitViewStateBehavior](./behaviors/SplitViewStateBehavior.md)
+
+## StorageProvider
+
+- [OpenFilePickerAction](./actions/OpenFilePickerAction.md)
+- [OpenFolderPickerAction](./actions/OpenFolderPickerAction.md)
+- [SaveFilePickerAction](./actions/SaveFilePickerAction.md)
+
+## StorageProvider – Button
+
+- [ButtonOpenFilePickerBehavior](./behaviors/ButtonOpenFilePickerBehavior.md)
+- [ButtonOpenFolderPickerBehavior](./behaviors/ButtonOpenFolderPickerBehavior.md)
+- [ButtonSaveFilePickerBehavior](./behaviors/ButtonSaveFilePickerBehavior.md)
+
+## StorageProvider – MenuItem
+
+- [MenuItemOpenFilePickerBehavior](./behaviors/MenuItemOpenFilePickerBehavior.md)
+- [MenuItemOpenFolderPickerBehavior](./behaviors/MenuItemOpenFolderPickerBehavior.md)
+- [MenuItemSaveFilePickerBehavior](./behaviors/MenuItemSaveFilePickerBehavior.md)
+
+## StyledElement
+
+- [StyledElementAction](./actions/StyledElementAction.md)
+- [StyledElementBehavior](./behaviors/StyledElementBehavior.md)
+- [StyledElementTrigger](./triggers/StyledElementTrigger.md)
+
+## TabControl
+
+- [TabControlKeyNavigationBehavior](./behaviors/TabControlKeyNavigationBehavior.md)
+- [TabControlNextAction](./actions/TabControlNextAction.md)
+- [TabControlPreviousAction](./actions/TabControlPreviousAction.md)
+- [TabControlSelectionChangedTrigger](./triggers/TabControlSelectionChangedTrigger.md)
+
+## TextBox
+
+- [AutoSelectBehavior](./behaviors/AutoSelectBehavior.md)
+- [TextBoxSelectAllOnGotFocusBehavior](./behaviors/TextBoxSelectAllOnGotFocusBehavior.md)
+- [TextBoxSelectAllTextBehavior](./behaviors/TextBoxSelectAllTextBehavior.md)
+
+## Transitions
+
+- [AddTransitionAction](./actions/AddTransitionAction.md)
+- [ClearTransitionsAction](./actions/ClearTransitionsAction.md)
+- [RemoveTransitionAction](./actions/RemoveTransitionAction.md)
+- [TransitionsBehavior](./behaviors/TransitionsBehavior.md)
+- [TransitionsChangedTrigger](./triggers/TransitionsChangedTrigger.md)
+
+## TreeView
+
+- [ApplyTreeViewFilterAction](./actions/ApplyTreeViewFilterAction.md)
+- [TreeViewFilterBehavior](./behaviors/TreeViewFilterBehavior.md)
+- [TreeViewFilterTextChangedTrigger](./triggers/TreeViewFilterTextChangedTrigger.md)
+
+## TreeViewItem
+
+- [ToggleIsExpandedOnDoubleTappedBehavior](./behaviors/ToggleIsExpandedOnDoubleTappedBehavior.md)
+
+## Validation
+
+- [ComboBoxValidationBehavior](./behaviors/ComboBoxValidationBehavior.md)
+- [DatePickerValidationBehavior](./behaviors/DatePickerValidationBehavior.md)
+- [NumericUpDownValidationBehavior](./behaviors/NumericUpDownValidationBehavior.md)
+- [PropertyValidationBehavior](./behaviors/PropertyValidationBehavior.md)
+- [SliderValidationBehavior](./behaviors/SliderValidationBehavior.md)
+- [TextBoxValidationBehavior](./behaviors/TextBoxValidationBehavior.md)
+
+## Window
+
+- [CloseWindowAction](./actions/CloseWindowAction.md)
+- [DialogClosedTrigger](./triggers/DialogClosedTrigger.md)
+- [DialogOpenedTrigger](./triggers/DialogOpenedTrigger.md)
+- [ShowDialogAction](./actions/ShowDialogAction.md)
+
+## WriteableBitmap
+
+- [WriteableBitmapBehavior](./behaviors/WriteableBitmapBehavior.md)
+- [WriteableBitmapRenderAction](./actions/WriteableBitmapRenderAction.md)
+- [WriteableBitmapRenderBehavior](./behaviors/WriteableBitmapRenderBehavior.md)
+- [WriteableBitmapTimerTrigger](./triggers/WriteableBitmapTimerTrigger.md)
+- [WriteableBitmapTrigger](./triggers/WriteableBitmapTrigger.md)

--- a/docs/triggers/ActualThemeVariantChangedTrigger.md
+++ b/docs/triggers/ActualThemeVariantChangedTrigger.md
@@ -1,0 +1,19 @@
+# ActualThemeVariantChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the actual theme variant of a control changes.
+
+Example: [ActualThemeVariantChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/ActualThemeVariantChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ActualThemeVariantChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ActualThemeVariantChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/AnimationCompletedTrigger.md
+++ b/docs/triggers/AnimationCompletedTrigger.md
@@ -1,0 +1,19 @@
+# AnimationCompletedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Plays an animation and invokes actions once the animation finishes running.
+
+Example: [AnimationCompletedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/AnimationCompletedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:AnimationCompletedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:AnimationCompletedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/AttachedToLogicalTreeTrigger.md
+++ b/docs/triggers/AttachedToLogicalTreeTrigger.md
@@ -1,0 +1,19 @@
+# AttachedToLogicalTreeTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when an element is attached to the logical tree.
+
+Example: [AttachedToLogicalTreeTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/AttachedToLogicalTreeTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:AttachedToLogicalTreeTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:AttachedToLogicalTreeTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/AttachedToVisualTreeTrigger.md
+++ b/docs/triggers/AttachedToVisualTreeTrigger.md
@@ -1,0 +1,19 @@
+# AttachedToVisualTreeTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the associated element is added to the visual tree.
+
+Example: [AttachedToVisualTreeTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/AttachedToVisualTreeTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:AttachedToVisualTreeTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:AttachedToVisualTreeTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/AutoCompleteBoxSelectionChangedTrigger.md
+++ b/docs/triggers/AutoCompleteBoxSelectionChangedTrigger.md
@@ -1,0 +1,19 @@
+# AutoCompleteBoxSelectionChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the AutoCompleteBox selection changes.
+
+Example: [AutoCompleteBoxView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutoCompleteBoxView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:AutoCompleteBoxSelectionChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:AutoCompleteBoxSelectionChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/AutomationNameChangedTrigger.md
+++ b/docs/triggers/AutomationNameChangedTrigger.md
@@ -1,0 +1,19 @@
+# AutomationNameChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the automation name of the control changes.
+
+Example: [AutomationView.axaml](samples/BehaviorsTestApplication/Views/Pages/AutomationView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:AutomationNameChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:AutomationNameChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/CollectionChangedTrigger.md
+++ b/docs/triggers/CollectionChangedTrigger.md
@@ -1,0 +1,19 @@
+# CollectionChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions whenever the observed collection changes.
+
+Example: [CollectionChangedTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/CollectionChangedTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:CollectionChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:CollectionChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ContextDialogClosedTrigger.md
+++ b/docs/triggers/ContextDialogClosedTrigger.md
@@ -1,0 +1,19 @@
+# ContextDialogClosedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a context dialog is closed.
+
+Example: [ContextDialogView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ContextDialogClosedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ContextDialogClosedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ContextDialogOpenedTrigger.md
+++ b/docs/triggers/ContextDialogOpenedTrigger.md
@@ -1,0 +1,19 @@
+# ContextDialogOpenedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a context dialog is opened.
+
+Example: [ContextDialogView.axaml](samples/BehaviorsTestApplication/Views/Pages/ContextDialogView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ContextDialogOpenedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ContextDialogOpenedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DataContextChangedTrigger.md
+++ b/docs/triggers/DataContextChangedTrigger.md
@@ -1,0 +1,19 @@
+# DataContextChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the DataContext of a control changes.
+
+Example: [DataContextChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/DataContextChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DataContextChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DataContextChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DataTrigger.md
+++ b/docs/triggers/DataTrigger.md
@@ -1,0 +1,19 @@
+# DataTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Performs actions when the bound data meets a specified condition.
+
+Example: [DataTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/DataTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Core:DataTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Core:DataTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DelayedLoadTrigger.md
+++ b/docs/triggers/DelayedLoadTrigger.md
@@ -1,0 +1,19 @@
+# DelayedLoadTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Invokes actions after the control is loaded and a delay period expires.
+
+Example: [DelayedLoadTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/DelayedLoadTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DelayedLoadTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DelayedLoadTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DetachedFromLogicalTreeTrigger.md
+++ b/docs/triggers/DetachedFromLogicalTreeTrigger.md
@@ -1,0 +1,19 @@
+# DetachedFromLogicalTreeTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control is removed from the logical tree.
+
+Example: [DetachedFromLogicalTreeTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/DetachedFromLogicalTreeTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DetachedFromLogicalTreeTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DetachedFromLogicalTreeTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DetachedFromVisualTreeTrigger.md
+++ b/docs/triggers/DetachedFromVisualTreeTrigger.md
@@ -1,0 +1,19 @@
+# DetachedFromVisualTreeTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control is removed from the visual tree.
+
+Example: [DetachedFromVisualTreeTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/DetachedFromVisualTreeTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DetachedFromVisualTreeTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DetachedFromVisualTreeTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DialogClosedTrigger.md
+++ b/docs/triggers/DialogClosedTrigger.md
@@ -1,0 +1,19 @@
+# DialogClosedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a window is closed.
+
+Example: [DialogActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/DialogActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DialogClosedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DialogClosedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DialogOpenedTrigger.md
+++ b/docs/triggers/DialogOpenedTrigger.md
@@ -1,0 +1,19 @@
+# DialogOpenedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a window is opened.
+
+Example: [DialogActionView.axaml](samples/BehaviorsTestApplication/Views/Pages/DialogActionView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DialogOpenedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DialogOpenedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DisposingTrigger.md
+++ b/docs/triggers/DisposingTrigger.md
@@ -1,0 +1,19 @@
+# DisposingTrigger
+
+Namespace: ``
+
+A base class for triggers that need to dispose of resources when detached.
+
+Example: [DisposingTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/DisposingTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <:DisposingTrigger>
+    <!-- actions -->
+  </:DisposingTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DoubleTappedEventTrigger.md
+++ b/docs/triggers/DoubleTappedEventTrigger.md
@@ -1,0 +1,19 @@
+# DoubleTappedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a double-tap gesture occurs.
+
+Example: [GestureEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:DoubleTappedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:DoubleTappedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DoubleTappedGestureTrigger.md
+++ b/docs/triggers/DoubleTappedGestureTrigger.md
@@ -1,0 +1,19 @@
+# DoubleTappedGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a double-tap gesture is detected.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DoubleTappedGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DoubleTappedGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DoubleTappedTrigger.md
+++ b/docs/triggers/DoubleTappedTrigger.md
@@ -1,0 +1,19 @@
+# DoubleTappedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Listens for a double-tap event and executes its actions.
+
+Example: [GestureTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:DoubleTappedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:DoubleTappedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DragEnterEventTrigger.md
+++ b/docs/triggers/DragEnterEventTrigger.md
@@ -1,0 +1,19 @@
+# DragEnterEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a drag operation enters the element.
+
+Example: [DragBetweenPanelsView.axaml](samples/BehaviorsTestApplication/Views/Pages/DragBetweenPanelsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:DragEnterEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:DragEnterEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DragLeaveEventTrigger.md
+++ b/docs/triggers/DragLeaveEventTrigger.md
@@ -1,0 +1,19 @@
+# DragLeaveEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a drag operation leaves the element.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:DragLeaveEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:DragLeaveEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DragOverEventTrigger.md
+++ b/docs/triggers/DragOverEventTrigger.md
@@ -1,0 +1,19 @@
+# DragOverEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions while a drag is over the element.
+
+Example: [FilesPreviewView.axaml](samples/BehaviorsTestApplication/Views/Pages/FilesPreviewView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:DragOverEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:DragOverEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/DropEventTrigger.md
+++ b/docs/triggers/DropEventTrigger.md
@@ -1,0 +1,19 @@
+# DropEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when an item is dropped on the element.
+
+Example: [DragBetweenPanelsView.axaml](samples/BehaviorsTestApplication/Views/Pages/DragBetweenPanelsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:DropEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:DropEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/EventTrigger.md
+++ b/docs/triggers/EventTrigger.md
@@ -1,0 +1,19 @@
+# EventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Executes its actions when the configured event is raised.
+
+Example: [RoutedEventTriggerBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/RoutedEventTriggerBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Core:EventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Core:EventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/GotFocusEventTrigger.md
+++ b/docs/triggers/GotFocusEventTrigger.md
@@ -1,0 +1,19 @@
+# GotFocusEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the control receives focus.
+
+Example: [FocusEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:GotFocusEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:GotFocusEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/GotFocusTrigger.md
+++ b/docs/triggers/GotFocusTrigger.md
@@ -1,0 +1,19 @@
+# GotFocusTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control receives focus.
+
+Example: [FocusTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:GotFocusTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:GotFocusTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/HoldingGestureTrigger.md
+++ b/docs/triggers/HoldingGestureTrigger.md
@@ -1,0 +1,19 @@
+# HoldingGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a holding (long press) gesture is detected.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:HoldingGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:HoldingGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/HoldingTrigger.md
+++ b/docs/triggers/HoldingTrigger.md
@@ -1,0 +1,19 @@
+# HoldingTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a holding gesture is detected.
+
+Example: [GestureTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:HoldingTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:HoldingTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ITrigger.md
+++ b/docs/triggers/ITrigger.md
@@ -1,0 +1,19 @@
+# ITrigger
+
+Namespace: ``
+
+Interface for triggers that encapsulate a collection of actions.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <:ITrigger>
+    <!-- actions -->
+  </:ITrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/IfElseTrigger.md
+++ b/docs/triggers/IfElseTrigger.md
@@ -1,0 +1,19 @@
+# IfElseTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes one collection of actions when a condition is true and another when it is false.
+
+Example: [IfElseTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/IfElseTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:IfElseTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:IfElseTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/InitializedTrigger.md
+++ b/docs/triggers/InitializedTrigger.md
@@ -1,0 +1,19 @@
+# InitializedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions once the control is initialized.
+
+Example: [InitializedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/InitializedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:InitializedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:InitializedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ItemsControlContainerClearingTrigger.md
+++ b/docs/triggers/ItemsControlContainerClearingTrigger.md
@@ -1,0 +1,19 @@
+# ItemsControlContainerClearingTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the ItemsControl clears its container(s).
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ItemsControlContainerClearingTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ItemsControlContainerClearingTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ItemsControlContainerIndexChangedTrigger.md
+++ b/docs/triggers/ItemsControlContainerIndexChangedTrigger.md
@@ -1,0 +1,19 @@
+# ItemsControlContainerIndexChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the index of an item’s container changes.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ItemsControlContainerIndexChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ItemsControlContainerIndexChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ItemsControlContainerPreparedTrigger.md
+++ b/docs/triggers/ItemsControlContainerPreparedTrigger.md
@@ -1,0 +1,19 @@
+# ItemsControlContainerPreparedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a container for an item is prepared.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ItemsControlContainerPreparedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ItemsControlContainerPreparedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ItemsControlPreparingContainerTrigger.md
+++ b/docs/triggers/ItemsControlPreparingContainerTrigger.md
@@ -1,0 +1,19 @@
+# ItemsControlPreparingContainerTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Executes actions when the ItemsControl raises the PreparingContainer event.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ItemsControlPreparingContainerTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ItemsControlPreparingContainerTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/KeyDownEventTrigger.md
+++ b/docs/triggers/KeyDownEventTrigger.md
@@ -1,0 +1,19 @@
+# KeyDownEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a key is pressed.
+
+Example: [KeyEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:KeyDownEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:KeyDownEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/KeyDownTrigger.md
+++ b/docs/triggers/KeyDownTrigger.md
@@ -1,0 +1,19 @@
+# KeyDownTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Listens for key down events and triggers actions if the pressed key (or gesture) matches the specified criteria.
+
+Example: [KeyInputTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:KeyDownTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:KeyDownTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/KeyGestureTrigger.md
+++ b/docs/triggers/KeyGestureTrigger.md
@@ -1,0 +1,19 @@
+# KeyGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions based on a specified key gesture.
+
+Example: [KeyGestureTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyGestureTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:KeyGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:KeyGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/KeyTrigger.md
+++ b/docs/triggers/KeyTrigger.md
@@ -1,0 +1,19 @@
+# KeyTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Listens for key down or key up events and triggers actions when the configured key or gesture occurs.
+
+Example: [KeyTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:KeyTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:KeyTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/KeyUpEventTrigger.md
+++ b/docs/triggers/KeyUpEventTrigger.md
@@ -1,0 +1,19 @@
+# KeyUpEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a key is released.
+
+Example: [KeyEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:KeyUpEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:KeyUpEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/KeyUpTrigger.md
+++ b/docs/triggers/KeyUpTrigger.md
@@ -1,0 +1,19 @@
+# KeyUpTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Listens for key up events and triggers actions when conditions are met.
+
+Example: [KeyInputTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:KeyUpTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:KeyUpTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/LoadedTrigger.md
+++ b/docs/triggers/LoadedTrigger.md
@@ -1,0 +1,19 @@
+# LoadedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control’s Loaded event fires.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:LoadedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:LoadedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/LostFocusEventTrigger.md
+++ b/docs/triggers/LostFocusEventTrigger.md
@@ -1,0 +1,19 @@
+# LostFocusEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the control loses focus.
+
+Example: [FocusEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:LostFocusEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:LostFocusEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/LostFocusTrigger.md
+++ b/docs/triggers/LostFocusTrigger.md
@@ -1,0 +1,19 @@
+# LostFocusTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control loses focus.
+
+Example: [FocusTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/FocusTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:LostFocusTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:LostFocusTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PathIconDataChangedTrigger.md
+++ b/docs/triggers/PathIconDataChangedTrigger.md
@@ -1,0 +1,19 @@
+# PathIconDataChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a PathIcon's Data changes.
+
+Example: [IconView.axaml](samples/BehaviorsTestApplication/Views/Pages/IconView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PathIconDataChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PathIconDataChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PinchEndedGestureTrigger.md
+++ b/docs/triggers/PinchEndedGestureTrigger.md
@@ -1,0 +1,19 @@
+# PinchEndedGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a pinch gesture has ended.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PinchEndedGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PinchEndedGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PinchGestureTrigger.md
+++ b/docs/triggers/PinchGestureTrigger.md
@@ -1,0 +1,19 @@
+# PinchGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions during a pinch gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PinchGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PinchGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerCaptureLostEventTrigger.md
+++ b/docs/triggers/PointerCaptureLostEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerCaptureLostEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when pointer capture is lost.
+
+Example: [PointerEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerCaptureLostEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerCaptureLostEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerCaptureLostTrigger.md
+++ b/docs/triggers/PointerCaptureLostTrigger.md
@@ -1,0 +1,19 @@
+# PointerCaptureLostTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when pointer capture is lost by the control.
+
+Example: [PointerExtraTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerCaptureLostTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerCaptureLostTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerEnteredEventTrigger.md
+++ b/docs/triggers/PointerEnteredEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerEnteredEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the pointer enters the control.
+
+Example: [PointerEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerEnteredEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerEnteredEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerEnteredTrigger.md
+++ b/docs/triggers/PointerEnteredTrigger.md
@@ -1,0 +1,19 @@
+# PointerEnteredTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the pointer enters the control’s area.
+
+Example: [PointerExtraTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerEnteredTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerEnteredTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerEventsTrigger.md
+++ b/docs/triggers/PointerEventsTrigger.md
@@ -1,0 +1,19 @@
+# PointerEventsTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions for pointer press, move, and release events.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerEventsTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerEventsTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerExitedEventTrigger.md
+++ b/docs/triggers/PointerExitedEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerExitedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the pointer exits the control.
+
+Example: [PointerEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerExitedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerExitedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerExitedTrigger.md
+++ b/docs/triggers/PointerExitedTrigger.md
@@ -1,0 +1,19 @@
+# PointerExitedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the pointer exits the control’s area.
+
+Example: [PointerExtraTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerExitedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerExitedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerMovedEventTrigger.md
+++ b/docs/triggers/PointerMovedEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerMovedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the pointer moves.
+
+Example: [PointerEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerMovedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerMovedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerMovedTrigger.md
+++ b/docs/triggers/PointerMovedTrigger.md
@@ -1,0 +1,19 @@
+# PointerMovedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions on pointer movement over the control.
+
+Example: [PointerTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerMovedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerMovedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerPressedEventTrigger.md
+++ b/docs/triggers/PointerPressedEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerPressedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the pointer is pressed.
+
+Example: [EventsBehaviorsView.axaml](samples/BehaviorsTestApplication/Views/Pages/EventsBehaviorsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerPressedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerPressedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerPressedTrigger.md
+++ b/docs/triggers/PointerPressedTrigger.md
@@ -1,0 +1,19 @@
+# PointerPressedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the pointer is pressed on the control.
+
+Example: [PointerTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerPressedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerPressedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerReleasedEventTrigger.md
+++ b/docs/triggers/PointerReleasedEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerReleasedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the pointer is released.
+
+Example: [PointerEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerReleasedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerReleasedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerReleasedTrigger.md
+++ b/docs/triggers/PointerReleasedTrigger.md
@@ -1,0 +1,19 @@
+# PointerReleasedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the pointer is released on the control.
+
+Example: [PointerTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerReleasedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerReleasedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerTouchPadGestureMagnifyGestureTrigger.md
+++ b/docs/triggers/PointerTouchPadGestureMagnifyGestureTrigger.md
@@ -1,0 +1,19 @@
+# PointerTouchPadGestureMagnifyGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions during a touchpad magnification gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerTouchPadGestureMagnifyGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerTouchPadGestureMagnifyGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerTouchPadGestureRotateGestureTrigger.md
+++ b/docs/triggers/PointerTouchPadGestureRotateGestureTrigger.md
@@ -1,0 +1,19 @@
+# PointerTouchPadGestureRotateGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions during a touchpad rotation gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerTouchPadGestureRotateGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerTouchPadGestureRotateGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerTouchPadGestureSwipeGestureTrigger.md
+++ b/docs/triggers/PointerTouchPadGestureSwipeGestureTrigger.md
@@ -1,0 +1,19 @@
+# PointerTouchPadGestureSwipeGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions during a touchpad swipe gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerTouchPadGestureSwipeGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerTouchPadGestureSwipeGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerWheelChangedEventTrigger.md
+++ b/docs/triggers/PointerWheelChangedEventTrigger.md
@@ -1,0 +1,19 @@
+# PointerWheelChangedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the pointer wheel changes.
+
+Example: [PointerEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:PointerWheelChangedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:PointerWheelChangedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PointerWheelChangedTrigger.md
+++ b/docs/triggers/PointerWheelChangedTrigger.md
@@ -1,0 +1,19 @@
+# PointerWheelChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions on mouse wheel (or equivalent) changes.
+
+Example: [PointerExtraTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerExtraTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PointerWheelChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PointerWheelChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PopupClosedTrigger.md
+++ b/docs/triggers/PopupClosedTrigger.md
@@ -1,0 +1,19 @@
+# PopupClosedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a popup is closed.
+
+Example: [PopupEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PopupEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PopupClosedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PopupClosedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PopupOpenedTrigger.md
+++ b/docs/triggers/PopupOpenedTrigger.md
@@ -1,0 +1,19 @@
+# PopupOpenedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a popup is opened.
+
+Example: [PopupEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PopupEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PopupOpenedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PopupOpenedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PropertyChangedTrigger.md
+++ b/docs/triggers/PropertyChangedTrigger.md
@@ -1,0 +1,19 @@
+# PropertyChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a property value changes.
+
+Example: [PropertyChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/PropertyChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PropertyChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PropertyChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PullGestureEndedGestureTrigger.md
+++ b/docs/triggers/PullGestureEndedGestureTrigger.md
@@ -1,0 +1,19 @@
+# PullGestureEndedGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a pull gesture ends.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PullGestureEndedGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PullGestureEndedGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/PullGestureGestureTrigger.md
+++ b/docs/triggers/PullGestureGestureTrigger.md
@@ -1,0 +1,19 @@
+# PullGestureGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions during a pull gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:PullGestureGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:PullGestureGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/RenderTargetBitmapTrigger.md
+++ b/docs/triggers/RenderTargetBitmapTrigger.md
@@ -1,0 +1,19 @@
+# RenderTargetBitmapTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when RenderTargetBitmap rendering completes.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:RenderTargetBitmapTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:RenderTargetBitmapTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ResourcesChangedTrigger.md
+++ b/docs/triggers/ResourcesChangedTrigger.md
@@ -1,0 +1,19 @@
+# ResourcesChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control’s resources are modified.
+
+Example: [ResourcesChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/ResourcesChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ResourcesChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ResourcesChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/RightTappedEventTrigger.md
+++ b/docs/triggers/RightTappedEventTrigger.md
@@ -1,0 +1,19 @@
+# RightTappedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions on a right-tap gesture.
+
+Example: [GestureEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:RightTappedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:RightTappedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/RightTappedGestureTrigger.md
+++ b/docs/triggers/RightTappedGestureTrigger.md
@@ -1,0 +1,19 @@
+# RightTappedGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions on a right-tap gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:RightTappedGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:RightTappedGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/RunAnimationTrigger.md
+++ b/docs/triggers/RunAnimationTrigger.md
@@ -1,0 +1,19 @@
+# RunAnimationTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Runs an animation and invokes actions when it completes.
+
+Example: [RunAnimationTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/RunAnimationTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:RunAnimationTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:RunAnimationTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ScreensChangedTrigger.md
+++ b/docs/triggers/ScreensChangedTrigger.md
@@ -1,0 +1,19 @@
+# ScreensChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the available screens change.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ScreensChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ScreensChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ScrollGestureEndedEventTrigger.md
+++ b/docs/triggers/ScrollGestureEndedEventTrigger.md
@@ -1,0 +1,19 @@
+# ScrollGestureEndedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a scroll gesture ends.
+
+Example: [GestureEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:ScrollGestureEndedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:ScrollGestureEndedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ScrollGestureEndedGestureTrigger.md
+++ b/docs/triggers/ScrollGestureEndedGestureTrigger.md
@@ -1,0 +1,19 @@
+# ScrollGestureEndedGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a scroll gesture completes.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ScrollGestureEndedGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ScrollGestureEndedGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ScrollGestureEventTrigger.md
+++ b/docs/triggers/ScrollGestureEventTrigger.md
@@ -1,0 +1,19 @@
+# ScrollGestureEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions during a scroll gesture.
+
+Example: [GestureEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:ScrollGestureEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:ScrollGestureEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ScrollGestureGestureTrigger.md
+++ b/docs/triggers/ScrollGestureGestureTrigger.md
@@ -1,0 +1,19 @@
+# ScrollGestureGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions during a scroll gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ScrollGestureGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ScrollGestureGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ScrollGestureInertiaStartingGestureTrigger.md
+++ b/docs/triggers/ScrollGestureInertiaStartingGestureTrigger.md
@@ -1,0 +1,19 @@
+# ScrollGestureInertiaStartingGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the inertia phase of a scroll gesture begins.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ScrollGestureInertiaStartingGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ScrollGestureInertiaStartingGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/SizeChangedTrigger.md
+++ b/docs/triggers/SizeChangedTrigger.md
@@ -1,0 +1,19 @@
+# SizeChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the associated control's size changes.
+
+Example: [SizeChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/SizeChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:SizeChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:SizeChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/SplitViewPaneClosedTrigger.md
+++ b/docs/triggers/SplitViewPaneClosedTrigger.md
@@ -1,0 +1,19 @@
+# SplitViewPaneClosedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions after the pane has closed.
+
+Example: [SplitViewStateBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SplitViewStateBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:SplitViewPaneClosedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:SplitViewPaneClosedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/SplitViewPaneClosingTrigger.md
+++ b/docs/triggers/SplitViewPaneClosingTrigger.md
@@ -1,0 +1,19 @@
+# SplitViewPaneClosingTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the pane is about to close.
+
+Example: [SplitViewStateBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SplitViewStateBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:SplitViewPaneClosingTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:SplitViewPaneClosingTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/SplitViewPaneOpenedTrigger.md
+++ b/docs/triggers/SplitViewPaneOpenedTrigger.md
@@ -1,0 +1,19 @@
+# SplitViewPaneOpenedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions after the pane has opened.
+
+Example: [SplitViewStateBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SplitViewStateBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:SplitViewPaneOpenedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:SplitViewPaneOpenedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/SplitViewPaneOpeningTrigger.md
+++ b/docs/triggers/SplitViewPaneOpeningTrigger.md
@@ -1,0 +1,19 @@
+# SplitViewPaneOpeningTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the pane is about to open.
+
+Example: [SplitViewStateBehaviorView.axaml](samples/BehaviorsTestApplication/Views/Pages/SplitViewStateBehaviorView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:SplitViewPaneOpeningTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:SplitViewPaneOpeningTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/StyledElementTrigger.md
+++ b/docs/triggers/StyledElementTrigger.md
@@ -1,0 +1,19 @@
+# StyledElementTrigger
+
+Namespace: ``
+
+A base trigger class for StyledElement objects.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <:StyledElementTrigger>
+    <!-- actions -->
+  </:StyledElementTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TabControlSelectionChangedTrigger.md
+++ b/docs/triggers/TabControlSelectionChangedTrigger.md
@@ -1,0 +1,19 @@
+# TabControlSelectionChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the TabControl selection changes.
+
+Example: [TabControlSelectionChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/TabControlSelectionChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TabControlSelectionChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TabControlSelectionChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TappedEventTrigger.md
+++ b/docs/triggers/TappedEventTrigger.md
@@ -1,0 +1,19 @@
+# TappedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when the control is tapped.
+
+Example: [GestureEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:TappedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:TappedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TappedGestureTrigger.md
+++ b/docs/triggers/TappedGestureTrigger.md
@@ -1,0 +1,19 @@
+# TappedGestureTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions on a simple tap gesture.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TappedGestureTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TappedGestureTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TappedTrigger.md
+++ b/docs/triggers/TappedTrigger.md
@@ -1,0 +1,19 @@
+# TappedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions on a tap event.
+
+Example: [GestureTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/GestureTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TappedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TappedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TextInputEventTrigger.md
+++ b/docs/triggers/TextInputEventTrigger.md
@@ -1,0 +1,19 @@
+# TextInputEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions on text input events.
+
+Example: [KeyEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:TextInputEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:TextInputEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TextInputMethodClientRequestedEventTrigger.md
+++ b/docs/triggers/TextInputMethodClientRequestedEventTrigger.md
@@ -1,0 +1,19 @@
+# TextInputMethodClientRequestedEventTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Events`
+
+Triggers actions when a text input method client is requested.
+
+Example: [KeyEventTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyEventTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Events:TextInputMethodClientRequestedEventTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Events:TextInputMethodClientRequestedEventTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TextInputMethodClientRequestedTrigger.md
+++ b/docs/triggers/TextInputMethodClientRequestedTrigger.md
@@ -1,0 +1,19 @@
+# TextInputMethodClientRequestedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a text input method (virtual keyboard) is requested.
+
+Example: [KeyInputTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TextInputMethodClientRequestedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TextInputMethodClientRequestedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TextInputTrigger.md
+++ b/docs/triggers/TextInputTrigger.md
@@ -1,0 +1,19 @@
+# TextInputTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions on text input events.
+
+Example: [KeyInputTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/KeyInputTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TextInputTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TextInputTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ThemeVariantTrigger.md
+++ b/docs/triggers/ThemeVariantTrigger.md
@@ -1,0 +1,19 @@
+# ThemeVariantTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the theme variant of a control changes.
+
+Example: [ThemeVariantTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/ThemeVariantTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ThemeVariantTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ThemeVariantTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TimerTrigger.md
+++ b/docs/triggers/TimerTrigger.md
@@ -1,0 +1,19 @@
+# TimerTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Core`
+
+Invokes actions repeatedly after a set interval.
+
+Example: [TimerTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/TimerTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Core:TimerTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Core:TimerTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ToolTipClosingTrigger.md
+++ b/docs/triggers/ToolTipClosingTrigger.md
@@ -1,0 +1,19 @@
+# ToolTipClosingTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a tooltip is closing.
+
+Example: [ToolTipHelpersView.axaml](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ToolTipClosingTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ToolTipClosingTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ToolTipOpeningTrigger.md
+++ b/docs/triggers/ToolTipOpeningTrigger.md
@@ -1,0 +1,19 @@
+# ToolTipOpeningTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when a tooltip is about to open.
+
+Example: [ToolTipHelpersView.axaml](samples/BehaviorsTestApplication/Views/Pages/ToolTipHelpersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ToolTipOpeningTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ToolTipOpeningTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TransitionsChangedTrigger.md
+++ b/docs/triggers/TransitionsChangedTrigger.md
@@ -1,0 +1,19 @@
+# TransitionsChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the `Transitions` property of a control changes.
+
+Example: [TransitionsChangedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/TransitionsChangedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TransitionsChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TransitionsChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/TreeViewFilterTextChangedTrigger.md
+++ b/docs/triggers/TreeViewFilterTextChangedTrigger.md
@@ -1,0 +1,19 @@
+# TreeViewFilterTextChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the search box text changes.
+
+Example: [TreeViewFilterView.axaml](samples/BehaviorsTestApplication/Views/Pages/TreeViewFilterView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:TreeViewFilterTextChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:TreeViewFilterTextChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/Trigger.md
+++ b/docs/triggers/Trigger.md
@@ -1,0 +1,19 @@
+# Trigger
+
+Namespace: ``
+
+A base class for triggers that execute a collection of actions when activated.
+
+Example: [PointerTriggersView.axaml](samples/BehaviorsTestApplication/Views/Pages/PointerTriggersView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <:Trigger>
+    <!-- actions -->
+  </:Trigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/UnloadedTrigger.md
+++ b/docs/triggers/UnloadedTrigger.md
@@ -1,0 +1,19 @@
+# UnloadedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Triggers actions when the control is unloaded from the visual tree.
+
+Example: [UnloadedTriggerView.axaml](samples/BehaviorsTestApplication/Views/Pages/UnloadedTriggerView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:UnloadedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:UnloadedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/UploadCompletedTrigger.md
+++ b/docs/triggers/UploadCompletedTrigger.md
@@ -1,0 +1,19 @@
+# UploadCompletedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Invokes actions when an upload is marked complete.
+
+Example: [UploadFileView.axaml](samples/BehaviorsTestApplication/Views/Pages/UploadFileView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:UploadCompletedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:UploadCompletedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/ViewModelPropertyChangedTrigger.md
+++ b/docs/triggers/ViewModelPropertyChangedTrigger.md
@@ -1,0 +1,19 @@
+# ViewModelPropertyChangedTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Invokes actions when a DataContext property changes.
+
+Example: [ViewModelPropertyActionsView.axaml](samples/BehaviorsTestApplication/Views/Pages/ViewModelPropertyActionsView.axaml)
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:ViewModelPropertyChangedTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:ViewModelPropertyChangedTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/WriteableBitmapTimerTrigger.md
+++ b/docs/triggers/WriteableBitmapTimerTrigger.md
@@ -1,0 +1,19 @@
+# WriteableBitmapTimerTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Fires its actions on a timer and passes the writeable bitmap as a parameter.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:WriteableBitmapTimerTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:WriteableBitmapTimerTrigger>
+</Interaction.Triggers>
+```

--- a/docs/triggers/WriteableBitmapTrigger.md
+++ b/docs/triggers/WriteableBitmapTrigger.md
@@ -1,0 +1,19 @@
+# WriteableBitmapTrigger
+
+Namespace: `Avalonia.Xaml.Interactions.Custom`
+
+Manually executes its actions with the provided writeable bitmap when triggered.
+
+
+
+## Key Properties
+None
+
+## XAML Usage
+```xaml
+<Interaction.Triggers>
+  <Avalonia.Xaml.Interactions.Custom:WriteableBitmapTrigger>
+    <!-- actions -->
+  </Avalonia.Xaml.Interactions.Custom:WriteableBitmapTrigger>
+</Interaction.Triggers>
+```


### PR DESCRIPTION
## Summary
- auto-generate docs for all public behaviors, actions and triggers
- add `actions/`, `behaviors/`, `triggers/` subfolders under docs
- create `docs/interactions.md` listing all interaction types
- link to the index from the docs README

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b324fa29c83218c1f165f71307e3d