### PR TITLE
Fix Drag and Drop by handling already handled events

### DIFF
--- a/src/Xaml.Behaviors.Interactions.Custom/ItemsControl/ItemNudgeDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/ItemsControl/ItemNudgeDropBehavior.cs
@@ -33,9 +33,9 @@ public class ItemNudgeDropBehavior : StyledElementBehavior<ItemsControl>
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, OnDragLeave);
-        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, OnDragOver);
-        AssociatedObject?.AddHandler(DragDrop.DropEvent, OnDrop);
+        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, OnDragLeave, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, OnDragOver, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DropEvent, OnDrop, RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -68,11 +68,11 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.KeyDownEvent, AssociatedObject_KeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(InputElement.KeyDownEvent, AssociatedObject_KeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
@@ -84,13 +84,13 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
     protected override void OnAttachedToVisualTree()
     {
         AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed,
-            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
         AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased,
-            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
         AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved,
-            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
         AssociatedObject?.AddHandler(InputElement.PointerCaptureLostEvent, AssociatedObject_CaptureLost,
-            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDropBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDropBehaviorBase.cs
@@ -39,10 +39,10 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
         {
             DragDrop.SetAllowDrop(AssociatedObject, true);
         }
-        AssociatedObject?.AddHandler(DragDrop.DragEnterEvent, DragEnter);
-        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, DragLeave);
-        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, DragOver);
-        AssociatedObject?.AddHandler(DragDrop.DropEvent, Drop);
+        AssociatedObject?.AddHandler(DragDrop.DragEnterEvent, DragEnter, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, DragLeave, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, DragOver, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DropEvent, Drop, RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DragAndDropEventsBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DragAndDropEventsBehavior.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.DragAndDrop;
@@ -42,10 +43,10 @@ public abstract class DragAndDropEventsBehavior : StyledElementBehavior<Control>
     private void AttachEvents(Control targetControl)
     {
         DragDrop.SetAllowDrop(targetControl, true);
-        targetControl.AddHandler(DragDrop.DragEnterEvent, DragEnter);
-        targetControl.AddHandler(DragDrop.DragLeaveEvent, DragLeave);
-        targetControl.AddHandler(DragDrop.DragOverEvent, DragOver);
-        targetControl.AddHandler(DragDrop.DropEvent, Drop);
+        targetControl.AddHandler(DragDrop.DragEnterEvent, DragEnter, RoutingStrategies.Bubble, true);
+        targetControl.AddHandler(DragDrop.DragLeaveEvent, DragLeave, RoutingStrategies.Bubble, true);
+        targetControl.AddHandler(DragDrop.DragOverEvent, DragOver, RoutingStrategies.Bubble, true);
+        targetControl.AddHandler(DragDrop.DropEvent, Drop, RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DropBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DropBehaviorBase.cs
@@ -23,10 +23,10 @@ public abstract class DropBehaviorBase : InvokeCommandBehaviorBase
         {
             DragDrop.SetAllowDrop(AssociatedObject, true);
         }
-        AssociatedObject?.AddHandler(DragDrop.DragEnterEvent, DragEnter);
-        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, DragLeave);
-        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, DragOver);
-        AssociatedObject?.AddHandler(DragDrop.DropEvent, Drop);
+        AssociatedObject?.AddHandler(DragDrop.DragEnterEvent, DragEnter, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, DragLeave, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, DragOver, RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(DragDrop.DropEvent, Drop, RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
@@ -37,9 +37,9 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
-        AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        AssociatedObject?.AddHandler(InputElement.PointerPressedEvent, AssociatedObject_PointerPressed, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(InputElement.PointerReleasedEvent, AssociatedObject_PointerReleased, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
+        AssociatedObject?.AddHandler(InputElement.PointerMovedEvent, AssociatedObject_PointerMoved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.Draggable/AutoScrollDuringDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/AutoScrollDuringDragBehavior.cs
@@ -52,10 +52,10 @@ public class AutoScrollDuringDragBehavior : StyledElementBehavior<ScrollViewer>
 
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/CanvasDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/CanvasDragBehavior.cs
@@ -25,10 +25,10 @@ public class CanvasDragBehavior : StyledElementBehavior<Control>
     {
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/GridDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/GridDragBehavior.cs
@@ -84,10 +84,10 @@ public class GridDragBehavior : StyledElementBehavior<Control>
     {
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/ItemDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/ItemDragBehavior.cs
@@ -76,10 +76,10 @@ public class ItemDragBehavior : StyledElementBehavior<Control>
     {
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, PointerReleased, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, PointerPressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, PointerMoved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, PointerCaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, PointerReleased, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, PointerPressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, PointerMoved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, PointerCaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/ListReorderDragBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/ListReorderDragBehavior.cs
@@ -50,10 +50,10 @@ public class ListReorderDragBehavior : ItemDragBehavior
         base.OnAttachedToVisualTree();
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, OnPointerMoved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, OnPointerMoved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/MouseDragElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/MouseDragElementBehavior.cs
@@ -39,10 +39,10 @@ public class MouseDragElementBehavior : StyledElementBehavior<Control>
     {
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Draggable/MultiMouseDragElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Draggable/MultiMouseDragElementBehavior.cs
@@ -55,10 +55,10 @@ public class MultiMouseDragElementBehavior : StyledElementBehavior<Control>
     {
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel);
-            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Tunnel, true);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, CaptureLost, RoutingStrategies.Tunnel, true);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactions.Events/DragEnterEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Events/DragEnterEventTrigger.cs
@@ -13,7 +13,7 @@ public sealed class DragEnterEventTrigger : InteractiveTriggerBase
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(DragDrop.DragEnterEvent, OnDragEnter, RoutingStrategies);
+        AssociatedObject?.AddHandler(DragDrop.DragEnterEvent, OnDragEnter, RoutingStrategies, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.Events/DragLeaveEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Events/DragLeaveEventTrigger.cs
@@ -14,7 +14,7 @@ public sealed class DragLeaveEventTrigger : InteractiveTriggerBase
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, OnDragLeave, RoutingStrategies);
+        AssociatedObject?.AddHandler(DragDrop.DragLeaveEvent, OnDragLeave, RoutingStrategies, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.Events/DragOverEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Events/DragOverEventTrigger.cs
@@ -13,7 +13,7 @@ public sealed class DragOverEventTrigger : InteractiveTriggerBase
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, OnDragOver, RoutingStrategies);
+        AssociatedObject?.AddHandler(DragDrop.DragOverEvent, OnDragOver, RoutingStrategies, true);
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.Events/DropEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Events/DropEventTrigger.cs
@@ -13,7 +13,7 @@ public sealed class DropEventTrigger : InteractiveTriggerBase
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
-        AssociatedObject?.AddHandler(DragDrop.DropEvent, OnDrop, RoutingStrategies);
+        AssociatedObject?.AddHandler(DragDrop.DropEvent, OnDrop, RoutingStrategies, true);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- register pointer and drag handlers with `handledEventsToo: true` so drag/drop works on controls like `ListBox`, `TreeView` and `DataGrid`
- update `DragAndDropEventsBehavior` using directive for `Avalonia.Interactivity`

## Testing
- `dotnet test AvaloniaBehaviors.sln --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687f7916110c832181a0f6fe2ed0c3a0