### PR TITLE
Add FilesDropBehavior drop test

### DIFF
--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/FilesDropBehavior001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/FilesDropBehavior001.axaml
@@ -1,0 +1,13 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dnd="using:Avalonia.Xaml.Interactions.DragAndDrop"
+        xmlns:local="clr-namespace:Avalonia.Xaml.Interactions.UnitTests.Core"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.FilesDropBehavior001"
+        x:DataType="local:FilesDropBehavior001"
+        Title="FilesDropBehavior001">
+  <Border Name="TargetBorder" Width="100" Height="100">
+    <Interaction.Behaviors>
+      <dnd:FilesDropBehavior Command="{Binding DropCommand}" />
+    </Interaction.Behaviors>
+  </Border>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/FilesDropBehavior001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/FilesDropBehavior001.axaml.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class FilesDropBehavior001 : Window
+{
+    public ICommand DropCommand { get; }
+
+    public IEnumerable<IStorageItem>? DroppedFiles { get; private set; }
+
+    public FilesDropBehavior001()
+    {
+        InitializeComponent();
+
+        DropCommand = new Command(parameter =>
+        {
+            DroppedFiles = parameter as IEnumerable<IStorageItem>;
+        });
+
+        DataContext = this;
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/FilesDropBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/FilesDropBehaviorTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Avalonia.Xaml.Interactions.DragAndDrop;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class FilesDropBehaviorTests
+{
+    [AvaloniaFact]
+    public void FilesDropBehavior_Drops_Files()
+    {
+        var tmp1 = Path.GetTempFileName();
+        var tmp2 = Path.GetTempFileName();
+        File.WriteAllText(tmp1, "1");
+        File.WriteAllText(tmp2, "2");
+
+        var provider = new MockStorageProvider();
+        var file1 = provider.GetFile(tmp1);
+        var file2 = provider.GetFile(tmp2);
+
+        var window = new FilesDropBehavior001();
+        window.Show();
+
+        var data = new DataObject();
+        data.Set(DataFormats.Files, new[] { file1, file2 });
+
+        var args = new DragEventArgs(DragDrop.DropEvent, data, window.TargetBorder, new Point(0, 0), KeyModifiers.None);
+        window.TargetBorder.RaiseEvent(args);
+
+        Assert.NotNull(window.DroppedFiles);
+        var list = new List<IStorageItem>(window.DroppedFiles!);
+        Assert.Equal(2, list.Count);
+        Assert.Equal(file1.Path, ((IStorageFile)list[0]).Path);
+        Assert.Equal(file2.Path, ((IStorageFile)list[1]).Path);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/TestStorage.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/TestStorage.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Avalonia.Platform.Storage;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+internal static class TestStorage
+{
+    public static IStorageFile CreateFile(string path)
+    {
+        var assembly = typeof(IStorageFile).Assembly;
+        var type = assembly.GetType("Avalonia.Platform.Storage.FileIO.BclStorageFile")!;
+        return (IStorageFile)Activator.CreateInstance(type, new FileInfo(path))!;
+    }
+}
+
+internal sealed class MockStorageProvider
+{
+    public IStorageFile GetFile(string path) => TestStorage.CreateFile(path);
+}


### PR DESCRIPTION
## Summary
- create FilesDropBehavior window and backing classes
- provide helper to construct `IStorageFile` instances
- test dropping files with FilesDropBehavior

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d9e5c083218d16e56d2d8fbe88