### PR TITLE
Add cross window drag sample

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -312,6 +312,9 @@
       <TabItem Header="Drag Between Panels">
         <pages:DragBetweenPanelsView />
       </TabItem>
+      <TabItem Header="Cross Window Drag">
+        <pages:CrossWindowDragView />
+      </TabItem>
       <TabItem Header="Cursor Behavior">
         <pages:CursorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/CrossWindowDragView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/CrossWindowDragView.axaml
@@ -1,0 +1,46 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:views="using:BehaviorsTestApplication.Views.Windows"
+             x:Class="BehaviorsTestApplication.Views.Pages.CrossWindowDragView"
+             x:DataType="vm:DragAndDropSampleViewModel"
+             x:CompileBindings="True"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="300">
+  <Design.DataContext>
+    <vm:DragAndDropSampleViewModel />
+  </Design.DataContext>
+
+  <UserControl.Styles>
+    <Style Selector="ListBox.CrossWindowDrag ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDragBehavior />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+  </UserControl.Styles>
+
+  <StackPanel Margin="5" Spacing="5">
+    <Button Content="Open Drop Window">
+      <Interaction.Behaviors>
+        <EventTriggerBehavior EventName="Click">
+          <ShowWindowAction>
+            <views:CrossWindowDragWindow DataContext="{Binding}" />
+          </ShowWindowAction>
+        </EventTriggerBehavior>
+      </Interaction.Behaviors>
+    </Button>
+    <ListBox ItemsSource="{Binding Items}" Classes="CrossWindowDrag">
+      <ListBox.ItemTemplate>
+        <DataTemplate DataType="vm:DragItemViewModel">
+          <TextBlock Text="{Binding Title}" />
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+  </StackPanel>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/CrossWindowDragView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/CrossWindowDragView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class CrossWindowDragView : UserControl
+{
+    public CrossWindowDragView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Windows/CrossWindowDragWindow.axaml
+++ b/samples/BehaviorsTestApplication/Views/Windows/CrossWindowDragWindow.axaml
@@ -1,0 +1,31 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+        x:Class="BehaviorsTestApplication.Views.Windows.CrossWindowDragWindow"
+        x:CompileBindings="True"
+        Width="300" Height="250" Title="Drop Window">
+  <Window.Styles>
+    <Style Selector="ListBox.CrossWindowDrop">
+      <Style.Resources>
+        <ItemsListBoxDropHandler x:Key="ItemsListBoxDropHandler" />
+      </Style.Resources>
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ContextDropBehavior Handler="{StaticResource ItemsListBoxDropHandler}" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="ListBox.CrossWindowDrop ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    </Style>
+  </Window.Styles>
+  <ListBox ItemsSource="{Binding Items}" Classes="CrossWindowDrop">
+    <ListBox.ItemTemplate>
+      <DataTemplate DataType="vm:DragItemViewModel">
+        <TextBlock Text="{Binding Title}" />
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+</Window>

--- a/samples/BehaviorsTestApplication/Views/Windows/CrossWindowDragWindow.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Windows/CrossWindowDragWindow.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Windows;
+
+public partial class CrossWindowDragWindow : Window
+{
+    public CrossWindowDragWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- demonstrate dragging between two windows with `ContextDragBehavior`
- link new `CrossWindowDragView` from the main navigation

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d5787883219a75db45a7e895a7