### PR TITLE
Update ItemDragBehavior pointer capture

### DIFF
--- a/samples/BehaviorsTestApplication/Views/Pages/MouseDragBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/MouseDragBehaviorView.axaml
@@ -6,18 +6,23 @@
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
   <StackPanel Margin="5" Spacing="12">
     <TextBlock Text="MouseDragElementBehavior" HorizontalAlignment="Center"/>
-    <Canvas Width="300" Height="120" Background="LightGray">
-      <Rectangle Fill="Red" Width="40" Height="40" Canvas.Left="20" Canvas.Top="20">
-        <Interaction.Behaviors>
-          <MouseDragElementBehavior ConstrainToParentBounds="True" />
-        </Interaction.Behaviors>
-      </Rectangle>
-      <Rectangle Fill="Green" Width="40" Height="40" Canvas.Left="120" Canvas.Top="20">
-        <Interaction.Behaviors>
-          <MouseDragElementBehavior ConstrainToParentBounds="True" />
-        </Interaction.Behaviors>
-      </Rectangle>
-    </Canvas>
+      <Canvas Width="300" Height="120" Background="LightGray">
+        <Rectangle Fill="Red" Width="40" Height="40" Canvas.Left="20" Canvas.Top="20">
+          <Interaction.Behaviors>
+            <MouseDragElementBehavior ConstrainToParentBounds="True" />
+          </Interaction.Behaviors>
+        </Rectangle>
+        <Rectangle Fill="Green" Width="40" Height="40" Canvas.Left="120" Canvas.Top="20">
+          <Interaction.Behaviors>
+            <MouseDragElementBehavior ConstrainToParentBounds="True" />
+          </Interaction.Behaviors>
+        </Rectangle>
+        <Rectangle Fill="Blue" Width="40" Height="40" Canvas.Left="220" Canvas.Top="20">
+          <Interaction.Behaviors>
+            <MouseDragElementBehavior ConstrainToParentBounds="True" />
+          </Interaction.Behaviors>
+        </Rectangle>
+      </Canvas>
 
     <TextBlock Text="MultiMouseDragElementBehavior" HorizontalAlignment="Center"/>
     <Canvas Width="300" Height="120" Background="LightGray">

--- a/src/Xaml.Behaviors.Interactions.Draggable/ItemDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/ItemDragBehavior.cs
@@ -117,6 +117,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
             AddTransforms(_itemsControl);
 
             _captured = true;
+            e.Pointer.Capture(AssociatedObject);
         }
     }
 
@@ -129,6 +130,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
                 Released();
             }
 
+            e.Pointer.Capture(null);
             _captured = false;
         }
     }
@@ -136,6 +138,7 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
     private void PointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
         Released();
+        e.Pointer.Capture(null);
         _captured = false;
     }
 


### PR DESCRIPTION
## Summary
- capture pointer for ItemDragBehavior and release it on pointer release or loss
- expand MouseDragBehavior sample with an extra draggable rectangle

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687caa7e64288321a6336269cc97f8f9