### PR TITLE
Fix drag source constant and allow dropping in samples

### DIFF
--- a/samples/BehaviorsTestApplication/Views/Pages/DragAndDropView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/DragAndDropView.axaml
@@ -195,6 +195,7 @@
         <TreeView ItemsSource="{Binding Nodes}"
                   Classes="NodesDragAndDrop"
                   SelectedItems="{Binding SelectedTreeNodes, Mode=TwoWay}"
+                  AllowDrop="True"
                   Grid.Column="0">
           <TreeView.ItemTemplate>
             <TreeDataTemplate DataType="vm:DragNodeViewModel" ItemsSource="{Binding Nodes}">
@@ -205,6 +206,7 @@
         <GridSplitter Width="8" ResizeDirection="Columns" ResizeBehavior="PreviousAndNext" Background="Transparent" Grid.Column="1"/>
         <ListBox ItemsSource="{Binding Nodes}"
                  Classes="NodesDragAndDrop"
+                 AllowDrop="True"
                  Grid.Column="2">
           <ListBox.ItemTemplate>
             <DataTemplate DataType="vm:DragNodeViewModel">
@@ -217,7 +219,8 @@
 
     <TabItem Header="ListBox">
       <ListBox ItemsSource="{Binding Items}"
-               Classes="ItemsDragAndDrop">
+               Classes="ItemsDragAndDrop"
+               AllowDrop="True">
         <ListBox.ItemTemplate>
           <DataTemplate DataType="vm:DragItemViewModel">
             <TextBlock Text="{Binding Title}" />
@@ -233,7 +236,8 @@
           ItemsSource="{Binding Items}"
           CanUserResizeColumns="True"
           HeadersVisibility="All"
-          Classes="DragAndDrop ItemsDragAndDrop">
+          Classes="DragAndDrop ItemsDragAndDrop"
+          AllowDrop="True">
           <DataGrid.Columns>
             <DataGridTextColumn
               Width="*"

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
@@ -105,7 +105,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string direction)
     {
         var data = new DataObject();
-        data.Set(ContextDropBehavior.DataFormat, value!);
+        data.Set(ContextDropBehaviorBase.DataFormat, value!);
         data.Set("direction", direction);
 
         var effect = DragDropEffects.None;


### PR DESCRIPTION
## Summary
- ensure drag-with-direction behavior uses the base DataFormat constant
- enable AllowDrop on sample drag/drop controls for clarity

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687caa7ef84c832199d35c3f893ea36c