### PR TITLE
Add Escape cancel to ContextDragBehaviorBase

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -72,6 +72,7 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
         AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         AssociatedObject?.AddHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.KeyDownEvent, AssociatedObject_KeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
     }
 
     /// <inheritdoc />
@@ -81,6 +82,7 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
         AssociatedObject?.RemoveHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased);
         AssociatedObject?.RemoveHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved);
         AssociatedObject?.RemoveHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost);
+        AssociatedObject?.RemoveHandler(InputElement.KeyDownEvent, AssociatedObject_KeyDown);
     }
 
     /// <summary>
@@ -213,5 +215,14 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
     {
         Released();
         _captured = false;
+    }
+
+    private void AssociatedObject_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Released();
+            _captured = false;
+        }
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragBehaviorTests.cs
@@ -1,0 +1,32 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
+
+public class ContextDragBehaviorTests
+{
+    [AvaloniaFact]
+    public void Escape_Cancels_Drag()
+    {
+        var window = new ContextDragEscapeWindow();
+
+        window.Show();
+        window.TargetBorder.Focus();
+
+        var start = new Point(5, 5);
+        window.MouseDown(window.TargetBorder, start, MouseButton.Left);
+
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+
+        var move = new Point(20, 20);
+        window.MouseMove(window.TargetBorder, move);
+        window.MouseUp(window.TargetBorder, move, MouseButton.Left);
+
+        Assert.False(window.TestBehavior.BeforeCalled);
+        Assert.False(window.TestBehavior.AfterCalled);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragEscapeWindow.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragEscapeWindow.axaml
@@ -1,0 +1,10 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.DragAndDrop"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.DragAndDrop.ContextDragEscapeWindow">
+  <Border x:Name="TargetBorder" Width="100" Height="100" Background="Gray">
+    <Interaction.Behaviors>
+      <local:TestContextDragBehavior x:Name="TestBehavior" HorizontalDragThreshold="0" VerticalDragThreshold="0" />
+    </Interaction.Behaviors>
+  </Border>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragEscapeWindow.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragEscapeWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
+
+public partial class ContextDragEscapeWindow : Window
+{
+    public ContextDragEscapeWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/TestContextDragBehavior.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/TestContextDragBehavior.cs
@@ -1,0 +1,20 @@
+using Avalonia.Input;
+using Avalonia.Xaml.Interactions.DragAndDrop;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
+
+internal class TestContextDragBehavior : ContextDragBehaviorBase
+{
+    public bool BeforeCalled { get; private set; }
+    public bool AfterCalled { get; private set; }
+
+    protected override void OnBeforeDragDrop(object? sender, PointerEventArgs e, object? context)
+    {
+        BeforeCalled = true;
+    }
+
+    protected override void OnAfterDragDrop(object? sender, PointerEventArgs e, object? context)
+    {
+        AfterCalled = true;
+    }
+}


### PR DESCRIPTION
## Summary
- cancel drag on Escape key
- add test ensuring Escape aborts drag

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d47d988321a15f04f40a150a5a