### PR TITLE
Add ListReorderDragBehavior with sample

### DIFF
--- a/samples/BehaviorsTestApplication/Views/Pages/DragAndDropView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DragAndDropView.axaml
@@ -16,6 +16,9 @@
     <!-- IconGrabber, MIT License, author: Primer, taken from: https://www.svgrepo.com/svg/347759/grabber -->
     <PathGeometry x:Key="IconGrabberGeometry">M15 18a1 1 0 100-2 1 1 0 000 2zm1-6a1 1 0 11-2 0 1 1 0 012 0zm-7 6a1 1 0 100-2 1 1 0 000 2zm0-5a1 1 0 100-2 1 1 0 000 2zm7-6a1 1 0 11-2 0 1 1 0 012 0zM9 8a1 1 0 100-2 1 1 0 000 2z</PathGeometry>
     <GeometryDrawing x:Key="IconGrabber" Brush="Black" Geometry="{StaticResource IconGrabberGeometry}" />
+    <ObjectTemplate x:Key="ReorderPlaceholder">
+      <Border BorderThickness="0 0 0 2" BorderBrush="{DynamicResource SystemAccentColor}"/>
+    </ObjectTemplate>
   </UserControl.Resources>
 
   <UserControl.Styles>
@@ -33,12 +36,31 @@
       </Setter>
     </Style>
 
+    <Style Selector="ListBox.Reorder">
+      <Setter Property="ItemsPanel">
+        <ItemsPanelTemplate>
+          <StackPanel Orientation="Vertical" />
+        </ItemsPanelTemplate>
+      </Setter>
+    </Style>
+
     <Style Selector="ListBox.ItemsDragAndDrop ListBoxItem">
       <Setter Property="HorizontalContentAlignment" Value="Stretch" />
       <Setter Property="(Interaction.Behaviors)">
         <BehaviorCollectionTemplate>
           <BehaviorCollection>
             <ContextDragBehavior HorizontalDragThreshold="3" VerticalDragThreshold="3" />
+          </BehaviorCollection>
+        </BehaviorCollectionTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="ListBox.Reorder ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="(Interaction.Behaviors)">
+        <BehaviorCollectionTemplate>
+          <BehaviorCollection>
+            <ListReorderDragBehavior PlaceholderTemplate="{StaticResource ReorderPlaceholder}" Orientation="Vertical" />
           </BehaviorCollection>
         </BehaviorCollectionTemplate>
       </Setter>
@@ -218,6 +240,17 @@
     <TabItem Header="ListBox">
       <ListBox ItemsSource="{Binding Items}"
                Classes="ItemsDragAndDrop">
+        <ListBox.ItemTemplate>
+          <DataTemplate DataType="vm:DragItemViewModel">
+            <TextBlock Text="{Binding Title}" />
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </TabItem>
+
+    <TabItem Header="Reorder Behavior">
+      <ListBox ItemsSource="{Binding Items}"
+               Classes="Reorder">
         <ListBox.ItemTemplate>
           <DataTemplate DataType="vm:DragItemViewModel">
             <TextBlock Text="{Binding Title}" />

