### PR TITLE
Add RemoteDropHandler with async drop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,10 @@ This section provides an overview of all available classes and their purpose in 
 - **UploadCompletedTrigger** ([Sample](samples/BehaviorsTestApplication/Views/Pages/UploadFileView.axaml))
   *Invokes actions when an upload is marked complete.*
 
+### Remote Drop Handling
+- **RemoteDropHandler** ([Sample](samples/BehaviorsTestApplication/Views/Pages/RemoteDropHandlerView.axaml))
+  *Uploads dropped files asynchronously to a remote service.*
+
 ### Focus
 - **AutoFocusBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/AutoFocusBehaviorView.axaml))
   *Automatically sets the focus on the associated control when it is loaded.*

--- a/samples/BehaviorsTestApplication/Behaviors/RemoteDropHandler.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/RemoteDropHandler.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Xaml.Interactions.DragAndDrop;
+using BehaviorsTestApplication.ViewModels;
+
+namespace BehaviorsTestApplication.Behaviors;
+
+public sealed class RemoteDropHandler : DropHandlerBase
+{
+    public string? Url { get; set; }
+
+    public override bool Validate(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
+    {
+        return e.Data.Contains(DataFormats.Files) && targetContext is MainWindowViewModel && !string.IsNullOrEmpty(Url);
+    }
+
+    public override async Task<bool> ExecuteAsync(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
+    {
+        if (!e.Data.Contains(DataFormats.Files) || targetContext is not MainWindowViewModel vm || string.IsNullOrEmpty(Url))
+        {
+            return false;
+        }
+
+        var files = e.Data.GetFiles();
+        if (files is null)
+        {
+            return false;
+        }
+
+        using var client = new HttpClient();
+        foreach (var file in files)
+        {
+#if NET6_0_OR_GREATER
+            await using var stream = File.OpenRead(file.Path);
+#else
+            using var stream = File.OpenRead(file.Path);
+#endif
+            using var content = new StreamContent(stream);
+            var response = await client.PostAsync(Url, content);
+            vm.UploadCompletedCommand?.Execute(response);
+        }
+
+        return true;
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -291,6 +291,9 @@
       <TabItem Header="Upload File">
         <pages:UploadFileView />
       </TabItem>
+      <TabItem Header="Remote Drop Handler">
+        <pages:RemoteDropHandlerView />
+      </TabItem>
       <TabItem Header="ContentControlFilesDropBehavior">
         <pages:ContentControlFilesDropBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoteDropHandlerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoteDropHandlerView.axaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:b="using:BehaviorsTestApplication.Behaviors"
+             x:Class="BehaviorsTestApplication.Views.Pages.RemoteDropHandlerView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+
+  <UserControl.Resources>
+    <b:RemoteDropHandler x:Key="RemoteDropHandler" Url="https://httpbin.org/post" />
+  </UserControl.Resources>
+
+  <Border Background="Transparent" Padding="20" BorderThickness="1" BorderBrush="{DynamicResource SystemAccentColor}">
+    <Interaction.Behaviors>
+      <ContextDropBehavior Handler="{StaticResource RemoteDropHandler}" Context="{Binding}" />
+    </Interaction.Behaviors>
+    <TextBlock Text="Drop files to upload" HorizontalAlignment="Center" VerticalAlignment="Center" />
+  </Border>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/RemoteDropHandlerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/RemoteDropHandlerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class RemoteDropHandlerView : UserControl
+{
+    public RemoteDropHandlerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/Contract/IDropHandler.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/Contract/IDropHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using System.Threading.Tasks;
 
 namespace Avalonia.Xaml.Interactions.DragAndDrop;
 
@@ -65,6 +66,17 @@ public interface IDropHandler
     /// <param name="state"></param>
     /// <returns></returns>
     bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state);
+
+    /// <summary>
+    /// Executes the drop logic asynchronously.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    /// <param name="sourceContext"></param>
+    /// <param name="targetContext"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    Task<bool> ExecuteAsync(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state);
 
     /// <summary>
     /// Cancels the drag operation.

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DropHandlerBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DropHandlerBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 
@@ -145,9 +146,9 @@ public abstract class DropHandlerBase : IDropHandler
     /// <param name="e"></param>
     /// <param name="sourceContext"></param>
     /// <param name="targetContext"></param>
-    public virtual void Drop(object? sender, DragEventArgs e, object? sourceContext, object? targetContext)
+    public virtual async void Drop(object? sender, DragEventArgs e, object? sourceContext, object? targetContext)
     {
-        if (Execute(sender, e, sourceContext, targetContext, null) == false)
+        if (await ExecuteAsync(sender, e, sourceContext, targetContext, null) == false)
         {
             e.DragEffects = DragDropEffects.None;
             e.Handled = true;
@@ -195,6 +196,20 @@ public abstract class DropHandlerBase : IDropHandler
     public virtual bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
     {
         return false;
+    }
+
+    /// <summary>
+    /// Executes the drop operation asynchronously.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    /// <param name="sourceContext"></param>
+    /// <param name="targetContext"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    public virtual Task<bool> ExecuteAsync(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
+    {
+        return Task.FromResult(Execute(sender, e, sourceContext, targetContext, state));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- expand `IDropHandler` with `ExecuteAsync`
- update `DropHandlerBase` to use async execution
- implement new sample `RemoteDropHandler`
- add `RemoteDropHandlerView` demo page and include it in the sample app
- document remote drop handler usage

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38dd83848321adf5fe968c3778a2