### PR TITLE
Add DropTargetHighlightBehavior for visual drag feedback

### DIFF
--- a/samples/BehaviorsTestApplication/Views/Pages/DragBetweenPanelsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DragBetweenPanelsView.axaml
@@ -4,10 +4,16 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="300">
+  <UserControl.Styles>
+    <Style Selector="StackPanel.DropTarget">
+      <Setter Property="Background" Value="LightGreen" />
+    </Style>
+  </UserControl.Styles>
   <Grid ColumnDefinitions="*,*" Margin="5">
     <StackPanel x:Name="LeftPanel" Background="LightGray" Margin="5">
       <Interaction.Behaviors>
         <PanelDropBehavior />
+        <DropTargetHighlightBehavior ClassName="DropTarget" IsPseudoClass="True" />
       </Interaction.Behaviors>
       <TextBlock Text="Left Panel" Margin="5" />
       <Rectangle Width="40" Height="40" Fill="Red" Margin="5">
@@ -24,6 +30,7 @@
     <StackPanel x:Name="RightPanel" Grid.Column="1" Background="LightGray" Margin="5">
       <Interaction.Behaviors>
         <PanelDropBehavior />
+        <DropTargetHighlightBehavior ClassName="DropTarget" IsPseudoClass="True" />
         <DragEnterEventTrigger>
           <ChangePropertyAction TargetObject="InfoText" PropertyName="Text" Value="Drag Enter" />
         </DragEnterEventTrigger>

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DropTargetHighlightBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DropTargetHighlightBehavior.cs
@@ -1,0 +1,116 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Metadata;
+using Avalonia.Styling;
+
+namespace Avalonia.Xaml.Interactions.DragAndDrop;
+
+/// <summary>
+/// Highlights the drop target while a drag is over the control.
+/// </summary>
+public class DropTargetHighlightBehavior : DragAndDropEventsBehavior
+{
+    /// <summary>
+    /// Identifies the <seealso cref="ClassName"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ClassNameProperty =
+        AvaloniaProperty.Register<DropTargetHighlightBehavior, string?>(nameof(ClassName));
+
+    /// <summary>
+    /// Identifies the <seealso cref="IsPseudoClass"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsPseudoClassProperty =
+        AvaloniaProperty.Register<DropTargetHighlightBehavior, bool>(nameof(IsPseudoClass));
+
+    /// <summary>
+    /// Identifies the <seealso cref="IsHighlighted"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsHighlightedProperty =
+        AvaloniaProperty.Register<DropTargetHighlightBehavior, bool>(nameof(IsHighlighted));
+
+    /// <summary>
+    /// Gets or sets the CSS class or pseudo class name that is toggled when the drop target is highlighted.
+    /// This is an avalonia property.
+    /// </summary>
+    [Content]
+    public string? ClassName
+    {
+        get => GetValue(ClassNameProperty);
+        set => SetValue(ClassNameProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <see cref="ClassName"/> is a pseudo class. This is an avalonia property.
+    /// </summary>
+    public bool IsPseudoClass
+    {
+        get => GetValue(IsPseudoClassProperty);
+        set => SetValue(IsPseudoClassProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the target control is highlighted.
+    /// This is an avalonia property.
+    /// </summary>
+    public bool IsHighlighted
+    {
+        get => GetValue(IsHighlightedProperty);
+        set => SetValue(IsHighlightedProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDragEnter(object? sender, DragEventArgs e)
+    {
+        SetHighlight(true);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDragLeave(object? sender, DragEventArgs e)
+    {
+        SetHighlight(false);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDrop(object? sender, DragEventArgs e)
+    {
+        SetHighlight(false);
+    }
+
+    private void SetHighlight(bool highlight)
+    {
+        var target = TargetControl ?? AssociatedObject;
+        if (target is null)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(ClassName))
+        {
+            if (highlight)
+            {
+                if (IsPseudoClass)
+                {
+                    ((IPseudoClasses)target.Classes).Add(ClassName);
+                }
+                else
+                {
+                    target.Classes.Add(ClassName);
+                }
+            }
+            else
+            {
+                if (IsPseudoClass)
+                {
+                    ((IPseudoClasses)target.Classes).Remove(ClassName);
+                }
+                else
+                {
+                    target.Classes.Remove(ClassName);
+                }
+            }
+        }
+
+        IsHighlighted = highlight;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `DropTargetHighlightBehavior` to highlight drop targets during drag
- demonstrate highlighting in `DragBetweenPanelsView.axaml`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d93e588321bf0e43e2d5a9c32b