### PR TITLE
Add AllowedEffects to TypedDragBehaviorBase

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,9 @@ Welcome to the project documentation. Below is the table of contents that mirror
 - [License](../README.md#license)
 
 For detailed information about each section, refer to the [project README](../README.md).
+
+## Drag-and-drop behavior updates
+
+`TypedDragBehaviorBase` now exposes an `AllowedEffects` property. Set this to the
+desired combination of `DragDropEffects` (e.g. `Move`, `Copy`) to control which
+operations are permitted when a drag is initiated.

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
@@ -20,6 +20,21 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
     private bool _lock;
 
     /// <summary>
+    /// Identifies the <see cref="AllowedEffects"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<DragDropEffects> AllowedEffectsProperty =
+        AvaloniaProperty.Register<TypedDragBehaviorBase, DragDropEffects>(nameof(AllowedEffects), DragDropEffects.Move);
+
+    /// <summary>
+    /// Gets or sets the drag drop effects allowed for the operation.
+    /// </summary>
+    public DragDropEffects AllowedEffects
+    {
+        get => GetValue(AllowedEffectsProperty);
+        set => SetValue(AllowedEffectsProperty, value);
+    }
+
+    /// <summary>
     /// Identifies the <see cref="DataType"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<Type?> DataTypeProperty =
@@ -71,26 +86,7 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
         var data = new DataObject();
         data.Set(ContextDropBehaviorBase.DataFormat, value!);
 
-        var effect = DragDropEffects.None;
-
-        if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Alt))
-        {
-            effect |= DragDropEffects.Link;
-        }
-        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Shift))
-        {
-            effect |= DragDropEffects.Move;
-        }
-        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Control))
-        {
-            effect |= DragDropEffects.Copy;
-        }
-        else
-        {
-            effect |= DragDropEffects.Move;
-        }
-
-        await DragDrop.DoDragDrop(triggerEvent, data, effect);
+        await DragDrop.DoDragDrop(triggerEvent, data, AllowedEffects);
     }
 
     private void AssociatedObject_PointerPressed(object? sender, PointerPressedEventArgs e)


### PR DESCRIPTION
## Summary
- add `AllowedEffects` property to `TypedDragBehaviorBase`
- use that property when starting a drag operation
- document the new property

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38cfded88321ac1092292835845b