### PR TITLE
Implement bounding drag behavior

### DIFF
--- a/src/Xaml.Behaviors.Interactions.Draggable/BoundedDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/BoundedDragBehavior.cs
@@ -1,0 +1,27 @@
+using Avalonia.Controls;
+using Avalonia.Metadata;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Draggable;
+
+/// <summary>
+/// Base class for drag behaviors that support constraining movement to a bounding container.
+/// </summary>
+public abstract class BoundedDragBehavior : StyledElementBehavior<Control>
+{
+    /// <summary>
+    /// Identifies the <see cref="BoundingContainer"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<Control?> BoundingContainerProperty =
+        AvaloniaProperty.Register<BoundedDragBehavior, Control?>(nameof(BoundingContainer));
+
+    /// <summary>
+    /// Gets or sets the control that defines the draggable area bounds.
+    /// </summary>
+    [ResolveByName]
+    public Control? BoundingContainer
+    {
+        get => GetValue(BoundingContainerProperty);
+        set => SetValue(BoundingContainerProperty, value);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Draggable/CanvasDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/CanvasDragBehavior.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -11,7 +12,7 @@ namespace Avalonia.Xaml.Interactions.Draggable;
 /// <summary>
 /// Enables dragging of child controls within a <see cref="Canvas"/>.
 /// </summary>
-public class CanvasDragBehavior : StyledElementBehavior<Control>
+public class CanvasDragBehavior : BoundedDragBehavior
 {
     private bool _enableDrag;
     private Point _start;
@@ -127,10 +128,30 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
             var deltaX = position.X - _start.X;
             var deltaY = position.Y - _start.Y;
             _start = position;
+
             var left = Canvas.GetLeft(_draggedContainer);
             var top = Canvas.GetTop(_draggedContainer);
-            Canvas.SetLeft(_draggedContainer, left + deltaX);
-            Canvas.SetTop(_draggedContainer, top + deltaY);
+
+            var newLeft = left + deltaX;
+            var newTop = top + deltaY;
+
+            var container = BoundingContainer ?? _parent;
+            if (container is not null)
+            {
+                var bounds = container.Bounds;
+                var elementBounds = _draggedContainer.Bounds;
+
+                var minX = 0d;
+                var minY = 0d;
+                var maxX = bounds.Width - elementBounds.Width;
+                var maxY = bounds.Height - elementBounds.Height;
+
+                newLeft = Math.Min(Math.Max(newLeft, minX), maxX);
+                newTop = Math.Min(Math.Max(newTop, minY), maxY);
+            }
+
+            Canvas.SetLeft(_draggedContainer, newLeft);
+            Canvas.SetTop(_draggedContainer, newTop);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/GridDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/GridDragBehavior.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -11,7 +12,7 @@ namespace Avalonia.Xaml.Interactions.Draggable;
 /// <summary>
 /// Allows dragging of grid child controls with optional layout copying.
 /// </summary>
-public class GridDragBehavior : StyledElementBehavior<Control>
+public class GridDragBehavior : BoundedDragBehavior
 {
     /// <summary>
     /// Identifies the <see cref="CopyColumn"/> avalonia property.
@@ -183,6 +184,17 @@ public class GridDragBehavior : StyledElementBehavior<Control>
             }
 
             var position = e.GetPosition(_parent);
+
+            var container = BoundingContainer ?? _parent;
+            if (container is not null)
+            {
+                var relative = e.GetPosition(container);
+                if (relative.X < 0 || relative.Y < 0 ||
+                    relative.X > container.Bounds.Width || relative.Y > container.Bounds.Height)
+                {
+                    return;
+                }
+            }
 
             Control? target = null;
 

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/CanvasDragBehavior001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/CanvasDragBehavior001.axaml
@@ -1,0 +1,13 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:drag="clr-namespace:Avalonia.Xaml.Interactions.Draggable;assembly=Xaml.Behaviors.Interactions.Draggable"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Draggable.CanvasDragBehavior001"
+        Title="CanvasDragBehavior001">
+  <Canvas Width="100" Height="100" Name="DragCanvas">
+    <Button Name="TargetButton" Width="20" Height="20" Canvas.Left="10" Canvas.Top="10">
+      <Interaction.Behaviors>
+        <drag:CanvasDragBehavior BoundingContainer="DragCanvas" />
+      </Interaction.Behaviors>
+    </Button>
+  </Canvas>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/CanvasDragBehavior001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/CanvasDragBehavior001.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Draggable;
+
+public partial class CanvasDragBehavior001 : Window
+{
+    public CanvasDragBehavior001()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/CanvasDragBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/CanvasDragBehaviorTests.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Draggable;
+
+public class CanvasDragBehaviorTests
+{
+    [AvaloniaFact]
+    public void CanvasDragBehavior_Within_Bounds()
+    {
+        var window = new CanvasDragBehavior001();
+
+        window.Show();
+        window.CaptureRenderedFrame()?.Save("CanvasDragBehavior_001_0.png");
+
+        // Begin drag inside the button
+        window.MouseDown(window.DragCanvas, new Point(15, 15), MouseButton.Left);
+        window.MouseMove(window.DragCanvas, new Point(120, 120), RawInputModifiers.LeftMouseButton);
+        window.MouseUp(window.DragCanvas, new Point(120, 120), MouseButton.Left);
+
+        window.CaptureRenderedFrame()?.Save("CanvasDragBehavior_001_1.png");
+
+        Assert.Equal(80d, Canvas.GetLeft(window.TargetButton));
+        Assert.Equal(80d, Canvas.GetTop(window.TargetButton));
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/GridDragBehavior001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/GridDragBehavior001.axaml
@@ -1,0 +1,15 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:drag="clr-namespace:Avalonia.Xaml.Interactions.Draggable;assembly=Xaml.Behaviors.Interactions.Draggable"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Draggable.GridDragBehavior001"
+        Title="GridDragBehavior001">
+  <Grid Width="100" Height="50" Name="DragGrid" ColumnDefinitions="50,50">
+    <Border Name="BoundingBorder" Grid.ColumnSpan="2" Width="50" Height="50" IsHitTestVisible="False" HorizontalAlignment="Left" VerticalAlignment="Top" />
+    <Button Name="LeftButton" Grid.Column="0" Width="50" Height="50">
+      <Interaction.Behaviors>
+        <drag:GridDragBehavior BoundingContainer="BoundingBorder" />
+      </Interaction.Behaviors>
+    </Button>
+    <Button Name="RightButton" Grid.Column="1" Width="50" Height="50" />
+  </Grid>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/GridDragBehavior001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/GridDragBehavior001.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Draggable;
+
+public partial class GridDragBehavior001 : Window
+{
+    public GridDragBehavior001()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/GridDragBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Draggable/GridDragBehaviorTests.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Draggable;
+
+public class GridDragBehaviorTests
+{
+    [AvaloniaFact]
+    public void GridDragBehavior_Respects_Bounds()
+    {
+        var window = new GridDragBehavior001();
+
+        window.Show();
+        window.CaptureRenderedFrame()?.Save("GridDragBehavior_001_0.png");
+
+        // Drag over the right button but outside bounding border
+        window.MouseDown(window.DragGrid, new Point(25, 25), MouseButton.Left);
+        window.MouseMove(window.DragGrid, new Point(75, 25), RawInputModifiers.LeftMouseButton);
+        window.MouseUp(window.DragGrid, new Point(75, 25), MouseButton.Left);
+
+        window.CaptureRenderedFrame()?.Save("GridDragBehavior_001_1.png");
+
+        Assert.Equal(0, Grid.GetColumn(window.LeftButton));
+        Assert.Equal(1, Grid.GetColumn(window.RightButton));
+    }
+}


### PR DESCRIPTION
## Summary
- add `BoundedDragBehavior` with `BoundingContainer` property
- use `BoundedDragBehavior` in `CanvasDragBehavior` and `GridDragBehavior`
- clamp dragged element to bounding container in both behaviors
- add sample windows and tests verifying drag bounds

## Testing
- `dotnet build AvaloniaBehaviors.sln --configuration Release`
- `dotnet test AvaloniaBehaviors.sln --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_687b38cde6bc8321a4d45d746486b0b5