### PR TITLE
Enable custom DataFormat for drag and drop

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -21,6 +21,21 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
     private bool _captured;
 
     /// <summary>
+    /// Identifies the <see cref="DataFormat"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string> DataFormatProperty =
+        AvaloniaProperty.Register<ContextDragBehaviorBase, string>(nameof(DataFormat), nameof(Context));
+
+    /// <summary>
+    /// Gets or sets the data format used for drag operations.
+    /// </summary>
+    public string DataFormat
+    {
+        get => GetValue(DataFormatProperty);
+        set => SetValue(DataFormatProperty, value);
+    }
+
+    /// <summary>
     /// Identifies the <see cref="Context"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<object?> ContextProperty =
@@ -102,7 +117,7 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value)
     {
         var data = new DataObject();
-        data.Set(ContextDropBehaviorBase.DataFormat, value!);
+        data.Set(DataFormat, value!);
 
         var effect = DragDropEffects.None;
 

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
@@ -21,6 +21,21 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     private bool _captured;
 
     /// <summary>
+    /// Identifies the <see cref="DataFormat"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string> DataFormatProperty =
+        AvaloniaProperty.Register<ContextDragWithDirectionBehavior, string>(nameof(DataFormat), nameof(Context));
+
+    /// <summary>
+    /// Gets or sets the data format used for drag operations.
+    /// </summary>
+    public string DataFormat
+    {
+        get => GetValue(DataFormatProperty);
+        set => SetValue(DataFormatProperty, value);
+    }
+
+    /// <summary>
     /// Identifies the <see cref="Context"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<object?> ContextProperty =
@@ -105,7 +120,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string direction)
     {
         var data = new DataObject();
-        data.Set(ContextDropBehavior.DataFormat, value!);
+        data.Set(DataFormat, value!);
         data.Set("direction", direction);
 
         var effect = DragDropEffects.None;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDropBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDropBehaviorBase.cs
@@ -13,9 +13,19 @@ namespace Avalonia.Xaml.Interactions.DragAndDrop;
 public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
 {
     /// <summary>
-    /// Identifies the data format used to store context information.
+    /// Identifies the <see cref="DataFormat"/> avalonia property.
     /// </summary>
-    public static string DataFormat = nameof(Context);
+    public static readonly StyledProperty<string> DataFormatProperty =
+        AvaloniaProperty.Register<ContextDropBehaviorBase, string>(nameof(DataFormat), nameof(Context));
+
+    /// <summary>
+    /// Gets or sets the data format used to store context information.
+    /// </summary>
+    public string DataFormat
+    {
+        get => GetValue(DataFormatProperty);
+        set => SetValue(DataFormatProperty, value);
+    }
 
     /// <summary>
     /// Identifies the <see cref="Context"/> avalonia property.
@@ -94,8 +104,8 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
 
     private void DragEnter(object? sender, DragEventArgs e)
     {
-        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat) 
-            ? e.Data.Get(ContextDropBehavior.DataFormat) 
+        var sourceContext = e.Data.Contains(DataFormat)
+            ? e.Data.Get(DataFormat)
             : null;
         var targetContext = Context ?? AssociatedObject?.DataContext;
         OnEnter(sender, e, sourceContext, targetContext);
@@ -108,8 +118,8 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
 
     private void DragOver(object? sender, DragEventArgs e)
     {
-        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat) 
-            ? e.Data.Get(ContextDropBehavior.DataFormat) 
+        var sourceContext = e.Data.Contains(DataFormat)
+            ? e.Data.Get(DataFormat)
             : null;
         var targetContext = Context ?? AssociatedObject?.DataContext;
         OnOver(sender, e, sourceContext, targetContext);
@@ -117,8 +127,8 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
 
     private void Drop(object? sender, DragEventArgs e)
     {
-        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat) 
-            ? e.Data.Get(ContextDropBehavior.DataFormat) 
+        var sourceContext = e.Data.Contains(DataFormat)
+            ? e.Data.Get(DataFormat)
             : null;
         var targetContext = Context ?? AssociatedObject?.DataContext;
         OnDrop(sender, e, sourceContext, targetContext);

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/PanelDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/PanelDropBehavior.cs
@@ -16,19 +16,24 @@ public sealed class PanelDropBehavior : DropBehaviorBase
     public PanelDropBehavior()
     {
         PassEventArgsToCommand = true;
-        Handler = new PanelDropHandler(ExecuteCommand);
+        Handler = new PanelDropHandler(this, ExecuteCommand);
     }
 
-    private sealed class PanelDropHandler(System.Action<object?> execute) : DropHandlerBase
+    /// <summary>
+    /// Gets or sets the data format used for drag operations.
+    /// </summary>
+    public string DataFormat { get; set; } = "Context";
+
+    private sealed class PanelDropHandler(PanelDropBehavior owner, System.Action<object?> execute) : DropHandlerBase
     {
         public override bool Validate(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
-            return e.Data.Contains(ContextDropBehavior.DataFormat) && e.Data.Get(ContextDropBehavior.DataFormat) is Control && sender is Panel;
+            return e.Data.Contains(owner.DataFormat) && e.Data.Get(owner.DataFormat) is Control && sender is Panel;
         }
 
         public override bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
-            if (sender is not Panel target || e.Data.Get(ContextDropBehavior.DataFormat) is not Control control)
+            if (sender is not Panel target || e.Data.Get(owner.DataFormat) is not Control control)
             {
                 return false;
             }

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
@@ -20,6 +20,21 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
     private bool _lock;
 
     /// <summary>
+    /// Identifies the <see cref="DataFormat"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string> DataFormatProperty =
+        AvaloniaProperty.Register<TypedDragBehaviorBase, string>(nameof(DataFormat), "Context");
+
+    /// <summary>
+    /// Gets or sets the data format used for drag operations.
+    /// </summary>
+    public string DataFormat
+    {
+        get => GetValue(DataFormatProperty);
+        set => SetValue(DataFormatProperty, value);
+    }
+
+    /// <summary>
     /// Identifies the <see cref="DataType"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<Type?> DataTypeProperty =
@@ -69,7 +84,7 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value)
     {
         var data = new DataObject();
-        data.Set(ContextDropBehaviorBase.DataFormat, value!);
+        data.Set(DataFormat, value!);
 
         var effect = DragDropEffects.None;
 


### PR DESCRIPTION
## Summary
- add `DataFormat` properties to drag behaviours
- respect `DataFormat` in drop handlers
- allow `PanelDropBehavior` to configure the data format

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687b38c94bc083219eefe722f0dffec8