### PR TITLE
Fix loop termination in DataGrid drop handler

### DIFF
--- a/samples/BehaviorsTestApplication/Behaviors/BaseDataGridDropHandler.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/BaseDataGridDropHandler.cs
@@ -106,7 +106,7 @@ public abstract class BaseDataGridDropHandler<T> : DropHandlerBase
         int maxDepth = 16;
         DataGridRow? row = null;
         StyledElement? current = sourceChild;
-        while (maxDepth --> 0 || row is null)
+        while (maxDepth-- > 0 && row is null)
         {
             if (current is DataGridRow dgr)
                 row = dgr;

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/BaseDataGridDropHandlerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/BaseDataGridDropHandlerTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+using Avalonia.Headless.XUnit;
+using Xunit;
+using BehaviorsTestApplication.Behaviors;
+using BehaviorsTestApplication.ViewModels;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class BaseDataGridDropHandlerTests
+{
+    [AvaloniaFact]
+    public void FindDataGridRowFromChildView_Returns_Null_For_Unrelated_Control()
+    {
+        // Arrange: create an element hierarchy simulating a disabled row
+        var container = new Border { IsEnabled = false };
+        var child = new Button();
+        container.Child = child;
+
+        // Use reflection to access the private method
+        var handlerType = typeof(BaseDataGridDropHandler<DragItemViewModel>);
+        var method = handlerType.GetMethod("FindDataGridRowFromChildView", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        // Act
+        var result = method!.Invoke(null, new object[] { child });
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\src\Xaml.Behaviors.Interactions.Events\Xaml.Behaviors.Interactions.Events.csproj" />
     <ProjectReference Include="..\..\src\Xaml.Behaviors.Interactions.Responsive\Xaml.Behaviors.Interactions.Responsive.csproj" />
     <ProjectReference Include="..\..\src\Xaml.Behaviors.Interactivity\Xaml.Behaviors.Interactivity.csproj" />
+    <ProjectReference Include="..\..\samples\BehaviorsTestApplication\BehaviorsTestApplication.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- fix infinite loop in `FindDataGridRowFromChildView`
- add regression test for DataGrid drop handler logic
- reference sample app from test project so the reflection call can reach the helper

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687caa7d8ff4832183bb72d0741c26cf