### PR TITLE
Add AllowExternalDrop property

### DIFF
--- a/samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EditableDraggableListBoxView.axaml
@@ -4,43 +4,46 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             xmlns:drag="clr-namespace:Avalonia.Xaml.Interactions.Draggable;assembly=Xaml.Behaviors.Interactions.Draggable"
              x:CompileBindings="True" x:DataType="vm:DragAndDropSampleViewModel"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
   <Design.DataContext>
     <vm:DragAndDropSampleViewModel />
   </Design.DataContext>
   <UserControl.Styles>
-    <Style Selector="ListBox.EditableDragList">
-      <Style.Resources>
-        <ItemsListBoxDropHandler x:Key="ItemsListBoxDropHandler" />
-      </Style.Resources>
-      <Setter Property="(Interaction.Behaviors)">
-        <BehaviorCollectionTemplate>
-          <BehaviorCollection>
-            <ContextDropBehavior Handler="{StaticResource ItemsListBoxDropHandler}" />
-          </BehaviorCollection>
-        </BehaviorCollectionTemplate>
-      </Setter>
-    </Style>
-    <Style Selector="ListBox.EditableDragList ListBoxItem">
+    <StyleInclude Source="avares://Xaml.Behaviors.Interactions.Draggable/Styles.axaml" />
+    <Style Selector="ListBox.EditableDragListExternal ListBoxItem">
       <Setter Property="HorizontalContentAlignment" Value="Stretch" />
       <Setter Property="Margin" Value="0" />
       <Setter Property="Padding" Value="0" />
       <Setter Property="(Interaction.Behaviors)">
         <BehaviorCollectionTemplate>
           <BehaviorCollection>
-            <ContextDragBehavior HorizontalDragThreshold="3" VerticalDragThreshold="3" />
+            <drag:ItemDragBehavior HorizontalDragThreshold="3" VerticalDragThreshold="3" AllowExternalDrop="True" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="ListBox.EditableDragListNoExternal ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Margin" Value="0" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <drag:ItemDragBehavior HorizontalDragThreshold="3" VerticalDragThreshold="3" AllowExternalDrop="False" />
           </BehaviorCollection>
         </BehaviorCollectionTemplate>
       </Setter>
     </Style>
   </UserControl.Styles>
-  <ListBox ItemsSource="{Binding Items}" Classes="EditableDragList">
-    <ListBox.ItemTemplate>
-      <DataTemplate DataType="vm:DragItemViewModel" x:CompileBindings="False">
-        <Panel Background="Transparent">
-          <Interaction.Behaviors>
-            <InlineEditBehavior DisplayControl="DisplayPanel" EditControl="EditBox" />
+  <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+    <ListBox ItemsSource="{Binding Items}" Classes="EditableDragListExternal">
+      <ListBox.ItemTemplate>
+        <DataTemplate DataType="vm:DragItemViewModel" x:CompileBindings="False">
+          <Panel Background="Transparent">
+            <Interaction.Behaviors>
+              <InlineEditBehavior DisplayControl="DisplayPanel" EditControl="EditBox" />
           </Interaction.Behaviors>
           <TextBox x:Name="EditBox"
                    IsVisible="False"
@@ -60,5 +63,32 @@
         </Panel>
       </DataTemplate>
     </ListBox.ItemTemplate>
-  </ListBox>
+    </ListBox>
+    <ListBox Grid.Column="1" ItemsSource="{Binding Items}" Classes="EditableDragListNoExternal">
+      <ListBox.ItemTemplate>
+        <DataTemplate DataType="vm:DragItemViewModel" x:CompileBindings="False">
+          <Panel Background="Transparent">
+            <Interaction.Behaviors>
+              <InlineEditBehavior DisplayControl="DisplayPanel" EditControl="EditBox" />
+            </Interaction.Behaviors>
+            <TextBox x:Name="EditBox"
+                     IsVisible="False"
+                     Height="{Binding #DisplayPanel.Bounds.Height}"
+                     VerticalContentAlignment="Center"
+                     Margin="0"
+                     Padding="6,0,6,0"
+                     BorderThickness="0"
+                     Text="{Binding Title}">
+            </TextBox>
+            <StackPanel x:Name="DisplayPanel"
+                        Orientation="Horizontal"
+                        Background="Transparent"
+                        Focusable="True">
+              <TextBlock Text="{Binding Title}" Margin="6,8,6,8" />
+            </StackPanel>
+          </Panel>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+  </Grid>
 </UserControl>

--- a/src/Xaml.Behaviors.Interactions.Draggable/ItemDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/ItemDragBehavior.cs
@@ -45,6 +45,12 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
         AvaloniaProperty.Register<ItemDragBehavior, double>(nameof(VerticalDragThreshold), 3);
 
     /// <summary>
+    /// Identifies the <see cref="AllowExternalDrop"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> AllowExternalDropProperty =
+        AvaloniaProperty.Register<ItemDragBehavior, bool>(nameof(AllowExternalDrop), true);
+
+    /// <summary>
     /// Gets or sets the orientation of the drag operation.
     /// </summary>
     public Orientation Orientation
@@ -71,6 +77,15 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
         set => SetValue(VerticalDragThresholdProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether dragging can start when the pointer leaves the control.
+    /// </summary>
+    public bool AllowExternalDrop
+    {
+        get => GetValue(AllowExternalDropProperty);
+        set => SetValue(AllowExternalDropProperty, value);
+    }
+
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
@@ -80,6 +95,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
             AssociatedObject.AddHandler(InputElement.PointerPressedEvent, PointerPressed, RoutingStrategies.Tunnel);
             AssociatedObject.AddHandler(InputElement.PointerMovedEvent, PointerMoved, RoutingStrategies.Tunnel);
             AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, PointerCaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerExitedEvent, PointerExited, RoutingStrategies.Tunnel);
         }
     }
 
@@ -92,6 +108,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
             AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, PointerPressed);
             AssociatedObject.RemoveHandler(InputElement.PointerMovedEvent, PointerMoved);
             AssociatedObject.RemoveHandler(InputElement.PointerCaptureLostEvent, PointerCaptureLost);
+            AssociatedObject.RemoveHandler(InputElement.PointerExitedEvent, PointerExited);
         }
     }
 
@@ -137,6 +154,15 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
     {
         Released();
         _captured = false;
+    }
+
+    private void PointerExited(object? sender, PointerEventArgs e)
+    {
+        if (_captured && !_dragStarted && !AllowExternalDrop)
+        {
+            Released();
+            _captured = false;
+        }
     }
 
     private void Released()


### PR DESCRIPTION
## Summary
- add `AllowExternalDrop` avalonia property to `ItemDragBehavior`
- cancel drag on pointer exit if external drops are disallowed
- show both drag modes in editable list sample

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38d15cd48321b5814b9bab4a8613