### PR TITLE
Introduce DragService for drag operations

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -99,31 +99,9 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
     /// <param name="context"></param>
     protected abstract void OnAfterDragDrop(object? sender, PointerEventArgs e, object? context);
 
-    private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value)
+    private Task DoDragDrop(PointerEventArgs triggerEvent, object? value)
     {
-        var data = new DataObject();
-        data.Set(ContextDropBehaviorBase.DataFormat, value!);
-
-        var effect = DragDropEffects.None;
-
-        if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Alt))
-        {
-            effect |= DragDropEffects.Link;
-        }
-        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Shift))
-        {
-            effect |= DragDropEffects.Move;
-        }
-        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Control))
-        {
-            effect |= DragDropEffects.Copy;
-        }
-        else
-        {
-            effect |= DragDropEffects.Move;
-        }
-
-        await DragDrop.DoDragDrop(triggerEvent, data, effect);
+        return DragService.StartDragAsync(triggerEvent, value);
     }
 
     private void Released()

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
@@ -102,32 +102,9 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
         AssociatedObject?.RemoveHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost);
     }
 
-    private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string direction)
+    private Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string direction)
     {
-        var data = new DataObject();
-        data.Set(ContextDropBehavior.DataFormat, value!);
-        data.Set("direction", direction);
-
-        var effect = DragDropEffects.None;
-
-        if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Alt))
-        {
-            effect |= DragDropEffects.Link;
-        }
-        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Shift))
-        {
-            effect |= DragDropEffects.Move;
-        }
-        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Control))
-        {
-            effect |= DragDropEffects.Copy;
-        }
-        else
-        {
-            effect |= DragDropEffects.Move;
-        }
-
-        await DragDrop.DoDragDrop(triggerEvent, data, effect);
+        return DragService.StartDragAsync(triggerEvent, value, ("direction", direction));
     }
 
     private void Released()

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DragService.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DragService.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+
+namespace Avalonia.Xaml.Interactions.DragAndDrop;
+
+/// <summary>
+/// Provides helpers for starting drag operations.
+/// </summary>
+public static class DragService
+{
+    /// <summary>
+    /// Creates a <see cref="DataObject"/> containing context data and any additional entries.
+    /// </summary>
+    /// <param name="context">Context object to store using <see cref="ContextDropBehaviorBase.DataFormat"/>.</param>
+    /// <param name="extras">Optional extra data entries.</param>
+    /// <returns>The created <see cref="DataObject"/>.</returns>
+    public static DataObject CreateDataObject(object? context, params (string format, object? data)[] extras)
+    {
+        var dataObject = new DataObject();
+        dataObject.Set(ContextDropBehaviorBase.DataFormat, context!);
+
+        foreach (var (format, data) in extras)
+        {
+            dataObject.Set(format, data!);
+        }
+
+        return dataObject;
+    }
+
+    /// <summary>
+    /// Determines allowed drag effects based on key modifiers.
+    /// </summary>
+    /// <param name="triggerEvent">Event containing modifier state.</param>
+    /// <returns>The drag effects.</returns>
+    public static DragDropEffects GetDragEffects(PointerEventArgs triggerEvent)
+    {
+        var effect = DragDropEffects.None;
+
+        if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            effect |= DragDropEffects.Link;
+        }
+        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            effect |= DragDropEffects.Move;
+        }
+        else if (triggerEvent.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            effect |= DragDropEffects.Copy;
+        }
+        else
+        {
+            effect |= DragDropEffects.Move;
+        }
+
+        return effect;
+    }
+
+    /// <summary>
+    /// Starts a drag operation using the provided data.
+    /// </summary>
+    /// <param name="triggerEvent">Pointer event that initiated the drag.</param>
+    /// <param name="data">Data object containing drag data.</param>
+    public static Task StartDragAsync(PointerEventArgs triggerEvent, DataObject data)
+    {
+        var effect = GetDragEffects(triggerEvent);
+        return DragDrop.DoDragDrop(triggerEvent, data, effect);
+    }
+
+    /// <summary>
+    /// Creates a data object and begins a drag using standard options.
+    /// </summary>
+    /// <param name="triggerEvent">Pointer event that initiated the drag.</param>
+    /// <param name="context">Context data to include.</param>
+    /// <param name="extras">Additional data entries.</param>
+    public static Task StartDragAsync(
+        PointerEventArgs triggerEvent,
+        object? context,
+        params (string format, object? data)[] extras)
+    {
+        var dataObject = CreateDataObject(context, extras);
+        return StartDragAsync(triggerEvent, dataObject);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DragServiceTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DragServiceTests.cs
@@ -1,0 +1,27 @@
+using Avalonia.Input;
+using Avalonia.Xaml.Interactions.DragAndDrop;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class DragServiceTests
+{
+    [Fact]
+    public void CreateDataObject_Sets_Context_Value()
+    {
+        var dataObject = DragService.CreateDataObject("value");
+
+        Assert.True(dataObject.Contains(ContextDropBehaviorBase.DataFormat));
+        Assert.Equal("value", dataObject.Get(ContextDropBehaviorBase.DataFormat));
+    }
+
+    [Fact]
+    public void CreateDataObject_Adds_Extras()
+    {
+        var dataObject = DragService.CreateDataObject("value", ("direction", "down"));
+
+        Assert.Equal("value", dataObject.Get(ContextDropBehaviorBase.DataFormat));
+        Assert.Equal("down", dataObject.Get("direction"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `DragService` helper for standardized drag & drop
- refactor context drag behaviors to use `DragService`
- add unit tests validating `DragService` data object creation

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38dbc7d8832196a41ef49b55e391