### PR TITLE
Add async ExecuteAsync to IDropHandler

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/Contract/IDropHandler.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/Contract/IDropHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using System.Threading.Tasks;
 
 namespace Avalonia.Xaml.Interactions.DragAndDrop;
 
@@ -65,6 +66,17 @@ public interface IDropHandler
     /// <param name="state"></param>
     /// <returns></returns>
     bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state);
+
+    /// <summary>
+    /// Executes the drop logic asynchronously.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    /// <param name="sourceContext"></param>
+    /// <param name="targetContext"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    Task<bool> ExecuteAsync(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state);
 
     /// <summary>
     /// Cancels the drag operation.

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DropBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DropBehaviorBase.cs
@@ -57,9 +57,31 @@ public abstract class DropBehaviorBase : InvokeCommandBehaviorBase
         Handler?.Over(sender, e, null, null);
     }
 
-    private void Drop(object? sender, DragEventArgs e)
+    private async void Drop(object? sender, DragEventArgs e)
     {
-        Handler?.Drop(sender, e, null, null);
+        if (Handler is null)
+        {
+            return;
+        }
+
+        if (!Handler.Validate(sender, e, null, null, null))
+        {
+            e.DragEffects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
+        var result = await Handler.ExecuteAsync(sender, e, null, null, null);
+        if (result == false)
+        {
+            e.DragEffects = DragDropEffects.None;
+            e.Handled = true;
+        }
+        else
+        {
+            e.DragEffects |= DragDropEffects.Copy | DragDropEffects.Move | DragDropEffects.Link;
+            e.Handled = true;
+        }
     }
 
     /// <summary>

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DropHandlerBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DropHandlerBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 
@@ -195,6 +196,20 @@ public abstract class DropHandlerBase : IDropHandler
     public virtual bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
     {
         return false;
+    }
+
+    /// <summary>
+    /// Executes the drop operation asynchronously.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    /// <param name="sourceContext"></param>
+    /// <param name="targetContext"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    public virtual Task<bool> ExecuteAsync(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
+    {
+        return Task.FromResult(Execute(sender, e, sourceContext, targetContext, state));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- extend `IDropHandler` with `ExecuteAsync`
- provide default implementation in `DropHandlerBase`
- use the async method from `DropBehaviorBase`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d407b48321a8b929e11c17f487