--- a/src/Xaml.Behaviors.Interactions.Draggable/ListReorderDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/ListReorderDragBehavior.cs
@@ -1,0 +1,267 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media.Transformation;
+using Avalonia.Styling;
+
+namespace Avalonia.Xaml.Interactions.Draggable;
+
+/// <summary>
+/// Allows reordering of items inside an <see cref="ItemsControl"/> while displaying
+/// a placeholder at the insertion point.
+/// </summary>
+public class ListReorderDragBehavior : ItemDragBehavior
+{
+    /// <summary>
+    /// Identifies the <see cref="PlaceholderTemplate"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ITemplate?> PlaceholderTemplateProperty =
+        AvaloniaProperty.Register<ListReorderDragBehavior, ITemplate?>(nameof(PlaceholderTemplate));
+
+    private bool _enableDrag;
+    private bool _dragStarted;
+    private Point _start;
+    private int _draggedIndex;
+    private int _targetIndex;
+    private ItemsControl? _itemsControl;
+    private Control? _draggedContainer;
+    private bool _captured;
+    private Control? _placeholder;
+    private Control? _placeholderContainer;
+
+    /// <summary>
+    /// Gets or sets template used to build placeholder shown while reordering.
+    /// </summary>
+    public ITemplate? PlaceholderTemplate
+    {
+        get => GetValue(PlaceholderTemplateProperty);
+        set => SetValue(PlaceholderTemplateProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        base.OnAttachedToVisualTree();
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, OnPointerMoved, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost, RoutingStrategies.Tunnel);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        base.OnDetachedFromVisualTree();
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.RemoveHandler(InputElement.PointerReleasedEvent, OnPointerReleased);
+            AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);
+            AssociatedObject.RemoveHandler(InputElement.PointerMovedEvent, OnPointerMoved);
+            AssociatedObject.RemoveHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost);
+        }
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var properties = e.GetCurrentPoint(AssociatedObject).Properties;
+        if (properties.IsLeftButtonPressed
+            && AssociatedObject?.Parent is ItemsControl itemsControl)
+        {
+            _enableDrag = true;
+            _dragStarted = false;
+            _start = e.GetPosition(itemsControl);
+            _draggedIndex = -1;
+            _targetIndex = -1;
+            _itemsControl = itemsControl;
+            _draggedContainer = AssociatedObject;
+            _captured = true;
+        }
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_captured)
+        {
+            if (e.InitialPressMouseButton == MouseButton.Left)
+            {
+                RemovePlaceholder();
+            }
+            _captured = false;
+        }
+    }
+
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        RemovePlaceholder();
+        _captured = false;
+    }
+
+    private void RemovePlaceholder()
+    {
+        if (_placeholderContainer is not null && _placeholder is not null)
+        {
+            var layer = AdornerLayer.GetAdornerLayer(_placeholderContainer);
+            if (layer is not null)
+            {
+                layer.Children.Remove(_placeholder);
+            }
+            ((ISetLogicalParent)_placeholder).SetParent(null);
+        }
+
+        _placeholder = null;
+        _placeholderContainer = null;
+        _enableDrag = false;
+        _dragStarted = false;
+        _itemsControl = null;
+        _draggedContainer = null;
+    }
+
+    private void AddPlaceholder(Control container)
+    {
+        if (PlaceholderTemplate is null)
+        {
+            return;
+        }
+
+        if (ReferenceEquals(container, _placeholderContainer))
+        {
+            return;
+        }
+
+        RemovePlaceholder();
+
+        var layer = AdornerLayer.GetAdornerLayer(container);
+        if (layer is null)
+        {
+            return;
+        }
+
+        if (PlaceholderTemplate.Build() is Control adorner)
+        {
+            adorner[AdornerLayer.AdornedElementProperty] = container;
+            ((ISetLogicalParent)adorner).SetParent(container);
+            layer.Children.Add(adorner);
+            _placeholder = adorner;
+            _placeholderContainer = container;
+        }
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        var properties = e.GetCurrentPoint(AssociatedObject).Properties;
+        if (_captured && properties.IsLeftButtonPressed)
+        {
+            if (_itemsControl?.Items is null || !_enableDrag)
+            {
+                return;
+            }
+
+            var orientation = Orientation;
+            var position = e.GetPosition(_itemsControl);
+            var delta = orientation == Orientation.Horizontal ? position.X - _start.X : position.Y - _start.Y;
+
+            if (!_dragStarted)
+            {
+                var diff = _start - position;
+                if (orientation == Orientation.Horizontal)
+                {
+                    if (Math.Abs(diff.X) > HorizontalDragThreshold)
+                    {
+                        _dragStarted = true;
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    if (Math.Abs(diff.Y) > VerticalDragThreshold)
+                    {
+                        _dragStarted = true;
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+            }
+
+            if (_draggedContainer is null)
+            {
+                return;
+            }
+
+            _draggedIndex = _itemsControl.IndexFromContainer(_draggedContainer);
+            _targetIndex = -1;
+
+            var draggedBounds = _draggedContainer.Bounds;
+
+            var draggedStart = orientation == Orientation.Horizontal ? draggedBounds.X : draggedBounds.Y;
+
+            var draggedDeltaStart = orientation == Orientation.Horizontal
+                ? draggedBounds.X + delta
+                : draggedBounds.Y + delta;
+
+            var draggedDeltaEnd = orientation == Orientation.Horizontal
+                ? draggedBounds.X + delta + draggedBounds.Width
+                : draggedBounds.Y + delta + draggedBounds.Height;
+
+            var i = 0;
+
+            foreach (var _ in _itemsControl.Items)
+            {
+                var targetContainer = _itemsControl.ContainerFromIndex(i);
+                if (targetContainer is null || ReferenceEquals(targetContainer, _draggedContainer))
+                {
+                    i++;
+                    continue;
+                }
+
+                var targetBounds = targetContainer.Bounds;
+
+                var targetStart = orientation == Orientation.Horizontal ? targetBounds.X : targetBounds.Y;
+
+                var targetMid = orientation == Orientation.Horizontal
+                    ? targetBounds.X + targetBounds.Width / 2
+                    : targetBounds.Y + targetBounds.Height / 2;
+
+                var targetIndex = _itemsControl.IndexFromContainer(targetContainer);
+
+                if (targetStart > draggedStart && draggedDeltaEnd >= targetMid)
+                {
+                    _targetIndex = _targetIndex == -1 ? targetIndex :
+                        targetIndex > _targetIndex ? targetIndex : _targetIndex;
+                }
+                else if (targetStart < draggedStart && draggedDeltaStart <= targetMid)
+                {
+                    _targetIndex = _targetIndex == -1 ? targetIndex :
+                        targetIndex < _targetIndex ? targetIndex : _targetIndex;
+                }
+
+                i++;
+            }
+
+            if (_targetIndex >= 0)
+            {
+                var container = _itemsControl.ContainerFromIndex(_targetIndex);
+                if (container is not null)
+                {
+                    AddPlaceholder(container);
+                }
+            }
+            else
+            {
+                RemovePlaceholder();
+            }
+        }
+    }
+}
+

--- a/src/Xaml.Behaviors.Interactions.Draggable/ListReorderDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/ListReorderDragBehavior.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
 using Avalonia;
 using Avalonia.Controls;


### PR DESCRIPTION
## Summary
- implement `ListReorderDragBehavior` derived from `ItemDragBehavior`
- allow displaying a placeholder while dragging via `PlaceholderTemplate`
- showcase behaviour in DragAndDropView with new list reordering tab

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38ce5cc48321b31dd5496927be26