### PR TITLE
Add auto-scroll during drag behavior

### DIFF
--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -309,6 +309,9 @@
       <TabItem Header="Mouse Drag Behaviors">
         <pages:MouseDragBehaviorView />
       </TabItem>
+      <TabItem Header="Auto Scroll During Drag">
+        <pages:AutoScrollDuringDragBehaviorView />
+      </TabItem>
       <TabItem Header="Drag Between Panels">
         <pages:DragBetweenPanelsView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/AutoScrollDuringDragBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AutoScrollDuringDragBehaviorView.axaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.AutoScrollDuringDragBehaviorView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="250">
+  <ScrollViewer Width="300" Height="200">
+    <Interaction.Behaviors>
+      <AutoScrollDuringDragBehavior />
+    </Interaction.Behaviors>
+    <Canvas Width="600" Height="400" Background="LightGray">
+      <Rectangle Fill="Red" Width="40" Height="40" Canvas.Left="20" Canvas.Top="20">
+        <Interaction.Behaviors>
+          <MouseDragElementBehavior />
+        </Interaction.Behaviors>
+      </Rectangle>
+      <Rectangle Fill="Green" Width="40" Height="40" Canvas.Left="200" Canvas.Top="150">
+        <Interaction.Behaviors>
+          <MouseDragElementBehavior />
+        </Interaction.Behaviors>
+      </Rectangle>
+    </Canvas>
+  </ScrollViewer>
+</UserControl>
+

--- a/samples/BehaviorsTestApplication/Views/Pages/AutoScrollDuringDragBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AutoScrollDuringDragBehaviorView.axaml
@@ -4,7 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="250">
-  <ScrollViewer Width="300" Height="200">
+  <ScrollViewer Width="300" Height="200"
+                HorizontalScrollBarVisibility="Auto"
+                VerticalScrollBarVisibility="Auto">
     <Interaction.Behaviors>
       <AutoScrollDuringDragBehavior />
     </Interaction.Behaviors>

--- a/samples/BehaviorsTestApplication/Views/Pages/AutoScrollDuringDragBehaviorView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AutoScrollDuringDragBehaviorView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AutoScrollDuringDragBehaviorView : UserControl
+{
+    public AutoScrollDuringDragBehaviorView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}
+

--- a/src/Xaml.Behaviors.Interactions.Draggable/AutoScrollDuringDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/AutoScrollDuringDragBehavior.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Draggable;

--- a/src/Xaml.Behaviors.Interactions.Draggable/AutoScrollDuringDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/AutoScrollDuringDragBehavior.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Draggable;
+
+/// <summary>
+/// Automatically scrolls the associated <see cref="ScrollViewer"/> when the pointer is dragged near its edges.
+/// </summary>
+public class AutoScrollDuringDragBehavior : StyledElementBehavior<ScrollViewer>
+{
+    /// <summary>
+    /// Identifies the <see cref="EdgeDistance"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<double> EdgeDistanceProperty =
+        AvaloniaProperty.Register<AutoScrollDuringDragBehavior, double>(nameof(EdgeDistance), 20);
+
+    /// <summary>
+    /// Identifies the <see cref="ScrollDelta"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<double> ScrollDeltaProperty =
+        AvaloniaProperty.Register<AutoScrollDuringDragBehavior, double>(nameof(ScrollDelta), 10);
+
+    private bool _dragging;
+
+    /// <summary>
+    /// Gets or sets the distance from the edge that triggers scrolling.
+    /// </summary>
+    public double EdgeDistance
+    {
+        get => GetValue(EdgeDistanceProperty);
+        set => SetValue(EdgeDistanceProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the amount scrolled when triggered.
+    /// </summary>
+    public double ScrollDelta
+    {
+        get => GetValue(ScrollDeltaProperty);
+        set => SetValue(ScrollDeltaProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        base.OnAttachedToVisualTree();
+
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        base.OnDetachedFromVisualTree();
+
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, Pressed);
+            AssociatedObject.RemoveHandler(InputElement.PointerReleasedEvent, Released);
+            AssociatedObject.RemoveHandler(InputElement.PointerMovedEvent, Moved);
+            AssociatedObject.RemoveHandler(InputElement.PointerCaptureLostEvent, CaptureLost);
+        }
+    }
+
+    private void Pressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(AssociatedObject).Properties.IsLeftButtonPressed)
+        {
+            _dragging = true;
+        }
+    }
+
+    private void Released(object? sender, PointerReleasedEventArgs e)
+    {
+        if (e.InitialPressMouseButton == MouseButton.Left)
+        {
+            _dragging = false;
+        }
+    }
+
+    private void CaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        _dragging = false;
+    }
+
+    private void Moved(object? sender, PointerEventArgs e)
+    {
+        if (!_dragging || AssociatedObject is null)
+        {
+            return;
+        }
+
+        var pos = e.GetPosition(AssociatedObject);
+        var bounds = AssociatedObject.Bounds;
+        var offset = AssociatedObject.Offset;
+        var extent = AssociatedObject.Extent;
+        var delta = ScrollDelta;
+        var threshold = EdgeDistance;
+
+        double newX = offset.X;
+        double newY = offset.Y;
+
+        if (pos.X < threshold)
+        {
+            newX = Math.Max(newX - delta, 0);
+        }
+        else if (pos.X > bounds.Width - threshold)
+        {
+            newX = Math.Min(newX + delta, Math.Max(extent.Width - bounds.Width, 0));
+        }
+
+        if (pos.Y < threshold)
+        {
+            newY = Math.Max(newY - delta, 0);
+        }
+        else if (pos.Y > bounds.Height - threshold)
+        {
+            newY = Math.Min(newY + delta, Math.Max(extent.Height - bounds.Height, 0));
+        }
+
+        if (Math.Abs(newX - offset.X) > double.Epsilon || Math.Abs(newY - offset.Y) > double.Epsilon)
+        {
+            AssociatedObject.Offset = new Vector(newX, newY);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AutoScrollDuringDragBehavior` for `ScrollViewer`
- autoscroll ScrollViewer while dragging near edges
- demonstrate usage in `BehaviorsTestApplication`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d286288321ad68a64e70dc5341