### PR TITLE
Add documentation stub generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,6 +276,8 @@ __pycache__/
 
 # Cake - Uncomment if you are using it
 tools/**
+# Allow custom documentation tool
+!tools/GenerateDocs/**
 # !tools/packages.config
 
 # Telerik's JustMock configuration file

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,8 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nuke.Common" Version="9.0.4" />
     <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="9.0.6" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
   </ItemGroup>
 </Project>

--- a/build/build/Build.cs
+++ b/build/build/Build.cs
@@ -96,6 +96,18 @@ class Build : NukeBuild
                 .EnableNoRestore());
         });
 
+    Target Docs => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            DotNetRun(s => s
+                .SetProjectFile(RootDirectory / "tools" / "GenerateDocs" / "GenerateDocs.csproj")
+                .SetConfiguration(Configuration)
+                .SetApplicationArguments($"{RootDirectory} {Configuration}")
+                .EnableNoBuild()
+                .EnableNoRestore());
+        });
+
     Target Pack => _ => _
         .DependsOn(Test)
         .Executes(() =>

--- a/docs/Actions/AddClassAction.md
+++ b/docs/Actions/AddClassAction.md
@@ -1,0 +1,3 @@
+# AddClassAction
+
+TODO: Document the AddClassAction.

--- a/docs/Actions/AddItemToItemsControlAction.md
+++ b/docs/Actions/AddItemToItemsControlAction.md
@@ -1,0 +1,3 @@
+# AddItemToItemsControlAction
+
+TODO: Document the AddItemToItemsControlAction.

--- a/docs/Actions/AddPreviewFilesAction.md
+++ b/docs/Actions/AddPreviewFilesAction.md
@@ -1,0 +1,3 @@
+# AddPreviewFilesAction
+
+TODO: Document the AddPreviewFilesAction.

--- a/docs/Actions/AddRangeAction.md
+++ b/docs/Actions/AddRangeAction.md
@@ -1,0 +1,3 @@
+# AddRangeAction
+
+TODO: Document the AddRangeAction.

--- a/docs/Actions/AddTransitionAction.md
+++ b/docs/Actions/AddTransitionAction.md
@@ -1,0 +1,3 @@
+# AddTransitionAction
+
+TODO: Document the AddTransitionAction.

--- a/docs/Actions/ApplyTreeViewFilterAction.md
+++ b/docs/Actions/ApplyTreeViewFilterAction.md
@@ -1,0 +1,3 @@
+# ApplyTreeViewFilterAction
+
+TODO: Document the ApplyTreeViewFilterAction.

--- a/docs/Actions/BeginAnimationAction.md
+++ b/docs/Actions/BeginAnimationAction.md
@@ -1,0 +1,3 @@
+# BeginAnimationAction
+
+TODO: Document the BeginAnimationAction.

--- a/docs/Actions/CallMethodAction.md
+++ b/docs/Actions/CallMethodAction.md
@@ -1,0 +1,3 @@
+# CallMethodAction
+
+TODO: Document the CallMethodAction.

--- a/docs/Actions/CallMethodAsyncAction.md
+++ b/docs/Actions/CallMethodAsyncAction.md
@@ -1,0 +1,3 @@
+# CallMethodAsyncAction
+
+TODO: Document the CallMethodAsyncAction.

--- a/docs/Actions/CapturePointerAction.md
+++ b/docs/Actions/CapturePointerAction.md
@@ -1,0 +1,3 @@
+# CapturePointerAction
+
+TODO: Document the CapturePointerAction.

--- a/docs/Actions/CarouselNextAction.md
+++ b/docs/Actions/CarouselNextAction.md
@@ -1,0 +1,3 @@
+# CarouselNextAction
+
+TODO: Document the CarouselNextAction.

--- a/docs/Actions/CarouselPreviousAction.md
+++ b/docs/Actions/CarouselPreviousAction.md
@@ -1,0 +1,3 @@
+# CarouselPreviousAction
+
+TODO: Document the CarouselPreviousAction.

--- a/docs/Actions/ChangeAvaloniaPropertyAction.md
+++ b/docs/Actions/ChangeAvaloniaPropertyAction.md
@@ -1,0 +1,3 @@
+# ChangeAvaloniaPropertyAction
+
+TODO: Document the ChangeAvaloniaPropertyAction.

--- a/docs/Actions/ChangePropertyAction.md
+++ b/docs/Actions/ChangePropertyAction.md
@@ -1,0 +1,3 @@
+# ChangePropertyAction
+
+TODO: Document the ChangePropertyAction.

--- a/docs/Actions/ClearAutoCompleteBoxSelectionAction.md
+++ b/docs/Actions/ClearAutoCompleteBoxSelectionAction.md
@@ -1,0 +1,3 @@
+# ClearAutoCompleteBoxSelectionAction
+
+TODO: Document the ClearAutoCompleteBoxSelectionAction.

--- a/docs/Actions/ClearClipboardAction.md
+++ b/docs/Actions/ClearClipboardAction.md
@@ -1,0 +1,3 @@
+# ClearClipboardAction
+
+TODO: Document the ClearClipboardAction.

--- a/docs/Actions/ClearCollectionAction.md
+++ b/docs/Actions/ClearCollectionAction.md
@@ -1,0 +1,3 @@
+# ClearCollectionAction
+
+TODO: Document the ClearCollectionAction.

--- a/docs/Actions/ClearItemsControlAction.md
+++ b/docs/Actions/ClearItemsControlAction.md
@@ -1,0 +1,3 @@
+# ClearItemsControlAction
+
+TODO: Document the ClearItemsControlAction.

--- a/docs/Actions/ClearTransitionsAction.md
+++ b/docs/Actions/ClearTransitionsAction.md
@@ -1,0 +1,3 @@
+# ClearTransitionsAction
+
+TODO: Document the ClearTransitionsAction.

--- a/docs/Actions/CloseNotificationAction.md
+++ b/docs/Actions/CloseNotificationAction.md
@@ -1,0 +1,3 @@
+# CloseNotificationAction
+
+TODO: Document the CloseNotificationAction.

--- a/docs/Actions/CloseWindowAction.md
+++ b/docs/Actions/CloseWindowAction.md
@@ -1,0 +1,3 @@
+# CloseWindowAction
+
+TODO: Document the CloseWindowAction.

--- a/docs/Actions/DelayedShowControlAction.md
+++ b/docs/Actions/DelayedShowControlAction.md
@@ -1,0 +1,3 @@
+# DelayedShowControlAction
+
+TODO: Document the DelayedShowControlAction.

--- a/docs/Actions/ExecuteScriptAction.md
+++ b/docs/Actions/ExecuteScriptAction.md
@@ -1,0 +1,3 @@
+# ExecuteScriptAction
+
+TODO: Document the ExecuteScriptAction.

--- a/docs/Actions/FocusControlAction.md
+++ b/docs/Actions/FocusControlAction.md
@@ -1,0 +1,3 @@
+# FocusControlAction
+
+TODO: Document the FocusControlAction.

--- a/docs/Actions/GetClipboardDataAction.md
+++ b/docs/Actions/GetClipboardDataAction.md
@@ -1,0 +1,3 @@
+# GetClipboardDataAction
+
+TODO: Document the GetClipboardDataAction.

--- a/docs/Actions/GetClipboardFormatsAction.md
+++ b/docs/Actions/GetClipboardFormatsAction.md
@@ -1,0 +1,3 @@
+# GetClipboardFormatsAction
+
+TODO: Document the GetClipboardFormatsAction.

--- a/docs/Actions/GetClipboardTextAction.md
+++ b/docs/Actions/GetClipboardTextAction.md
@@ -1,0 +1,3 @@
+# GetClipboardTextAction
+
+TODO: Document the GetClipboardTextAction.

--- a/docs/Actions/HideContextDialogAction.md
+++ b/docs/Actions/HideContextDialogAction.md
@@ -1,0 +1,3 @@
+# HideContextDialogAction
+
+TODO: Document the HideContextDialogAction.

--- a/docs/Actions/HideControlAction.md
+++ b/docs/Actions/HideControlAction.md
@@ -1,0 +1,3 @@
+# HideControlAction
+
+TODO: Document the HideControlAction.

--- a/docs/Actions/HideFlyoutAction.md
+++ b/docs/Actions/HideFlyoutAction.md
@@ -1,0 +1,3 @@
+# HideFlyoutAction
+
+TODO: Document the HideFlyoutAction.

--- a/docs/Actions/HidePopupAction.md
+++ b/docs/Actions/HidePopupAction.md
@@ -1,0 +1,3 @@
+# HidePopupAction
+
+TODO: Document the HidePopupAction.

--- a/docs/Actions/HideToolTipAction.md
+++ b/docs/Actions/HideToolTipAction.md
@@ -1,0 +1,3 @@
+# HideToolTipAction
+
+TODO: Document the HideToolTipAction.

--- a/docs/Actions/IncrementViewModelPropertyAction.md
+++ b/docs/Actions/IncrementViewModelPropertyAction.md
@@ -1,0 +1,3 @@
+# IncrementViewModelPropertyAction
+
+TODO: Document the IncrementViewModelPropertyAction.

--- a/docs/Actions/InsertItemToItemsControlAction.md
+++ b/docs/Actions/InsertItemToItemsControlAction.md
@@ -1,0 +1,3 @@
+# InsertItemToItemsControlAction
+
+TODO: Document the InsertItemToItemsControlAction.

--- a/docs/Actions/InvokeButtonClickAction.md
+++ b/docs/Actions/InvokeButtonClickAction.md
@@ -1,0 +1,3 @@
+# InvokeButtonClickAction
+
+TODO: Document the InvokeButtonClickAction.

--- a/docs/Actions/InvokeCommandAction.md
+++ b/docs/Actions/InvokeCommandAction.md
@@ -1,0 +1,3 @@
+# InvokeCommandAction
+
+TODO: Document the InvokeCommandAction.

--- a/docs/Actions/LaunchUriOrFileAction.md
+++ b/docs/Actions/LaunchUriOrFileAction.md
@@ -1,0 +1,3 @@
+# LaunchUriOrFileAction
+
+TODO: Document the LaunchUriOrFileAction.

--- a/docs/Actions/MoveElementToPanelAction.md
+++ b/docs/Actions/MoveElementToPanelAction.md
@@ -1,0 +1,3 @@
+# MoveElementToPanelAction
+
+TODO: Document the MoveElementToPanelAction.

--- a/docs/Actions/MoveItemInItemsControlAction.md
+++ b/docs/Actions/MoveItemInItemsControlAction.md
@@ -1,0 +1,3 @@
+# MoveItemInItemsControlAction
+
+TODO: Document the MoveItemInItemsControlAction.

--- a/docs/Actions/OpenFilePickerAction.md
+++ b/docs/Actions/OpenFilePickerAction.md
@@ -1,0 +1,3 @@
+# OpenFilePickerAction
+
+TODO: Document the OpenFilePickerAction.

--- a/docs/Actions/OpenFolderPickerAction.md
+++ b/docs/Actions/OpenFolderPickerAction.md
@@ -1,0 +1,3 @@
+# OpenFolderPickerAction
+
+TODO: Document the OpenFolderPickerAction.

--- a/docs/Actions/PopupAction.md
+++ b/docs/Actions/PopupAction.md
@@ -1,0 +1,3 @@
+# PopupAction
+
+TODO: Document the PopupAction.

--- a/docs/Actions/ReleasePointerCaptureAction.md
+++ b/docs/Actions/ReleasePointerCaptureAction.md
@@ -1,0 +1,3 @@
+# ReleasePointerCaptureAction
+
+TODO: Document the ReleasePointerCaptureAction.

--- a/docs/Actions/RemoveClassAction.md
+++ b/docs/Actions/RemoveClassAction.md
@@ -1,0 +1,3 @@
+# RemoveClassAction
+
+TODO: Document the RemoveClassAction.

--- a/docs/Actions/RemoveElementAction.md
+++ b/docs/Actions/RemoveElementAction.md
@@ -1,0 +1,3 @@
+# RemoveElementAction
+
+TODO: Document the RemoveElementAction.

--- a/docs/Actions/RemoveItemAtAction.md
+++ b/docs/Actions/RemoveItemAtAction.md
@@ -1,0 +1,3 @@
+# RemoveItemAtAction
+
+TODO: Document the RemoveItemAtAction.

--- a/docs/Actions/RemoveItemInItemsControlAction.md
+++ b/docs/Actions/RemoveItemInItemsControlAction.md
@@ -1,0 +1,3 @@
+# RemoveItemInItemsControlAction
+
+TODO: Document the RemoveItemInItemsControlAction.

--- a/docs/Actions/RemoveItemInListBoxAction.md
+++ b/docs/Actions/RemoveItemInListBoxAction.md
@@ -1,0 +1,3 @@
+# RemoveItemInListBoxAction
+
+TODO: Document the RemoveItemInListBoxAction.

--- a/docs/Actions/RemoveRangeAction.md
+++ b/docs/Actions/RemoveRangeAction.md
@@ -1,0 +1,3 @@
+# RemoveRangeAction
+
+TODO: Document the RemoveRangeAction.

--- a/docs/Actions/RemoveTransitionAction.md
+++ b/docs/Actions/RemoveTransitionAction.md
@@ -1,0 +1,3 @@
+# RemoveTransitionAction
+
+TODO: Document the RemoveTransitionAction.

--- a/docs/Actions/RenderRenderTargetBitmapAction.md
+++ b/docs/Actions/RenderRenderTargetBitmapAction.md
@@ -1,0 +1,3 @@
+# RenderRenderTargetBitmapAction
+
+TODO: Document the RenderRenderTargetBitmapAction.

--- a/docs/Actions/RequestScreenDetailsAction.md
+++ b/docs/Actions/RequestScreenDetailsAction.md
@@ -1,0 +1,3 @@
+# RequestScreenDetailsAction
+
+TODO: Document the RequestScreenDetailsAction.

--- a/docs/Actions/SaveFilePickerAction.md
+++ b/docs/Actions/SaveFilePickerAction.md
@@ -1,0 +1,3 @@
+# SaveFilePickerAction
+
+TODO: Document the SaveFilePickerAction.

--- a/docs/Actions/ScrollToOffsetAction.md
+++ b/docs/Actions/ScrollToOffsetAction.md
@@ -1,0 +1,3 @@
+# ScrollToOffsetAction
+
+TODO: Document the ScrollToOffsetAction.

--- a/docs/Actions/SetAutomationIdAction.md
+++ b/docs/Actions/SetAutomationIdAction.md
@@ -1,0 +1,3 @@
+# SetAutomationIdAction
+
+TODO: Document the SetAutomationIdAction.

--- a/docs/Actions/SetClipboardDataObjectAction.md
+++ b/docs/Actions/SetClipboardDataObjectAction.md
@@ -1,0 +1,3 @@
+# SetClipboardDataObjectAction
+
+TODO: Document the SetClipboardDataObjectAction.

--- a/docs/Actions/SetClipboardTextAction.md
+++ b/docs/Actions/SetClipboardTextAction.md
@@ -1,0 +1,3 @@
+# SetClipboardTextAction
+
+TODO: Document the SetClipboardTextAction.

--- a/docs/Actions/SetCursorAction.md
+++ b/docs/Actions/SetCursorAction.md
@@ -1,0 +1,3 @@
+# SetCursorAction
+
+TODO: Document the SetCursorAction.

--- a/docs/Actions/SetCursorFromProviderAction.md
+++ b/docs/Actions/SetCursorFromProviderAction.md
@@ -1,0 +1,3 @@
+# SetCursorFromProviderAction
+
+TODO: Document the SetCursorFromProviderAction.

--- a/docs/Actions/SetEnabledAction.md
+++ b/docs/Actions/SetEnabledAction.md
@@ -1,0 +1,3 @@
+# SetEnabledAction
+
+TODO: Document the SetEnabledAction.

--- a/docs/Actions/SetPathIconDataAction.md
+++ b/docs/Actions/SetPathIconDataAction.md
@@ -1,0 +1,3 @@
+# SetPathIconDataAction
+
+TODO: Document the SetPathIconDataAction.

--- a/docs/Actions/SetThemeVariantAction.md
+++ b/docs/Actions/SetThemeVariantAction.md
@@ -1,0 +1,3 @@
+# SetThemeVariantAction
+
+TODO: Document the SetThemeVariantAction.

--- a/docs/Actions/SetToolTipTipAction.md
+++ b/docs/Actions/SetToolTipTipAction.md
@@ -1,0 +1,3 @@
+# SetToolTipTipAction
+
+TODO: Document the SetToolTipTipAction.

--- a/docs/Actions/SetViewModelPropertyAction.md
+++ b/docs/Actions/SetViewModelPropertyAction.md
@@ -1,0 +1,3 @@
+# SetViewModelPropertyAction
+
+TODO: Document the SetViewModelPropertyAction.

--- a/docs/Actions/ShowContextDialogAction.md
+++ b/docs/Actions/ShowContextDialogAction.md
@@ -1,0 +1,3 @@
+# ShowContextDialogAction
+
+TODO: Document the ShowContextDialogAction.

--- a/docs/Actions/ShowContextMenuAction.md
+++ b/docs/Actions/ShowContextMenuAction.md
@@ -1,0 +1,3 @@
+# ShowContextMenuAction
+
+TODO: Document the ShowContextMenuAction.

--- a/docs/Actions/ShowControlAction.md
+++ b/docs/Actions/ShowControlAction.md
@@ -1,0 +1,3 @@
+# ShowControlAction
+
+TODO: Document the ShowControlAction.

--- a/docs/Actions/ShowDialogAction.md
+++ b/docs/Actions/ShowDialogAction.md
@@ -1,0 +1,3 @@
+# ShowDialogAction
+
+TODO: Document the ShowDialogAction.

--- a/docs/Actions/ShowErrorNotificationAction.md
+++ b/docs/Actions/ShowErrorNotificationAction.md
@@ -1,0 +1,3 @@
+# ShowErrorNotificationAction
+
+TODO: Document the ShowErrorNotificationAction.

--- a/docs/Actions/ShowFlyoutAction.md
+++ b/docs/Actions/ShowFlyoutAction.md
@@ -1,0 +1,3 @@
+# ShowFlyoutAction
+
+TODO: Document the ShowFlyoutAction.

--- a/docs/Actions/ShowInformationNotificationAction.md
+++ b/docs/Actions/ShowInformationNotificationAction.md
@@ -1,0 +1,3 @@
+# ShowInformationNotificationAction
+
+TODO: Document the ShowInformationNotificationAction.

--- a/docs/Actions/ShowNotificationAction.md
+++ b/docs/Actions/ShowNotificationAction.md
@@ -1,0 +1,3 @@
+# ShowNotificationAction
+
+TODO: Document the ShowNotificationAction.

--- a/docs/Actions/ShowPopupAction.md
+++ b/docs/Actions/ShowPopupAction.md
@@ -1,0 +1,3 @@
+# ShowPopupAction
+
+TODO: Document the ShowPopupAction.

--- a/docs/Actions/ShowSuccessNotificationAction.md
+++ b/docs/Actions/ShowSuccessNotificationAction.md
@@ -1,0 +1,3 @@
+# ShowSuccessNotificationAction
+
+TODO: Document the ShowSuccessNotificationAction.

--- a/docs/Actions/ShowToolTipAction.md
+++ b/docs/Actions/ShowToolTipAction.md
@@ -1,0 +1,3 @@
+# ShowToolTipAction
+
+TODO: Document the ShowToolTipAction.

--- a/docs/Actions/ShowWarningNotificationAction.md
+++ b/docs/Actions/ShowWarningNotificationAction.md
@@ -1,0 +1,3 @@
+# ShowWarningNotificationAction
+
+TODO: Document the ShowWarningNotificationAction.

--- a/docs/Actions/ShowWindowAction.md
+++ b/docs/Actions/ShowWindowAction.md
@@ -1,0 +1,3 @@
+# ShowWindowAction
+
+TODO: Document the ShowWindowAction.

--- a/docs/Actions/SplitViewTogglePaneAction.md
+++ b/docs/Actions/SplitViewTogglePaneAction.md
@@ -1,0 +1,3 @@
+# SplitViewTogglePaneAction
+
+TODO: Document the SplitViewTogglePaneAction.

--- a/docs/Actions/StartAnimationAction.md
+++ b/docs/Actions/StartAnimationAction.md
@@ -1,0 +1,3 @@
+# StartAnimationAction
+
+TODO: Document the StartAnimationAction.

--- a/docs/Actions/StartBuiltAnimationAction.md
+++ b/docs/Actions/StartBuiltAnimationAction.md
@@ -1,0 +1,3 @@
+# StartBuiltAnimationAction
+
+TODO: Document the StartBuiltAnimationAction.

--- a/docs/Actions/TabControlNextAction.md
+++ b/docs/Actions/TabControlNextAction.md
@@ -1,0 +1,3 @@
+# TabControlNextAction
+
+TODO: Document the TabControlNextAction.

--- a/docs/Actions/TabControlPreviousAction.md
+++ b/docs/Actions/TabControlPreviousAction.md
@@ -1,0 +1,3 @@
+# TabControlPreviousAction
+
+TODO: Document the TabControlPreviousAction.

--- a/docs/Actions/ToggleViewModelBooleanAction.md
+++ b/docs/Actions/ToggleViewModelBooleanAction.md
@@ -1,0 +1,3 @@
+# ToggleViewModelBooleanAction
+
+TODO: Document the ToggleViewModelBooleanAction.

--- a/docs/Actions/UploadFileAction.md
+++ b/docs/Actions/UploadFileAction.md
@@ -1,0 +1,3 @@
+# UploadFileAction
+
+TODO: Document the UploadFileAction.

--- a/docs/Actions/WriteableBitmapRenderAction.md
+++ b/docs/Actions/WriteableBitmapRenderAction.md
@@ -1,0 +1,3 @@
+# WriteableBitmapRenderAction
+
+TODO: Document the WriteableBitmapRenderAction.

--- a/docs/Behaviors/AsyncLoadBehavior.md
+++ b/docs/Behaviors/AsyncLoadBehavior.md
@@ -1,0 +1,3 @@
+# AsyncLoadBehavior
+
+TODO: Document the AsyncLoadBehavior.

--- a/docs/Behaviors/BehaviorCollection.md
+++ b/docs/Behaviors/BehaviorCollection.md
@@ -1,0 +1,3 @@
+# BehaviorCollection
+
+TODO: Document the BehaviorCollection.

--- a/docs/Behaviors/BehaviorCollectionTemplate.md
+++ b/docs/Behaviors/BehaviorCollectionTemplate.md
@@ -1,0 +1,3 @@
+# BehaviorCollectionTemplate
+
+TODO: Document the BehaviorCollectionTemplate.

--- a/docs/Behaviors/FluidMoveBehavior.md
+++ b/docs/Behaviors/FluidMoveBehavior.md
@@ -1,0 +1,3 @@
+# FluidMoveBehavior
+
+TODO: Document the FluidMoveBehavior.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,15 @@ Welcome to the project documentation. Below is the table of contents that mirror
 - [License](../README.md#license)
 
 For detailed information about each section, refer to the [project README](../README.md).
+
+## Generating API Docs
+
+After building the solution you can create markdown stubs for behaviors,
+actions and triggers. Run the following command:
+
+```bash
+./build.sh --target Docs
+```
+
+New files will appear under `docs/Behaviors`, `docs/Actions` and `docs/Triggers`
+for any components that are missing documentation.

--- a/docs/Triggers/ActualThemeVariantChangedTrigger.md
+++ b/docs/Triggers/ActualThemeVariantChangedTrigger.md
@@ -1,0 +1,3 @@
+# ActualThemeVariantChangedTrigger
+
+TODO: Document the ActualThemeVariantChangedTrigger.

--- a/docs/Triggers/AnimationCompletedTrigger.md
+++ b/docs/Triggers/AnimationCompletedTrigger.md
@@ -1,0 +1,3 @@
+# AnimationCompletedTrigger
+
+TODO: Document the AnimationCompletedTrigger.

--- a/docs/Triggers/AttachedToLogicalTreeTrigger.md
+++ b/docs/Triggers/AttachedToLogicalTreeTrigger.md
@@ -1,0 +1,3 @@
+# AttachedToLogicalTreeTrigger
+
+TODO: Document the AttachedToLogicalTreeTrigger.

--- a/docs/Triggers/AttachedToVisualTreeTrigger.md
+++ b/docs/Triggers/AttachedToVisualTreeTrigger.md
@@ -1,0 +1,3 @@
+# AttachedToVisualTreeTrigger
+
+TODO: Document the AttachedToVisualTreeTrigger.

--- a/docs/Triggers/AutoCompleteBoxSelectionChangedTrigger.md
+++ b/docs/Triggers/AutoCompleteBoxSelectionChangedTrigger.md
@@ -1,0 +1,3 @@
+# AutoCompleteBoxSelectionChangedTrigger
+
+TODO: Document the AutoCompleteBoxSelectionChangedTrigger.

--- a/docs/Triggers/AutomationNameChangedTrigger.md
+++ b/docs/Triggers/AutomationNameChangedTrigger.md
@@ -1,0 +1,3 @@
+# AutomationNameChangedTrigger
+
+TODO: Document the AutomationNameChangedTrigger.

--- a/docs/Triggers/BindingTriggerBehavior.md
+++ b/docs/Triggers/BindingTriggerBehavior.md
@@ -1,0 +1,3 @@
+# BindingTriggerBehavior
+
+TODO: Document the BindingTriggerBehavior.

--- a/docs/Triggers/ButtonClickEventTriggerBehavior.md
+++ b/docs/Triggers/ButtonClickEventTriggerBehavior.md
@@ -1,0 +1,3 @@
+# ButtonClickEventTriggerBehavior
+
+TODO: Document the ButtonClickEventTriggerBehavior.

--- a/docs/Triggers/CarouselSelectionChangedTrigger.md
+++ b/docs/Triggers/CarouselSelectionChangedTrigger.md
@@ -1,0 +1,3 @@
+# CarouselSelectionChangedTrigger
+
+TODO: Document the CarouselSelectionChangedTrigger.

--- a/docs/Triggers/CollectionChangedTrigger.md
+++ b/docs/Triggers/CollectionChangedTrigger.md
@@ -1,0 +1,3 @@
+# CollectionChangedTrigger
+
+TODO: Document the CollectionChangedTrigger.

--- a/docs/Triggers/ContextDialogClosedTrigger.md
+++ b/docs/Triggers/ContextDialogClosedTrigger.md
@@ -1,0 +1,3 @@
+# ContextDialogClosedTrigger
+
+TODO: Document the ContextDialogClosedTrigger.

--- a/docs/Triggers/ContextDialogOpenedTrigger.md
+++ b/docs/Triggers/ContextDialogOpenedTrigger.md
@@ -1,0 +1,3 @@
+# ContextDialogOpenedTrigger
+
+TODO: Document the ContextDialogOpenedTrigger.

--- a/docs/Triggers/DataContextChangedTrigger.md
+++ b/docs/Triggers/DataContextChangedTrigger.md
@@ -1,0 +1,3 @@
+# DataContextChangedTrigger
+
+TODO: Document the DataContextChangedTrigger.

--- a/docs/Triggers/DataTrigger.md
+++ b/docs/Triggers/DataTrigger.md
@@ -1,0 +1,3 @@
+# DataTrigger
+
+TODO: Document the DataTrigger.

--- a/docs/Triggers/DataTriggerBehavior.md
+++ b/docs/Triggers/DataTriggerBehavior.md
@@ -1,0 +1,3 @@
+# DataTriggerBehavior
+
+TODO: Document the DataTriggerBehavior.

--- a/docs/Triggers/DelayedLoadTrigger.md
+++ b/docs/Triggers/DelayedLoadTrigger.md
@@ -1,0 +1,3 @@
+# DelayedLoadTrigger
+
+TODO: Document the DelayedLoadTrigger.

--- a/docs/Triggers/DetachedFromLogicalTreeTrigger.md
+++ b/docs/Triggers/DetachedFromLogicalTreeTrigger.md
@@ -1,0 +1,3 @@
+# DetachedFromLogicalTreeTrigger
+
+TODO: Document the DetachedFromLogicalTreeTrigger.

--- a/docs/Triggers/DetachedFromVisualTreeTrigger.md
+++ b/docs/Triggers/DetachedFromVisualTreeTrigger.md
@@ -1,0 +1,3 @@
+# DetachedFromVisualTreeTrigger
+
+TODO: Document the DetachedFromVisualTreeTrigger.

--- a/docs/Triggers/DialogClosedTrigger.md
+++ b/docs/Triggers/DialogClosedTrigger.md
@@ -1,0 +1,3 @@
+# DialogClosedTrigger
+
+TODO: Document the DialogClosedTrigger.

--- a/docs/Triggers/DialogOpenedTrigger.md
+++ b/docs/Triggers/DialogOpenedTrigger.md
@@ -1,0 +1,3 @@
+# DialogOpenedTrigger
+
+TODO: Document the DialogOpenedTrigger.

--- a/docs/Triggers/DoubleTappedEventTrigger.md
+++ b/docs/Triggers/DoubleTappedEventTrigger.md
@@ -1,0 +1,3 @@
+# DoubleTappedEventTrigger
+
+TODO: Document the DoubleTappedEventTrigger.

--- a/docs/Triggers/DoubleTappedGestureTrigger.md
+++ b/docs/Triggers/DoubleTappedGestureTrigger.md
@@ -1,0 +1,3 @@
+# DoubleTappedGestureTrigger
+
+TODO: Document the DoubleTappedGestureTrigger.

--- a/docs/Triggers/DoubleTappedTrigger.md
+++ b/docs/Triggers/DoubleTappedTrigger.md
@@ -1,0 +1,3 @@
+# DoubleTappedTrigger
+
+TODO: Document the DoubleTappedTrigger.

--- a/docs/Triggers/DragEnterEventTrigger.md
+++ b/docs/Triggers/DragEnterEventTrigger.md
@@ -1,0 +1,3 @@
+# DragEnterEventTrigger
+
+TODO: Document the DragEnterEventTrigger.

--- a/docs/Triggers/DragLeaveEventTrigger.md
+++ b/docs/Triggers/DragLeaveEventTrigger.md
@@ -1,0 +1,3 @@
+# DragLeaveEventTrigger
+
+TODO: Document the DragLeaveEventTrigger.

--- a/docs/Triggers/DragOverEventTrigger.md
+++ b/docs/Triggers/DragOverEventTrigger.md
@@ -1,0 +1,3 @@
+# DragOverEventTrigger
+
+TODO: Document the DragOverEventTrigger.

--- a/docs/Triggers/DropEventTrigger.md
+++ b/docs/Triggers/DropEventTrigger.md
@@ -1,0 +1,3 @@
+# DropEventTrigger
+
+TODO: Document the DropEventTrigger.

--- a/docs/Triggers/EventTrigger.md
+++ b/docs/Triggers/EventTrigger.md
@@ -1,0 +1,3 @@
+# EventTrigger
+
+TODO: Document the EventTrigger.

--- a/docs/Triggers/EventTriggerBehavior.md
+++ b/docs/Triggers/EventTriggerBehavior.md
@@ -1,0 +1,3 @@
+# EventTriggerBehavior
+
+TODO: Document the EventTriggerBehavior.

--- a/docs/Triggers/GotFocusEventTrigger.md
+++ b/docs/Triggers/GotFocusEventTrigger.md
@@ -1,0 +1,3 @@
+# GotFocusEventTrigger
+
+TODO: Document the GotFocusEventTrigger.

--- a/docs/Triggers/GotFocusTrigger.md
+++ b/docs/Triggers/GotFocusTrigger.md
@@ -1,0 +1,3 @@
+# GotFocusTrigger
+
+TODO: Document the GotFocusTrigger.

--- a/docs/Triggers/HoldingGestureTrigger.md
+++ b/docs/Triggers/HoldingGestureTrigger.md
@@ -1,0 +1,3 @@
+# HoldingGestureTrigger
+
+TODO: Document the HoldingGestureTrigger.

--- a/docs/Triggers/HoldingTrigger.md
+++ b/docs/Triggers/HoldingTrigger.md
@@ -1,0 +1,3 @@
+# HoldingTrigger
+
+TODO: Document the HoldingTrigger.

--- a/docs/Triggers/IfElseTrigger.md
+++ b/docs/Triggers/IfElseTrigger.md
@@ -1,0 +1,3 @@
+# IfElseTrigger
+
+TODO: Document the IfElseTrigger.

--- a/docs/Triggers/InitializedTrigger.md
+++ b/docs/Triggers/InitializedTrigger.md
@@ -1,0 +1,3 @@
+# InitializedTrigger
+
+TODO: Document the InitializedTrigger.

--- a/docs/Triggers/ItemsControlContainerClearingTrigger.md
+++ b/docs/Triggers/ItemsControlContainerClearingTrigger.md
@@ -1,0 +1,3 @@
+# ItemsControlContainerClearingTrigger
+
+TODO: Document the ItemsControlContainerClearingTrigger.

--- a/docs/Triggers/ItemsControlContainerIndexChangedTrigger.md
+++ b/docs/Triggers/ItemsControlContainerIndexChangedTrigger.md
@@ -1,0 +1,3 @@
+# ItemsControlContainerIndexChangedTrigger
+
+TODO: Document the ItemsControlContainerIndexChangedTrigger.

--- a/docs/Triggers/ItemsControlContainerPreparedTrigger.md
+++ b/docs/Triggers/ItemsControlContainerPreparedTrigger.md
@@ -1,0 +1,3 @@
+# ItemsControlContainerPreparedTrigger
+
+TODO: Document the ItemsControlContainerPreparedTrigger.

--- a/docs/Triggers/ItemsControlPreparingContainerTrigger.md
+++ b/docs/Triggers/ItemsControlPreparingContainerTrigger.md
@@ -1,0 +1,3 @@
+# ItemsControlPreparingContainerTrigger
+
+TODO: Document the ItemsControlPreparingContainerTrigger.

--- a/docs/Triggers/KeyDownEventTrigger.md
+++ b/docs/Triggers/KeyDownEventTrigger.md
@@ -1,0 +1,3 @@
+# KeyDownEventTrigger
+
+TODO: Document the KeyDownEventTrigger.

--- a/docs/Triggers/KeyDownTrigger.md
+++ b/docs/Triggers/KeyDownTrigger.md
@@ -1,0 +1,3 @@
+# KeyDownTrigger
+
+TODO: Document the KeyDownTrigger.

--- a/docs/Triggers/KeyGestureTrigger.md
+++ b/docs/Triggers/KeyGestureTrigger.md
@@ -1,0 +1,3 @@
+# KeyGestureTrigger
+
+TODO: Document the KeyGestureTrigger.

--- a/docs/Triggers/KeyTrigger.md
+++ b/docs/Triggers/KeyTrigger.md
@@ -1,0 +1,3 @@
+# KeyTrigger
+
+TODO: Document the KeyTrigger.

--- a/docs/Triggers/KeyUpEventTrigger.md
+++ b/docs/Triggers/KeyUpEventTrigger.md
@@ -1,0 +1,3 @@
+# KeyUpEventTrigger
+
+TODO: Document the KeyUpEventTrigger.

--- a/docs/Triggers/KeyUpTrigger.md
+++ b/docs/Triggers/KeyUpTrigger.md
@@ -1,0 +1,3 @@
+# KeyUpTrigger
+
+TODO: Document the KeyUpTrigger.

--- a/docs/Triggers/LoadedTrigger.md
+++ b/docs/Triggers/LoadedTrigger.md
@@ -1,0 +1,3 @@
+# LoadedTrigger
+
+TODO: Document the LoadedTrigger.

--- a/docs/Triggers/LostFocusEventTrigger.md
+++ b/docs/Triggers/LostFocusEventTrigger.md
@@ -1,0 +1,3 @@
+# LostFocusEventTrigger
+
+TODO: Document the LostFocusEventTrigger.

--- a/docs/Triggers/LostFocusTrigger.md
+++ b/docs/Triggers/LostFocusTrigger.md
@@ -1,0 +1,3 @@
+# LostFocusTrigger
+
+TODO: Document the LostFocusTrigger.

--- a/docs/Triggers/ObservableTriggerBehavior`1.md
+++ b/docs/Triggers/ObservableTriggerBehavior`1.md
@@ -1,0 +1,3 @@
+# ObservableTriggerBehavior`1
+
+TODO: Document the ObservableTriggerBehavior`1.

--- a/docs/Triggers/PathIconDataChangedTrigger.md
+++ b/docs/Triggers/PathIconDataChangedTrigger.md
@@ -1,0 +1,3 @@
+# PathIconDataChangedTrigger
+
+TODO: Document the PathIconDataChangedTrigger.

--- a/docs/Triggers/PinchEndedGestureTrigger.md
+++ b/docs/Triggers/PinchEndedGestureTrigger.md
@@ -1,0 +1,3 @@
+# PinchEndedGestureTrigger
+
+TODO: Document the PinchEndedGestureTrigger.

--- a/docs/Triggers/PinchGestureTrigger.md
+++ b/docs/Triggers/PinchGestureTrigger.md
@@ -1,0 +1,3 @@
+# PinchGestureTrigger
+
+TODO: Document the PinchGestureTrigger.

--- a/docs/Triggers/PointerCaptureLostEventTrigger.md
+++ b/docs/Triggers/PointerCaptureLostEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerCaptureLostEventTrigger
+
+TODO: Document the PointerCaptureLostEventTrigger.

--- a/docs/Triggers/PointerCaptureLostTrigger.md
+++ b/docs/Triggers/PointerCaptureLostTrigger.md
@@ -1,0 +1,3 @@
+# PointerCaptureLostTrigger
+
+TODO: Document the PointerCaptureLostTrigger.

--- a/docs/Triggers/PointerEnteredEventTrigger.md
+++ b/docs/Triggers/PointerEnteredEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerEnteredEventTrigger
+
+TODO: Document the PointerEnteredEventTrigger.

--- a/docs/Triggers/PointerEnteredTrigger.md
+++ b/docs/Triggers/PointerEnteredTrigger.md
@@ -1,0 +1,3 @@
+# PointerEnteredTrigger
+
+TODO: Document the PointerEnteredTrigger.

--- a/docs/Triggers/PointerEventsTrigger.md
+++ b/docs/Triggers/PointerEventsTrigger.md
@@ -1,0 +1,3 @@
+# PointerEventsTrigger
+
+TODO: Document the PointerEventsTrigger.

--- a/docs/Triggers/PointerExitedEventTrigger.md
+++ b/docs/Triggers/PointerExitedEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerExitedEventTrigger
+
+TODO: Document the PointerExitedEventTrigger.

--- a/docs/Triggers/PointerExitedTrigger.md
+++ b/docs/Triggers/PointerExitedTrigger.md
@@ -1,0 +1,3 @@
+# PointerExitedTrigger
+
+TODO: Document the PointerExitedTrigger.

--- a/docs/Triggers/PointerMovedEventTrigger.md
+++ b/docs/Triggers/PointerMovedEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerMovedEventTrigger
+
+TODO: Document the PointerMovedEventTrigger.

--- a/docs/Triggers/PointerMovedTrigger.md
+++ b/docs/Triggers/PointerMovedTrigger.md
@@ -1,0 +1,3 @@
+# PointerMovedTrigger
+
+TODO: Document the PointerMovedTrigger.

--- a/docs/Triggers/PointerPressedEventTrigger.md
+++ b/docs/Triggers/PointerPressedEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerPressedEventTrigger
+
+TODO: Document the PointerPressedEventTrigger.

--- a/docs/Triggers/PointerPressedTrigger.md
+++ b/docs/Triggers/PointerPressedTrigger.md
@@ -1,0 +1,3 @@
+# PointerPressedTrigger
+
+TODO: Document the PointerPressedTrigger.

--- a/docs/Triggers/PointerReleasedEventTrigger.md
+++ b/docs/Triggers/PointerReleasedEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerReleasedEventTrigger
+
+TODO: Document the PointerReleasedEventTrigger.

--- a/docs/Triggers/PointerReleasedTrigger.md
+++ b/docs/Triggers/PointerReleasedTrigger.md
@@ -1,0 +1,3 @@
+# PointerReleasedTrigger
+
+TODO: Document the PointerReleasedTrigger.

--- a/docs/Triggers/PointerTouchPadGestureMagnifyGestureTrigger.md
+++ b/docs/Triggers/PointerTouchPadGestureMagnifyGestureTrigger.md
@@ -1,0 +1,3 @@
+# PointerTouchPadGestureMagnifyGestureTrigger
+
+TODO: Document the PointerTouchPadGestureMagnifyGestureTrigger.

--- a/docs/Triggers/PointerTouchPadGestureRotateGestureTrigger.md
+++ b/docs/Triggers/PointerTouchPadGestureRotateGestureTrigger.md
@@ -1,0 +1,3 @@
+# PointerTouchPadGestureRotateGestureTrigger
+
+TODO: Document the PointerTouchPadGestureRotateGestureTrigger.

--- a/docs/Triggers/PointerTouchPadGestureSwipeGestureTrigger.md
+++ b/docs/Triggers/PointerTouchPadGestureSwipeGestureTrigger.md
@@ -1,0 +1,3 @@
+# PointerTouchPadGestureSwipeGestureTrigger
+
+TODO: Document the PointerTouchPadGestureSwipeGestureTrigger.

--- a/docs/Triggers/PointerWheelChangedEventTrigger.md
+++ b/docs/Triggers/PointerWheelChangedEventTrigger.md
@@ -1,0 +1,3 @@
+# PointerWheelChangedEventTrigger
+
+TODO: Document the PointerWheelChangedEventTrigger.

--- a/docs/Triggers/PointerWheelChangedTrigger.md
+++ b/docs/Triggers/PointerWheelChangedTrigger.md
@@ -1,0 +1,3 @@
+# PointerWheelChangedTrigger
+
+TODO: Document the PointerWheelChangedTrigger.

--- a/docs/Triggers/PopupClosedTrigger.md
+++ b/docs/Triggers/PopupClosedTrigger.md
@@ -1,0 +1,3 @@
+# PopupClosedTrigger
+
+TODO: Document the PopupClosedTrigger.

--- a/docs/Triggers/PopupOpenedTrigger.md
+++ b/docs/Triggers/PopupOpenedTrigger.md
@@ -1,0 +1,3 @@
+# PopupOpenedTrigger
+
+TODO: Document the PopupOpenedTrigger.

--- a/docs/Triggers/PropertyChangedTrigger.md
+++ b/docs/Triggers/PropertyChangedTrigger.md
@@ -1,0 +1,3 @@
+# PropertyChangedTrigger
+
+TODO: Document the PropertyChangedTrigger.

--- a/docs/Triggers/PullGestureEndedGestureTrigger.md
+++ b/docs/Triggers/PullGestureEndedGestureTrigger.md
@@ -1,0 +1,3 @@
+# PullGestureEndedGestureTrigger
+
+TODO: Document the PullGestureEndedGestureTrigger.

--- a/docs/Triggers/PullGestureGestureTrigger.md
+++ b/docs/Triggers/PullGestureGestureTrigger.md
@@ -1,0 +1,3 @@
+# PullGestureGestureTrigger
+
+TODO: Document the PullGestureGestureTrigger.

--- a/docs/Triggers/RenderTargetBitmapTrigger.md
+++ b/docs/Triggers/RenderTargetBitmapTrigger.md
@@ -1,0 +1,3 @@
+# RenderTargetBitmapTrigger
+
+TODO: Document the RenderTargetBitmapTrigger.

--- a/docs/Triggers/ResourcesChangedTrigger.md
+++ b/docs/Triggers/ResourcesChangedTrigger.md
@@ -1,0 +1,3 @@
+# ResourcesChangedTrigger
+
+TODO: Document the ResourcesChangedTrigger.

--- a/docs/Triggers/RightTappedEventTrigger.md
+++ b/docs/Triggers/RightTappedEventTrigger.md
@@ -1,0 +1,3 @@
+# RightTappedEventTrigger
+
+TODO: Document the RightTappedEventTrigger.

--- a/docs/Triggers/RightTappedGestureTrigger.md
+++ b/docs/Triggers/RightTappedGestureTrigger.md
@@ -1,0 +1,3 @@
+# RightTappedGestureTrigger
+
+TODO: Document the RightTappedGestureTrigger.

--- a/docs/Triggers/RoutedEventTriggerBehavior.md
+++ b/docs/Triggers/RoutedEventTriggerBehavior.md
@@ -1,0 +1,3 @@
+# RoutedEventTriggerBehavior
+
+TODO: Document the RoutedEventTriggerBehavior.

--- a/docs/Triggers/RunAnimationTrigger.md
+++ b/docs/Triggers/RunAnimationTrigger.md
@@ -1,0 +1,3 @@
+# RunAnimationTrigger
+
+TODO: Document the RunAnimationTrigger.

--- a/docs/Triggers/ScreensChangedTrigger.md
+++ b/docs/Triggers/ScreensChangedTrigger.md
@@ -1,0 +1,3 @@
+# ScreensChangedTrigger
+
+TODO: Document the ScreensChangedTrigger.

--- a/docs/Triggers/ScrollChangedTrigger.md
+++ b/docs/Triggers/ScrollChangedTrigger.md
@@ -1,0 +1,3 @@
+# ScrollChangedTrigger
+
+TODO: Document the ScrollChangedTrigger.

--- a/docs/Triggers/ScrollGestureEndedEventTrigger.md
+++ b/docs/Triggers/ScrollGestureEndedEventTrigger.md
@@ -1,0 +1,3 @@
+# ScrollGestureEndedEventTrigger
+
+TODO: Document the ScrollGestureEndedEventTrigger.

--- a/docs/Triggers/ScrollGestureEndedGestureTrigger.md
+++ b/docs/Triggers/ScrollGestureEndedGestureTrigger.md
@@ -1,0 +1,3 @@
+# ScrollGestureEndedGestureTrigger
+
+TODO: Document the ScrollGestureEndedGestureTrigger.

--- a/docs/Triggers/ScrollGestureEventTrigger.md
+++ b/docs/Triggers/ScrollGestureEventTrigger.md
@@ -1,0 +1,3 @@
+# ScrollGestureEventTrigger
+
+TODO: Document the ScrollGestureEventTrigger.

--- a/docs/Triggers/ScrollGestureGestureTrigger.md
+++ b/docs/Triggers/ScrollGestureGestureTrigger.md
@@ -1,0 +1,3 @@
+# ScrollGestureGestureTrigger
+
+TODO: Document the ScrollGestureGestureTrigger.

--- a/docs/Triggers/ScrollGestureInertiaStartingGestureTrigger.md
+++ b/docs/Triggers/ScrollGestureInertiaStartingGestureTrigger.md
@@ -1,0 +1,3 @@
+# ScrollGestureInertiaStartingGestureTrigger
+
+TODO: Document the ScrollGestureInertiaStartingGestureTrigger.

--- a/docs/Triggers/SizeChangedTrigger.md
+++ b/docs/Triggers/SizeChangedTrigger.md
@@ -1,0 +1,3 @@
+# SizeChangedTrigger
+
+TODO: Document the SizeChangedTrigger.

--- a/docs/Triggers/SplitViewPaneClosedTrigger.md
+++ b/docs/Triggers/SplitViewPaneClosedTrigger.md
@@ -1,0 +1,3 @@
+# SplitViewPaneClosedTrigger
+
+TODO: Document the SplitViewPaneClosedTrigger.

--- a/docs/Triggers/SplitViewPaneClosingTrigger.md
+++ b/docs/Triggers/SplitViewPaneClosingTrigger.md
@@ -1,0 +1,3 @@
+# SplitViewPaneClosingTrigger
+
+TODO: Document the SplitViewPaneClosingTrigger.

--- a/docs/Triggers/SplitViewPaneOpenedTrigger.md
+++ b/docs/Triggers/SplitViewPaneOpenedTrigger.md
@@ -1,0 +1,3 @@
+# SplitViewPaneOpenedTrigger
+
+TODO: Document the SplitViewPaneOpenedTrigger.

--- a/docs/Triggers/SplitViewPaneOpeningTrigger.md
+++ b/docs/Triggers/SplitViewPaneOpeningTrigger.md
@@ -1,0 +1,3 @@
+# SplitViewPaneOpeningTrigger
+
+TODO: Document the SplitViewPaneOpeningTrigger.

--- a/docs/Triggers/TabControlSelectionChangedTrigger.md
+++ b/docs/Triggers/TabControlSelectionChangedTrigger.md
@@ -1,0 +1,3 @@
+# TabControlSelectionChangedTrigger
+
+TODO: Document the TabControlSelectionChangedTrigger.

--- a/docs/Triggers/TappedEventTrigger.md
+++ b/docs/Triggers/TappedEventTrigger.md
@@ -1,0 +1,3 @@
+# TappedEventTrigger
+
+TODO: Document the TappedEventTrigger.

--- a/docs/Triggers/TappedGestureTrigger.md
+++ b/docs/Triggers/TappedGestureTrigger.md
@@ -1,0 +1,3 @@
+# TappedGestureTrigger
+
+TODO: Document the TappedGestureTrigger.

--- a/docs/Triggers/TappedTrigger.md
+++ b/docs/Triggers/TappedTrigger.md
@@ -1,0 +1,3 @@
+# TappedTrigger
+
+TODO: Document the TappedTrigger.

--- a/docs/Triggers/TaskCompletedTrigger.md
+++ b/docs/Triggers/TaskCompletedTrigger.md
@@ -1,0 +1,3 @@
+# TaskCompletedTrigger
+
+TODO: Document the TaskCompletedTrigger.

--- a/docs/Triggers/TextInputEventTrigger.md
+++ b/docs/Triggers/TextInputEventTrigger.md
@@ -1,0 +1,3 @@
+# TextInputEventTrigger
+
+TODO: Document the TextInputEventTrigger.

--- a/docs/Triggers/TextInputMethodClientRequestedEventTrigger.md
+++ b/docs/Triggers/TextInputMethodClientRequestedEventTrigger.md
@@ -1,0 +1,3 @@
+# TextInputMethodClientRequestedEventTrigger
+
+TODO: Document the TextInputMethodClientRequestedEventTrigger.

--- a/docs/Triggers/TextInputMethodClientRequestedTrigger.md
+++ b/docs/Triggers/TextInputMethodClientRequestedTrigger.md
@@ -1,0 +1,3 @@
+# TextInputMethodClientRequestedTrigger
+
+TODO: Document the TextInputMethodClientRequestedTrigger.

--- a/docs/Triggers/TextInputTrigger.md
+++ b/docs/Triggers/TextInputTrigger.md
@@ -1,0 +1,3 @@
+# TextInputTrigger
+
+TODO: Document the TextInputTrigger.

--- a/docs/Triggers/ThemeVariantTrigger.md
+++ b/docs/Triggers/ThemeVariantTrigger.md
@@ -1,0 +1,3 @@
+# ThemeVariantTrigger
+
+TODO: Document the ThemeVariantTrigger.

--- a/docs/Triggers/TimerTrigger.md
+++ b/docs/Triggers/TimerTrigger.md
@@ -1,0 +1,3 @@
+# TimerTrigger
+
+TODO: Document the TimerTrigger.

--- a/docs/Triggers/ToolTipClosingTrigger.md
+++ b/docs/Triggers/ToolTipClosingTrigger.md
@@ -1,0 +1,3 @@
+# ToolTipClosingTrigger
+
+TODO: Document the ToolTipClosingTrigger.

--- a/docs/Triggers/ToolTipOpeningTrigger.md
+++ b/docs/Triggers/ToolTipOpeningTrigger.md
@@ -1,0 +1,3 @@
+# ToolTipOpeningTrigger
+
+TODO: Document the ToolTipOpeningTrigger.

--- a/docs/Triggers/TransitionsChangedTrigger.md
+++ b/docs/Triggers/TransitionsChangedTrigger.md
@@ -1,0 +1,3 @@
+# TransitionsChangedTrigger
+
+TODO: Document the TransitionsChangedTrigger.

--- a/docs/Triggers/TreeViewFilterTextChangedTrigger.md
+++ b/docs/Triggers/TreeViewFilterTextChangedTrigger.md
@@ -1,0 +1,3 @@
+# TreeViewFilterTextChangedTrigger
+
+TODO: Document the TreeViewFilterTextChangedTrigger.

--- a/docs/Triggers/UnloadedTrigger.md
+++ b/docs/Triggers/UnloadedTrigger.md
@@ -1,0 +1,3 @@
+# UnloadedTrigger
+
+TODO: Document the UnloadedTrigger.

--- a/docs/Triggers/UploadCompletedTrigger.md
+++ b/docs/Triggers/UploadCompletedTrigger.md
@@ -1,0 +1,3 @@
+# UploadCompletedTrigger
+
+TODO: Document the UploadCompletedTrigger.

--- a/docs/Triggers/ValueChangedTriggerBehavior.md
+++ b/docs/Triggers/ValueChangedTriggerBehavior.md
@@ -1,0 +1,3 @@
+# ValueChangedTriggerBehavior
+
+TODO: Document the ValueChangedTriggerBehavior.

--- a/docs/Triggers/ViewModelPropertyChangedTrigger.md
+++ b/docs/Triggers/ViewModelPropertyChangedTrigger.md
@@ -1,0 +1,3 @@
+# ViewModelPropertyChangedTrigger
+
+TODO: Document the ViewModelPropertyChangedTrigger.

--- a/docs/Triggers/WindowStateTrigger.md
+++ b/docs/Triggers/WindowStateTrigger.md
@@ -1,0 +1,3 @@
+# WindowStateTrigger
+
+TODO: Document the WindowStateTrigger.

--- a/docs/Triggers/WriteableBitmapTimerTrigger.md
+++ b/docs/Triggers/WriteableBitmapTimerTrigger.md
@@ -1,0 +1,3 @@
+# WriteableBitmapTimerTrigger
+
+TODO: Document the WriteableBitmapTimerTrigger.

--- a/docs/Triggers/WriteableBitmapTrigger.md
+++ b/docs/Triggers/WriteableBitmapTrigger.md
@@ -1,0 +1,3 @@
+# WriteableBitmapTrigger
+
+TODO: Document the WriteableBitmapTrigger.

--- a/tools/GenerateDocs/GenerateDocs.csproj
+++ b/tools/GenerateDocs/GenerateDocs.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Xaml.Behaviors.Interactivity/Xaml.Behaviors.Interactivity.csproj" />
+    <PackageReference Include="Mono.Cecil" />
+  </ItemGroup>
+</Project>

--- a/tools/GenerateDocs/Program.cs
+++ b/tools/GenerateDocs/Program.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+
+namespace GenerateDocs;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length == 1 && args[0].Contains(' '))
+        {
+            args = args[0].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        }
+        var root = args.Length > 0 ? args[0] : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var configuration = args.Length > 1 ? args[1] : "Debug";
+
+        var srcDir = Path.Combine(root, "src");
+        var docsDir = Path.Combine(root, "docs");
+
+        var assemblyPaths = Directory.GetFiles(srcDir, "Xaml.Behaviors.*.dll", SearchOption.AllDirectories)
+            .Where(p => p.Contains(Path.Combine("bin", configuration)))
+            .ToList();
+
+        foreach (var asmPath in assemblyPaths)
+        {
+            AssemblyDefinition asm;
+            try
+            {
+                asm = AssemblyDefinition.ReadAssembly(asmPath);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var type in asm.MainModule.Types.Where(t => t.IsPublic && t.IsClass && !t.IsAbstract))
+            {
+                string? category = null;
+                if (DerivesFrom(type, "Avalonia.Xaml.Interactivity.Behavior"))
+                    category = "Behaviors";
+                else if (ImplementsInterface(type, "Avalonia.Xaml.Interactivity.IAction"))
+                    category = "Actions";
+                else if (DerivesFrom(type, "Avalonia.Xaml.Interactivity.Trigger") || ImplementsInterface(type, "Avalonia.Xaml.Interactivity.ITrigger"))
+                    category = "Triggers";
+
+                if (category is null)
+                    continue;
+
+                var stubDir = Path.Combine(docsDir, category);
+                Directory.CreateDirectory(stubDir);
+                var file = Path.Combine(stubDir, $"{type.Name}.md");
+                if (!File.Exists(file))
+                {
+                    File.WriteAllText(file, $"# {type.Name}\n\nTODO: Document the {type.Name}.\n");
+                    Console.WriteLine($"Created {file}");
+                }
+            }
+        }
+    }
+
+    static bool DerivesFrom(TypeDefinition type, string baseFullName)
+    {
+        var current = type;
+        while (current != null)
+        {
+            if (current.FullName.StartsWith(baseFullName))
+                return true;
+            current = current.BaseType?.Resolve();
+        }
+        return false;
+    }
+
+    static bool ImplementsInterface(TypeDefinition type, string ifaceFullName)
+    {
+        return type.Interfaces.Any(i => i.InterfaceType.FullName.StartsWith(ifaceFullName));
+    }
+}


### PR DESCRIPTION
## Summary
- add new GenerateDocs tool that reflects over compiled assemblies and creates missing markdown stubs
- wire the tool into the Nuke build with a `Docs` target
- describe how to run the generator in docs
- allow committing tools/GenerateDocs directory via .gitignore update
- add package reference for Mono.Cecil

## Testing
- `dotnet build tools/GenerateDocs/GenerateDocs.csproj -c Release`
- `dotnet run --project tools/GenerateDocs/GenerateDocs.csproj -- /workspace/Xaml.Behaviors Release`
- `./build.sh --target Docs`
- `dotnet test AvaloniaBehaviors.sln --configuration Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b325039888321845eb5bb0faeaaa8