### PR TITLE
Add drag preview adorner support

### DIFF
--- a/src/Xaml.Behaviors.Interactions.Draggable/CanvasDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/CanvasDragBehavior.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactions.DragAndDrop;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Draggable;
@@ -46,18 +47,25 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
 
     private void AddAdorner(Control control)
     {
+        var template = ContextDragBehaviorBase.GetDragPreviewTemplate(control);
+        if (template is null)
+        {
+            return;
+        }
+
         var layer = AdornerLayer.GetAdornerLayer(control);
         if (layer is null)
         {
             return;
         }
 
-        _adorner = new SelectionAdorner()
+        _adorner = new DragPreviewAdorner()
         {
+            Content = template.Build(control.DataContext),
             [AdornerLayer.AdornedElementProperty] = control
         };
 
-        ((ISetLogicalParent) _adorner).SetParent(control);
+        ((ISetLogicalParent)_adorner).SetParent(control);
         layer.Children.Add(_adorner);
     }
 
@@ -70,7 +78,7 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
         }
 
         layer.Children.Remove(_adorner);
-        ((ISetLogicalParent) _adorner).SetParent(null);
+        ((ISetLogicalParent)_adorner).SetParent(null);
         _adorner = null;
     }
 
@@ -87,7 +95,7 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
 
             SetDraggingPseudoClasses(_draggedContainer, true);
 
-            // AddAdorner(_draggedContainer);
+            AddAdorner(_draggedContainer);
 
             _captured = true;
         }
@@ -140,7 +148,7 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
         {
             if (_parent is not null && _draggedContainer is not null)
             {
-                // RemoveAdorner(_draggedContainer);
+                RemoveAdorner(_draggedContainer);
             }
 
             if (_draggedContainer is not null)

--- a/src/Xaml.Behaviors.Interactions.Draggable/DragPreviewAdorner.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/DragPreviewAdorner.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.Draggable;
+
+/// <summary>
+/// Displays drag preview content in an <see cref="AdornerLayer"/>.
+/// </summary>
+public class DragPreviewAdorner : ContentControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DragPreviewAdorner"/> class.
+    /// </summary>
+    public DragPreviewAdorner()
+    {
+        IsHitTestVisible = false;
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Draggable/GridDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/GridDragBehavior.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactions.DragAndDrop;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Draggable;
@@ -105,18 +106,25 @@ public class GridDragBehavior : StyledElementBehavior<Control>
 
     private void AddAdorner(Control control)
     {
+        var template = ContextDragBehaviorBase.GetDragPreviewTemplate(control);
+        if (template is null)
+        {
+            return;
+        }
+
         var layer = AdornerLayer.GetAdornerLayer(control);
         if (layer is null)
         {
             return;
         }
 
-        _adorner = new SelectionAdorner()
+        _adorner = new DragPreviewAdorner()
         {
+            Content = template.Build(control.DataContext),
             [AdornerLayer.AdornedElementProperty] = control
         };
 
-        ((ISetLogicalParent) _adorner).SetParent(control);
+        ((ISetLogicalParent)_adorner).SetParent(control);
         layer.Children.Add(_adorner);
     }
 
@@ -129,7 +137,7 @@ public class GridDragBehavior : StyledElementBehavior<Control>
         }
 
         layer.Children.Remove(_adorner);
-        ((ISetLogicalParent) _adorner).SetParent(null);
+        ((ISetLogicalParent)_adorner).SetParent(null);
         _adorner = null;
     }
 
@@ -146,7 +154,7 @@ public class GridDragBehavior : StyledElementBehavior<Control>
 
             SetDraggingPseudoClasses(_draggedContainer, true);
 
-            // AddAdorner(_draggedContainer);
+            AddAdorner(_draggedContainer);
 
             _captured = true;
         }
@@ -295,7 +303,7 @@ public class GridDragBehavior : StyledElementBehavior<Control>
         {
             if (_parent is not null && _draggedContainer is not null)
             {
-                // RemoveAdorner(_draggedContainer);
+                RemoveAdorner(_draggedContainer);
             }
 
             if (_draggedContainer is not null)


### PR DESCRIPTION
## Summary
- add `DragPreviewAdorner` for displaying drag previews
- support `DragPreviewTemplate` attached property in `ContextDragBehaviorBase`
- show drag preview during `CanvasDragBehavior` and `GridDragBehavior`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38ca2d888321ab718c1ac1291bd9