### PR TITLE
Add composition animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,22 @@ This section provides an overview of all available classes and their purpose in 
 
 - **SlidingAnimation** ([Sample](samples/BehaviorsTestApplication/Views/Pages/SlidingAnimationView.axaml))
   *Provides static methods to apply sliding animations (from left, right, top, or bottom) to a control.*
+- **FadeAnimation** ([Sample](samples/BehaviorsTestApplication/Views/Pages/FadeAnimationView.axaml))
+  *Adds composition-driven fade-in, fade-out, and custom opacity transitions.*
+- **ScaleAnimation** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ScaleAnimationView.axaml))
+  *Provides scale, zoom, and bounce helpers implemented with composition animations.*
+- **RotateAnimation** ([Sample](samples/BehaviorsTestApplication/Views/Pages/RotateAnimationView.axaml))
+  *Offers rotation-based composition animations including swing and flip effects.*
+- **EntranceAnimations** ([Sample](samples/BehaviorsTestApplication/Views/Pages/EntranceAnimationsView.axaml))
+  *Ready-to-use fade/slide/zoom entrance animations inspired by CSS motion libraries.*
+- **AttentionAnimations** ([Sample](samples/BehaviorsTestApplication/Views/Pages/AttentionAnimationsView.axaml))
+  *Pulse, shake, flash, and tada animations that mirror common web attention patterns.*
+- **SpecialAnimations** ([Sample](samples/BehaviorsTestApplication/Views/Pages/SpecialAnimationsView.axaml))
+  *House bespoke effects such as the animate.css `flip` approximation implemented via composition helpers.*
+- **ExitAnimations** ([Sample](samples/BehaviorsTestApplication/Views/Pages/ExitAnimationsView.axaml))
+  *Animate.css-inspired exits (back, bounce, fade, rotate, slide, zoom, hinge, roll) built with composition.*
+- **FramerMotionAnimations** ([Sample](samples/BehaviorsTestApplication/Views/Pages/FramerMotionAnimationsView.axaml))
+  *Framer Motion style fade, slide, pop, spring, rotate, and scale presets expressed with composition APIs.*
 - **FluidMoveBehavior** ([Sample](samples/BehaviorsTestApplication/Views/Pages/FluidMoveBehaviorView.axaml))
   *Animates layout changes of a control or its children.*
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -213,6 +213,30 @@
       <TabItem Header="Sliding Animation">
         <pages:SlidingAnimationView />
       </TabItem>
+      <TabItem Header="Fade Animation">
+        <pages:FadeAnimationView />
+      </TabItem>
+      <TabItem Header="Scale Animation">
+        <pages:ScaleAnimationView />
+      </TabItem>
+      <TabItem Header="Rotate Animation">
+        <pages:RotateAnimationView />
+      </TabItem>
+      <TabItem Header="Entrance Animations">
+        <pages:EntranceAnimationsView />
+      </TabItem>
+      <TabItem Header="Attention Animations">
+        <pages:AttentionAnimationsView />
+      </TabItem>
+      <TabItem Header="Exit Animations">
+        <pages:ExitAnimationsView />
+      </TabItem>
+      <TabItem Header="Framer Motion Animations">
+        <pages:FramerMotionAnimationsView />
+      </TabItem>
+      <TabItem Header="Special Animations">
+        <pages:SpecialAnimationsView />
+      </TabItem>
       <TabItem Header="Animation Behaviors">
         <pages:AnimationBehaviorView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/AttentionAnimationsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttentionAnimationsView.axaml
@@ -1,0 +1,106 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
+             x:Class="BehaviorsTestApplication.Views.Pages.AttentionAnimationsView">
+  <TabControl>
+    <TabItem Header="Bounce">
+      <Border Margin="12" Width="220" Height="150" Background="#FFE6F2" CornerRadius="12" custom:AttentionAnimations.Bounce="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Bounce" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Y-offset bounce inspired by animate.css" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Flash">
+      <Border Margin="12" Width="220" Height="150" Background="#ECEFF1" CornerRadius="12" custom:AttentionAnimations.Flash="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Flash" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Opacity pulses" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Pulse">
+      <Border Margin="12" Width="220" Height="150" Background="#E8F4FF" CornerRadius="12" custom:AttentionAnimations.Pulse="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Pulse" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Subtle scale pulse" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="RubberBand">
+      <Border Margin="12" Width="220" Height="150" Background="#FFF3E0" CornerRadius="12" custom:AttentionAnimations.RubberBand="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="RubberBand" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Axis-stretch rubber band" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Shake X">
+      <Border Margin="12" Width="220" Height="150" Background="#F1F8E9" CornerRadius="12" custom:AttentionAnimations.ShakeX="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Shake X" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Horizontal validation shake" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Shake Y">
+      <Border Margin="12" Width="220" Height="150" Background="#FFF9C4" CornerRadius="12" custom:AttentionAnimations.ShakeY="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Shake Y" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Vertical bounce" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Head Shake">
+      <Border Margin="12" Width="220" Height="150" Background="#EDE7F6" CornerRadius="12" custom:AttentionAnimations.HeadShake="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Head Shake" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Rotation plus offset" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Swing">
+      <Border Margin="12" Width="220" Height="150" Background="#FFE0B2" CornerRadius="12" custom:AttentionAnimations.Swing="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Swing" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Top-anchored pendulum" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Tada">
+      <Border Margin="12" Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:AttentionAnimations.Tada="1100">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Tada" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Celebrate with spin" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Wobble">
+      <Border Margin="12" Width="220" Height="150" Background="#DCEDC8" CornerRadius="12" custom:AttentionAnimations.Wobble="1100">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Wobble" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Translation + rotation wobble" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Jello">
+      <Border Margin="12" Width="220" Height="150" Background="#F8BBD0" CornerRadius="12" custom:AttentionAnimations.Jello="1100">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Jello" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Squishy scale effect" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Heart Beat">
+      <Border Margin="12" Width="220" Height="150" Background="#FFCDD2" CornerRadius="12" custom:AttentionAnimations.HeartBeat="1200">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Heart Beat" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Pulse twice like a heartbeat" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/AttentionAnimationsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/AttentionAnimationsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class AttentionAnimationsView : UserControl
+{
+    public AttentionAnimationsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/EntranceAnimationsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/EntranceAnimationsView.axaml
@@ -1,0 +1,187 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
+             x:Class="BehaviorsTestApplication.Views.Pages.EntranceAnimationsView">
+  <TabControl>
+    <TabItem Header="Back">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:EntranceAnimations.BackInDown="900">
+            <TextBlock Text="Back In Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:EntranceAnimations.BackInUp="900">
+            <TextBlock Text="Back In Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:EntranceAnimations.BackInLeft="900">
+            <TextBlock Text="Back In Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:EntranceAnimations.BackInRight="900">
+            <TextBlock Text="Back In Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Bounce">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:EntranceAnimations.BounceIn="900">
+            <TextBlock Text="Bounce In" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:EntranceAnimations.BounceInDown="900">
+            <TextBlock Text="Bounce In Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:EntranceAnimations.BounceInUp="900">
+            <TextBlock Text="Bounce In Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:EntranceAnimations.BounceInLeft="900">
+            <TextBlock Text="Bounce In Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:EntranceAnimations.BounceInRight="900">
+            <TextBlock Text="Bounce In Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Fade">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeIn="900">
+            <TextBlock Text="Fade In" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInDown="900">
+            <TextBlock Text="Fade In Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInDownBig="900">
+            <TextBlock Text="Fade In Down Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInUp="900">
+            <TextBlock Text="Fade In Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInUpBig="900">
+            <TextBlock Text="Fade In Up Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInLeft="900">
+            <TextBlock Text="Fade In Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInLeftBig="900">
+            <TextBlock Text="Fade In Left Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInRight="900">
+            <TextBlock Text="Fade In Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInRightBig="900">
+            <TextBlock Text="Fade In Right Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInTopLeft="900">
+            <TextBlock Text="Fade In Top Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInTopRight="900">
+            <TextBlock Text="Fade In Top Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInBottomLeft="900">
+            <TextBlock Text="Fade In Bottom Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:EntranceAnimations.FadeInBottomRight="900">
+            <TextBlock Text="Fade In Bottom Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Flip &amp; LightSpeed">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#FCE4EC" CornerRadius="12" custom:EntranceAnimations.FlipInX="1000">
+            <TextBlock Text="Flip In X" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FCE4EC" CornerRadius="12" custom:EntranceAnimations.FlipInY="1000">
+            <TextBlock Text="Flip In Y" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFECB3" CornerRadius="12" custom:EntranceAnimations.LightSpeedInLeft="900">
+            <TextBlock Text="Light Speed In Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFECB3" CornerRadius="12" custom:EntranceAnimations.LightSpeedInRight="900">
+            <TextBlock Text="Light Speed In Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Rotate">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:EntranceAnimations.RotateIn="900">
+            <TextBlock Text="Rotate In" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:EntranceAnimations.RotateInDownLeft="900">
+            <TextBlock Text="Rotate In Down Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:EntranceAnimations.RotateInDownRight="900">
+            <TextBlock Text="Rotate In Down Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:EntranceAnimations.RotateInUpLeft="900">
+            <TextBlock Text="Rotate In Up Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:EntranceAnimations.RotateInUpRight="900">
+            <TextBlock Text="Rotate In Up Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Slide">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:EntranceAnimations.SlideInDown="900">
+            <TextBlock Text="Slide In Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:EntranceAnimations.SlideInUp="900">
+            <TextBlock Text="Slide In Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:EntranceAnimations.SlideInLeft="900">
+            <TextBlock Text="Slide In Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:EntranceAnimations.SlideInRight="900">
+            <TextBlock Text="Slide In Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Zoom">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:EntranceAnimations.ZoomIn="900">
+            <TextBlock Text="Zoom In" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:EntranceAnimations.ZoomInDown="900">
+            <TextBlock Text="Zoom In Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:EntranceAnimations.ZoomInUp="900">
+            <TextBlock Text="Zoom In Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:EntranceAnimations.ZoomInLeft="900">
+            <TextBlock Text="Zoom In Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:EntranceAnimations.ZoomInRight="900">
+            <TextBlock Text="Zoom In Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Special">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#F3E5F5" CornerRadius="12" custom:EntranceAnimations.FadeInZoom="900">
+            <TextBlock Text="Fade In Zoom" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#F3E5F5" CornerRadius="12" custom:EntranceAnimations.JackInTheBox="1100">
+            <TextBlock Text="Jack In The Box" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#F3E5F5" CornerRadius="12" custom:EntranceAnimations.RollIn="900">
+            <TextBlock Text="Roll In" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/EntranceAnimationsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/EntranceAnimationsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class EntranceAnimationsView : UserControl
+{
+    public EntranceAnimationsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ExitAnimationsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ExitAnimationsView.axaml
@@ -1,0 +1,184 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
+             x:Class="BehaviorsTestApplication.Views.Pages.ExitAnimationsView">
+  <TabControl>
+    <TabItem Header="Back">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:ExitAnimations.BackOutDown="900">
+            <TextBlock Text="Back Out Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:ExitAnimations.BackOutUp="900">
+            <TextBlock Text="Back Out Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:ExitAnimations.BackOutLeft="900">
+            <TextBlock Text="Back Out Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E8F5E9" CornerRadius="12" custom:ExitAnimations.BackOutRight="900">
+            <TextBlock Text="Back Out Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Bounce">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:ExitAnimations.BounceOut="900">
+            <TextBlock Text="Bounce Out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:ExitAnimations.BounceOutDown="900">
+            <TextBlock Text="Bounce Out Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:ExitAnimations.BounceOutUp="900">
+            <TextBlock Text="Bounce Out Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:ExitAnimations.BounceOutLeft="900">
+            <TextBlock Text="Bounce Out Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFF8E1" CornerRadius="12" custom:ExitAnimations.BounceOutRight="900">
+            <TextBlock Text="Bounce Out Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Fade">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOut="900">
+            <TextBlock Text="Fade Out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutDown="900">
+            <TextBlock Text="Fade Out Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutDownBig="900">
+            <TextBlock Text="Fade Out Down Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutUp="900">
+            <TextBlock Text="Fade Out Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutUpBig="900">
+            <TextBlock Text="Fade Out Up Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutLeft="900">
+            <TextBlock Text="Fade Out Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutLeftBig="900">
+            <TextBlock Text="Fade Out Left Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutRight="900">
+            <TextBlock Text="Fade Out Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutRightBig="900">
+            <TextBlock Text="Fade Out Right Big" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutTopLeft="900">
+            <TextBlock Text="Fade Out Top Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutTopRight="900">
+            <TextBlock Text="Fade Out Top Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutBottomLeft="900">
+            <TextBlock Text="Fade Out Bottom Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+          <Border Width="200" Height="140" Background="#E1F5FE" CornerRadius="12" custom:ExitAnimations.FadeOutBottomRight="900">
+            <TextBlock Text="Fade Out Bottom Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="16" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Flip &amp; LightSpeed">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#FCE4EC" CornerRadius="12" custom:ExitAnimations.FlipOutX="900">
+            <TextBlock Text="Flip Out X" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FCE4EC" CornerRadius="12" custom:ExitAnimations.FlipOutY="900">
+            <TextBlock Text="Flip Out Y" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFECB3" CornerRadius="12" custom:ExitAnimations.LightSpeedOutLeft="900">
+            <TextBlock Text="Light Speed Out Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFECB3" CornerRadius="12" custom:ExitAnimations.LightSpeedOutRight="900">
+            <TextBlock Text="Light Speed Out Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Rotate">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:ExitAnimations.RotateOut="900">
+            <TextBlock Text="Rotate Out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:ExitAnimations.RotateOutDownLeft="900">
+            <TextBlock Text="Rotate Out Down Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:ExitAnimations.RotateOutDownRight="900">
+            <TextBlock Text="Rotate Out Down Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:ExitAnimations.RotateOutUpLeft="900">
+            <TextBlock Text="Rotate Out Up Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#D1C4E9" CornerRadius="12" custom:ExitAnimations.RotateOutUpRight="900">
+            <TextBlock Text="Rotate Out Up Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Slide">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:ExitAnimations.SlideOutDown="900">
+            <TextBlock Text="Slide Out Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:ExitAnimations.SlideOutUp="900">
+            <TextBlock Text="Slide Out Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:ExitAnimations.SlideOutLeft="900">
+            <TextBlock Text="Slide Out Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#FFCCBC" CornerRadius="12" custom:ExitAnimations.SlideOutRight="900">
+            <TextBlock Text="Slide Out Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Zoom">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:ExitAnimations.ZoomOut="900">
+            <TextBlock Text="Zoom Out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:ExitAnimations.ZoomOutDown="900">
+            <TextBlock Text="Zoom Out Down" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:ExitAnimations.ZoomOutUp="900">
+            <TextBlock Text="Zoom Out Up" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:ExitAnimations.ZoomOutLeft="900">
+            <TextBlock Text="Zoom Out Left" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:ExitAnimations.ZoomOutRight="900">
+            <TextBlock Text="Zoom Out Right" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+    <TabItem Header="Special">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <WrapPanel Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+          <Border Width="220" Height="150" Background="#F3E5F5" CornerRadius="12" custom:ExitAnimations.Hinge="1200">
+            <TextBlock Text="Hinge" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+          <Border Width="220" Height="150" Background="#F3E5F5" CornerRadius="12" custom:ExitAnimations.RollOut="900">
+            <TextBlock Text="Roll Out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18" />
+          </Border>
+        </WrapPanel>
+      </ScrollViewer>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ExitAnimationsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ExitAnimationsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ExitAnimationsView : UserControl
+{
+    public ExitAnimationsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/FadeAnimationView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FadeAnimationView.axaml
@@ -1,0 +1,38 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="BehaviorsTestApplication.Views.Pages.FadeAnimationView">
+  <TabControl>
+    <TabItem Header="Fade In">
+      <Panel ClipToBounds="True">
+        <Border Name="Border1"
+                Background="LightBlue"
+                custom:FadeAnimation.FadeIn="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Fade Out">
+      <Panel ClipToBounds="True">
+        <Border Name="Border2"
+                Background="LightGreen"
+                custom:FadeAnimation.FadeOut="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FadeAnimationView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FadeAnimationView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FadeAnimationView : UserControl
+{
+    public FadeAnimationView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/FramerMotionAnimationsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/FramerMotionAnimationsView.axaml
@@ -1,0 +1,146 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
+             x:Class="BehaviorsTestApplication.Views.Pages.FramerMotionAnimationsView">
+  <TabControl>
+    <TabItem Header="Fade In">
+      <Border Margin="12" Width="220" Height="150" Background="#E3F2FD" CornerRadius="12" custom:FramerMotionAnimations.FadeIn="800">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Fade In" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Default Framer fade" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Fade In Up">
+      <Border Margin="12" Width="220" Height="150" Background="#F1F8E9" CornerRadius="12" custom:FramerMotionAnimations.FadeInUp="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Fade In Up" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Rise with damped spring" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Fade In Down">
+      <Border Margin="12" Width="220" Height="150" Background="#F1F8E9" CornerRadius="12" custom:FramerMotionAnimations.FadeInDown="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Fade In Down" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Drop in from top" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Fade In Left">
+      <Border Margin="12" Width="220" Height="150" Background="#FFF3E0" CornerRadius="12" custom:FramerMotionAnimations.FadeInLeft="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Fade In Left" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Directional fade" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Fade In Right">
+      <Border Margin="12" Width="220" Height="150" Background="#FFF3E0" CornerRadius="12" custom:FramerMotionAnimations.FadeInRight="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Fade In Right" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Directional fade" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Slide In Left">
+      <Border Margin="12" Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:FramerMotionAnimations.SlideInFromLeft="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Slide In Left" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Framer-esque slide" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Slide In Right">
+      <Border Margin="12" Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:FramerMotionAnimations.SlideInFromRight="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Slide In Right" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Framer-esque slide" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Slide In Top">
+      <Border Margin="12" Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:FramerMotionAnimations.SlideInFromTop="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Slide In Top" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Framer slide vertical" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Slide In Bottom">
+      <Border Margin="12" Width="220" Height="150" Background="#E0F2F1" CornerRadius="12" custom:FramerMotionAnimations.SlideInFromBottom="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Slide In Bottom" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Framer slide vertical" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Pop In">
+      <Border Margin="12" Width="220" Height="150" Background="#F8BBD0" CornerRadius="12" custom:FramerMotionAnimations.PopIn="800">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Pop In" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Overshooting scale" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Pop Out">
+      <Border Margin="12" Width="220" Height="150" Background="#F8BBD0" CornerRadius="12" custom:FramerMotionAnimations.PopOut="700">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Pop Out" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Scale &amp; fade" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Spring In">
+      <Border Margin="12" Width="220" Height="150" Background="#C5CAE9" CornerRadius="12" custom:FramerMotionAnimations.SpringIn="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Spring In" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Bouncy translate" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Spring Out">
+      <Border Margin="12" Width="220" Height="150" Background="#C5CAE9" CornerRadius="12" custom:FramerMotionAnimations.SpringOut="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Spring Out" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Exit with overshoot" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Rotate In">
+      <Border Margin="12" Width="220" Height="150" Background="#FFECB3" CornerRadius="12" custom:FramerMotionAnimations.RotateIn="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Rotate In" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Framer rotate entry" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Rotate Out">
+      <Border Margin="12" Width="220" Height="150" Background="#FFECB3" CornerRadius="12" custom:FramerMotionAnimations.RotateOut="900">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Rotate Out" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Framer rotate exit" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Scale In">
+      <Border Margin="12" Width="220" Height="150" Background="#DCEDC8" CornerRadius="12" custom:FramerMotionAnimations.ScaleIn="800">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Scale In" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Ease overshoot scale" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+    <TabItem Header="Scale Out">
+      <Border Margin="12" Width="220" Height="150" Background="#DCEDC8" CornerRadius="12" custom:FramerMotionAnimations.ScaleOut="800">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Scale Out" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Ease scale exit" TextWrapping="Wrap" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/FramerMotionAnimationsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/FramerMotionAnimationsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class FramerMotionAnimationsView : UserControl
+{
+    public FramerMotionAnimationsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/RotateAnimationView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/RotateAnimationView.axaml
@@ -1,0 +1,94 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="BehaviorsTestApplication.Views.Pages.RotateAnimationView">
+  <TabControl>
+    <TabItem Header="Rotate Clockwise">
+      <Panel ClipToBounds="False">
+        <Border Name="Border1"
+                Background="Lavender"
+                custom:RotateAnimation.RotateClockwise="2000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Rotate Counter-Clockwise">
+      <Panel ClipToBounds="False">
+        <Border Name="Border2"
+                Background="Thistle"
+                custom:RotateAnimation.RotateCounterClockwise="2000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Rotate In">
+      <Panel ClipToBounds="False">
+        <Border Name="Border3"
+                Background="PaleGreen"
+                custom:RotateAnimation.RotateIn="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Rotate Out">
+      <Panel ClipToBounds="False">
+        <Border Name="Border4"
+                Background="PaleTurquoise"
+                custom:RotateAnimation.RotateOut="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Flip">
+      <Panel ClipToBounds="False">
+        <Border Name="Border5"
+                Background="PeachPuff"
+                custom:RotateAnimation.Flip="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Swing">
+      <Panel ClipToBounds="False">
+        <Border Name="Border6"
+                Background="MistyRose"
+                custom:RotateAnimation.Swing="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/RotateAnimationView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/RotateAnimationView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class RotateAnimationView : UserControl
+{
+    public RotateAnimationView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/ScaleAnimationView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ScaleAnimationView.axaml
@@ -1,0 +1,80 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="BehaviorsTestApplication.Views.Pages.ScaleAnimationView">
+  <TabControl>
+    <TabItem Header="Scale In">
+      <Panel ClipToBounds="False">
+        <Border Name="Border1"
+                Background="LightCoral"
+                custom:ScaleAnimation.ScaleIn="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Scale Out">
+      <Panel ClipToBounds="False">
+        <Border Name="Border2"
+                Background="LightYellow"
+                custom:ScaleAnimation.ScaleOut="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Zoom In">
+      <Panel ClipToBounds="False">
+        <Border Name="Border3"
+                Background="LightSalmon"
+                custom:ScaleAnimation.ZoomIn="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Zoom Out">
+      <Panel ClipToBounds="False">
+        <Border Name="Border4"
+                Background="LightSeaGreen"
+                custom:ScaleAnimation.ZoomOut="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+    <TabItem Header="Bounce">
+      <Panel ClipToBounds="False">
+        <Border Name="Border5"
+                Background="LightSkyBlue"
+                custom:ScaleAnimation.Bounce="1000">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <CheckBox IsChecked="True" Content="CheckBox" />
+            <TextBlock Text="TextBlock" FontSize="16"/>
+            <TextBox Text="TextBox" Width="200"/>
+          </StackPanel>
+        </Border>
+      </Panel>
+    </TabItem>
+  </TabControl>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ScaleAnimationView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ScaleAnimationView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ScaleAnimationView : UserControl
+{
+    public ScaleAnimationView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/BehaviorsTestApplication/Views/Pages/SpecialAnimationsView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SpecialAnimationsView.axaml
@@ -1,0 +1,23 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="BehaviorsTestApplication.Views.Pages.SpecialAnimationsView">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <TextBlock Text="Special Animations" FontSize="20" Margin="12" />
+    <WrapPanel Grid.Row="1" Margin="12" ItemSpacing="16" HorizontalAlignment="Center">
+      <Border Width="220" Height="160" Background="#FFFDE7" CornerRadius="12" custom:SpecialAnimations.Flip="1000">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
+          <TextBlock Text="Flip" FontSize="18" HorizontalAlignment="Center" />
+          <TextBlock Text="Approximation of animate.css flip" TextWrapping="Wrap" MaxWidth="180" HorizontalAlignment="Center" />
+        </StackPanel>
+      </Border>
+    </WrapPanel>
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/SpecialAnimationsView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/SpecialAnimationsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class SpecialAnimationsView : UserControl
+{
+    public SpecialAnimationsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/AttentionAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/AttentionAnimations.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Numerics;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides attention-drawing animation helpers inspired by popular web animation libraries such as animate.css.
+/// </summary>
+public static class AttentionAnimations
+{
+    /// <summary>
+    /// Applies a bounce animation to the element when loaded.
+    /// </summary>
+    public static void SetBounce(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyBounce);
+
+    /// <summary>
+    /// Applies a flash animation to the element when loaded.
+    /// </summary>
+    public static void SetFlash(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyFlash);
+
+    /// <summary>
+    /// Applies a pulse animation to the element when loaded.
+    /// </summary>
+    public static void SetPulse(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyPulse, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies a rubber band animation to the element when loaded.
+    /// </summary>
+    public static void SetRubberBand(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyRubberBand, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies a horizontal shake animation to the element when loaded.
+    /// </summary>
+    public static void SetShakeX(Control element, double milliseconds) =>
+        Run(element, milliseconds, (ctrl, visual, duration) => ApplyShake(ctrl, visual, duration, horizontal: true));
+
+    /// <summary>
+    /// Applies a vertical shake animation to the element when loaded.
+    /// </summary>
+    public static void SetShakeY(Control element, double milliseconds) =>
+        Run(element, milliseconds, (ctrl, visual, duration) => ApplyShake(ctrl, visual, duration, horizontal: false));
+
+    /// <summary>
+    /// Applies a head shake animation to the element when loaded.
+    /// </summary>
+    public static void SetHeadShake(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyHeadShake, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies a swing animation to the element when loaded.
+    /// </summary>
+    public static void SetSwing(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplySwing, anchor: new Vector2(0.5f, 0f));
+
+    /// <summary>
+    /// Applies a tada animation (scale and rotation) to the element when loaded.
+    /// </summary>
+    public static void SetTada(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyTada, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies a wobble animation to the element when loaded.
+    /// </summary>
+    public static void SetWobble(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyWobble, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies a jello animation to the element when loaded.
+    /// </summary>
+    public static void SetJello(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyJello, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies a heart beat animation to the element when loaded.
+    /// </summary>
+    public static void SetHeartBeat(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyHeartBeat, ensureCenterPoint: true);
+
+    private static void Run(Control element, double milliseconds, Action<Control, CompositionVisual, TimeSpan> animation, bool ensureCenterPoint = false, Vector2? anchor = null)
+    {
+        element.Loaded += (_, _) =>
+        {
+            var visual = ElementComposition.GetElementVisual(element);
+            if (visual is null)
+            {
+                return;
+            }
+
+            if (anchor.HasValue)
+            {
+                CompositionAnimationHelpers.SetNormalizedCenterPoint(element, visual, anchor.Value);
+            }
+            else if (ensureCenterPoint)
+            {
+                CompositionAnimationHelpers.EnsureCenterPoint(element, visual);
+            }
+
+            animation(element, visual, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    private static void ApplyBounce(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Offset",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.Zero),
+                new(0.2f, Vector3.Zero),
+                new(0.4f, new Vector3(0f, -24f, 0f)),
+                new(0.43f, new Vector3(0f, -24f, 0f)),
+                new(0.53f, Vector3.Zero),
+                new(0.7f, new Vector3(0f, -12f, 0f)),
+                new(0.8f, Vector3.Zero),
+                new(0.9f, new Vector3(0f, -4f, 0f)),
+                new(1.0f, Vector3.Zero)
+            });
+    }
+
+    private static void ApplyFlash(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartScalarAnimation(
+            visual,
+            "Opacity",
+            duration,
+            new CompositionAnimationHelpers.ScalarKeyFrame[]
+            {
+                new(0.0f, 1.0f),
+                new(0.25f, 0.0f),
+                new(0.5f, 1.0f),
+                new(0.75f, 0.0f),
+                new(1.0f, 1.0f)
+            });
+    }
+
+    private static void ApplyPulse(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Scale",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.One),
+                new(0.5f, new Vector3(1.05f, 1.05f, 1f)),
+                new(1.0f, Vector3.One)
+            });
+    }
+
+    private static void ApplyRubberBand(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Scale",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.One),
+                new(0.3f, new Vector3(1.25f, 0.75f, 1f)),
+                new(0.4f, new Vector3(0.75f, 1.25f, 1f)),
+                new(0.5f, new Vector3(1.15f, 0.85f, 1f)),
+                new(0.65f, new Vector3(0.95f, 1.05f, 1f)),
+                new(0.75f, new Vector3(1.05f, 0.95f, 1f)),
+                new(1.0f, Vector3.One)
+            });
+    }
+
+    private static void ApplyShake(Control element, CompositionVisual visual, TimeSpan duration, bool horizontal)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Offset",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.Zero),
+                new(0.1f, horizontal ? new Vector3(-8f, 0f, 0f) : new Vector3(0f, -8f, 0f)),
+                new(0.2f, horizontal ? new Vector3(8f, 0f, 0f) : new Vector3(0f, 8f, 0f)),
+                new(0.3f, horizontal ? new Vector3(-6f, 0f, 0f) : new Vector3(0f, -6f, 0f)),
+                new(0.4f, horizontal ? new Vector3(6f, 0f, 0f) : new Vector3(0f, 6f, 0f)),
+                new(0.5f, horizontal ? new Vector3(-4f, 0f, 0f) : new Vector3(0f, -4f, 0f)),
+                new(0.6f, horizontal ? new Vector3(4f, 0f, 0f) : new Vector3(0f, 4f, 0f)),
+                new(0.7f, horizontal ? new Vector3(-2f, 0f, 0f) : new Vector3(0f, -2f, 0f)),
+                new(0.8f, horizontal ? new Vector3(2f, 0f, 0f) : new Vector3(0f, 2f, 0f)),
+                new(1.0f, Vector3.Zero)
+            });
+    }
+
+    private static void ApplyHeadShake(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Offset",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.Zero),
+                new(0.065f, new Vector3(-6f, 0f, 0f)),
+                new(0.185f, new Vector3(5f, 0f, 0f)),
+                new(0.315f, new Vector3(-3f, 0f, 0f)),
+                new(0.435f, new Vector3(2f, 0f, 0f)),
+                new(0.5f, Vector3.Zero),
+                new(1.0f, Vector3.Zero)
+            });
+
+        CompositionAnimationHelpers.StartScalarAnimation(
+            visual,
+            "RotationAngle",
+            duration,
+            new CompositionAnimationHelpers.ScalarKeyFrame[]
+            {
+                new(0.0f, 0f),
+                new(0.065f, CompositionAnimationHelpers.DegreesToRadians(-6f)),
+                new(0.185f, CompositionAnimationHelpers.DegreesToRadians(4f)),
+                new(0.315f, CompositionAnimationHelpers.DegreesToRadians(-3f)),
+                new(0.435f, CompositionAnimationHelpers.DegreesToRadians(2f)),
+                new(0.5f, 0f),
+                new(1.0f, 0f)
+            });
+    }
+
+    private static void ApplySwing(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartScalarAnimation(
+            visual,
+            "RotationAngle",
+            duration,
+            new CompositionAnimationHelpers.ScalarKeyFrame[]
+            {
+                new(0.0f, 0f),
+                new(0.2f, CompositionAnimationHelpers.DegreesToRadians(15f)),
+                new(0.4f, CompositionAnimationHelpers.DegreesToRadians(-10f)),
+                new(0.6f, CompositionAnimationHelpers.DegreesToRadians(5f)),
+                new(0.8f, CompositionAnimationHelpers.DegreesToRadians(-5f)),
+                new(1.0f, 0f)
+            });
+    }
+
+    private static void ApplyTada(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Scale",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.One),
+                new(0.1f, new Vector3(0.9f, 0.9f, 1f)),
+                new(0.2f, new Vector3(0.9f, 0.9f, 1f)),
+                new(0.3f, new Vector3(1.1f, 1.1f, 1f)),
+                new(0.4f, new Vector3(1.1f, 1.1f, 1f)),
+                new(0.5f, new Vector3(0.95f, 0.95f, 1f)),
+                new(0.6f, new Vector3(1.05f, 1.05f, 1f)),
+                new(0.7f, new Vector3(0.95f, 0.95f, 1f)),
+                new(0.8f, new Vector3(1.05f, 1.05f, 1f)),
+                new(1.0f, Vector3.One)
+            });
+
+        CompositionAnimationHelpers.StartScalarAnimation(
+            visual,
+            "RotationAngle",
+            duration,
+            new CompositionAnimationHelpers.ScalarKeyFrame[]
+            {
+                new(0.0f, 0f),
+                new(0.1f, CompositionAnimationHelpers.DegreesToRadians(-12f)),
+                new(0.2f, CompositionAnimationHelpers.DegreesToRadians(12f)),
+                new(0.3f, CompositionAnimationHelpers.DegreesToRadians(-10f)),
+                new(0.4f, CompositionAnimationHelpers.DegreesToRadians(10f)),
+                new(0.5f, CompositionAnimationHelpers.DegreesToRadians(-6f)),
+                new(0.6f, CompositionAnimationHelpers.DegreesToRadians(6f)),
+                new(0.7f, CompositionAnimationHelpers.DegreesToRadians(-3f)),
+                new(0.8f, CompositionAnimationHelpers.DegreesToRadians(3f)),
+                new(1.0f, 0f)
+            });
+    }
+
+    private static void ApplyWobble(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Offset",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.Zero),
+                new(0.15f, new Vector3(-20f, 0f, 0f)),
+                new(0.3f, new Vector3(16f, 0f, 0f)),
+                new(0.45f, new Vector3(-12f, 0f, 0f)),
+                new(0.6f, new Vector3(8f, 0f, 0f)),
+                new(0.75f, new Vector3(-4f, 0f, 0f)),
+                new(1.0f, Vector3.Zero)
+            });
+
+        CompositionAnimationHelpers.StartScalarAnimation(
+            visual,
+            "RotationAngle",
+            duration,
+            new CompositionAnimationHelpers.ScalarKeyFrame[]
+            {
+                new(0.0f, 0f),
+                new(0.15f, CompositionAnimationHelpers.DegreesToRadians(-5f)),
+                new(0.3f, CompositionAnimationHelpers.DegreesToRadians(3f)),
+                new(0.45f, CompositionAnimationHelpers.DegreesToRadians(-3f)),
+                new(0.6f, CompositionAnimationHelpers.DegreesToRadians(2f)),
+                new(0.75f, CompositionAnimationHelpers.DegreesToRadians(-1f)),
+                new(1.0f, 0f)
+            });
+    }
+
+    private static void ApplyJello(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Scale",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.One),
+                new(0.22f, new Vector3(1.02f, 0.98f, 1f)),
+                new(0.33f, new Vector3(0.98f, 1.02f, 1f)),
+                new(0.44f, new Vector3(1.015f, 0.985f, 1f)),
+                new(0.55f, new Vector3(0.99f, 1.01f, 1f)),
+                new(0.66f, new Vector3(1.01f, 0.99f, 1f)),
+                new(0.77f, new Vector3(0.995f, 1.005f, 1f)),
+                new(1.0f, Vector3.One)
+            });
+    }
+
+    private static void ApplyHeartBeat(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        CompositionAnimationHelpers.StartVector3Animation(
+            visual,
+            "Scale",
+            duration,
+            new CompositionAnimationHelpers.Vector3KeyFrame[]
+            {
+                new(0.0f, Vector3.One),
+                new(0.14f, Vector3.One),
+                new(0.28f, new Vector3(1.3f, 1.3f, 1f)),
+                new(0.42f, Vector3.One),
+                new(0.7f, new Vector3(1.3f, 1.3f, 1f)),
+                new(1.0f, Vector3.One)
+            });
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/CompositionAnimationDefinition.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/CompositionAnimationDefinition.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Numerics;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+internal sealed class CompositionAnimationDefinition
+{
+    public CompositionAnimationDefinition(
+        CompositionAnimationHelpers.Vector3KeyFrame[]? offsetFrames = null,
+        CompositionAnimationHelpers.Vector3KeyFrame[]? scaleFrames = null,
+        CompositionAnimationHelpers.ScalarKeyFrame[]? opacityFrames = null,
+        CompositionAnimationHelpers.ScalarKeyFrame[]? rotationFrames = null,
+        Vector2? anchor = null,
+        Vector3? initialOffset = null,
+        Vector3? initialScale = null,
+        float? initialOpacity = null,
+        float? initialRotation = null,
+        bool ensureCenterPoint = false)
+    {
+        OffsetFrames = offsetFrames;
+        ScaleFrames = scaleFrames;
+        OpacityFrames = opacityFrames;
+        RotationFrames = rotationFrames;
+        Anchor = anchor;
+        InitialOffset = initialOffset;
+        InitialScale = initialScale;
+        InitialOpacity = initialOpacity;
+        InitialRotation = initialRotation;
+        EnsureCenterPoint = ensureCenterPoint;
+    }
+
+    public CompositionAnimationHelpers.Vector3KeyFrame[]? OffsetFrames { get; }
+    public CompositionAnimationHelpers.Vector3KeyFrame[]? ScaleFrames { get; }
+    public CompositionAnimationHelpers.ScalarKeyFrame[]? OpacityFrames { get; }
+    public CompositionAnimationHelpers.ScalarKeyFrame[]? RotationFrames { get; }
+    public Vector2? Anchor { get; }
+    public Vector3? InitialOffset { get; }
+    public Vector3? InitialScale { get; }
+    public float? InitialOpacity { get; }
+    public float? InitialRotation { get; }
+    public bool EnsureCenterPoint { get; }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/CompositionAnimationHelpers.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/CompositionAnimationHelpers.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Animations;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+internal static class CompositionAnimationHelpers
+{
+    internal readonly struct ScalarKeyFrame
+    {
+        public ScalarKeyFrame(float progress, float value)
+        {
+            Progress = progress;
+            Value = value;
+        }
+
+        public float Progress { get; }
+        public float Value { get; }
+    }
+
+    public static float DegreesToRadians(float degrees)
+    {
+        return (float)(Math.PI / 180.0) * degrees;
+    }
+
+    internal readonly struct Vector3KeyFrame
+    {
+        public Vector3KeyFrame(float progress, Vector3 value)
+        {
+            Progress = progress;
+            Value = value;
+        }
+
+        public float Progress { get; }
+        public Vector3 Value { get; }
+    }
+
+    public static void EnsureCenterPoint(Control element, CompositionVisual compositionVisual)
+    {
+        var bounds = element.Bounds;
+        if (bounds.Width > 0 && bounds.Height > 0)
+        {
+            compositionVisual.CenterPoint = new Vector3((float)(bounds.Width * 0.5), (float)(bounds.Height * 0.5), 0f);
+        }
+        else
+        {
+            var halfX = (float)(compositionVisual.Size.X * 0.5);
+            var halfY = (float)(compositionVisual.Size.Y * 0.5);
+            compositionVisual.CenterPoint = new Vector3(halfX, halfY, 0f);
+        }
+    }
+
+    public static void SetNormalizedCenterPoint(Control element, CompositionVisual compositionVisual, Vector2 anchor)
+    {
+        var bounds = element.Bounds;
+        if (bounds.Width > 0 && bounds.Height > 0)
+        {
+            compositionVisual.CenterPoint = new Vector3(
+                (float)(bounds.Width * anchor.X),
+                (float)(bounds.Height * anchor.Y),
+                0f);
+        }
+        else
+        {
+            compositionVisual.CenterPoint = new Vector3(
+                (float)(compositionVisual.Size.X * anchor.X),
+                (float)(compositionVisual.Size.Y * anchor.Y),
+                0f);
+        }
+    }
+
+    public static void StartVector3Animation(CompositionVisual visual, string propertyName, TimeSpan duration, IReadOnlyList<Vector3KeyFrame> keyFrames)
+    {
+        if (keyFrames.Count == 0)
+        {
+            return;
+        }
+
+        var animation = visual.Compositor.CreateVector3KeyFrameAnimation();
+        foreach (var keyFrame in keyFrames)
+        {
+            animation.InsertKeyFrame(keyFrame.Progress, keyFrame.Value);
+        }
+
+        ConfigureAndStartAnimation(visual, propertyName, duration, animation);
+    }
+
+    public static void StartScalarAnimation(CompositionVisual visual, string propertyName, TimeSpan duration, IReadOnlyList<ScalarKeyFrame> keyFrames)
+    {
+        if (keyFrames.Count == 0)
+        {
+            return;
+        }
+
+        var animation = visual.Compositor.CreateScalarKeyFrameAnimation();
+        foreach (var keyFrame in keyFrames)
+        {
+            animation.InsertKeyFrame(keyFrame.Progress, keyFrame.Value);
+        }
+
+        ConfigureAndStartAnimation(visual, propertyName, duration, animation);
+    }
+
+    private static void ConfigureAndStartAnimation(CompositionVisual visual, string propertyName, TimeSpan duration, CompositionAnimation animation)
+    {
+        if (animation is KeyFrameAnimation keyFrameAnimation)
+        {
+            keyFrameAnimation.Direction = PlaybackDirection.Normal;
+            keyFrameAnimation.Duration = duration;
+            keyFrameAnimation.IterationBehavior = AnimationIterationBehavior.Count;
+            keyFrameAnimation.IterationCount = 1;
+        }
+
+        visual.StartAnimation(propertyName, animation);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/EntranceAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/EntranceAnimations.cs
@@ -1,0 +1,742 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Numerics;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides entrance animation helpers inspired by common CSS transitions (e.g. animate.css, Framer Motion).
+/// </summary>
+public static class EntranceAnimations
+{
+    /// <summary>
+    /// Applies the animate.css backInDown animation.
+    /// </summary>
+    public static void SetBackInDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackInDown);
+
+    /// <summary>
+    /// Applies the animate.css backInLeft animation.
+    /// </summary>
+    public static void SetBackInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackInLeft);
+
+    /// <summary>
+    /// Applies the animate.css backInRight animation.
+    /// </summary>
+    public static void SetBackInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackInRight);
+
+    /// <summary>
+    /// Applies the animate.css backInUp animation.
+    /// </summary>
+    public static void SetBackInUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackInUp);
+
+    /// <summary>
+    /// Applies the animate.css bounceIn animation.
+    /// </summary>
+    public static void SetBounceIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceIn, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css bounceInDown animation.
+    /// </summary>
+    public static void SetBounceInDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceInDown);
+
+    /// <summary>
+    /// Applies the animate.css bounceInLeft animation.
+    /// </summary>
+    public static void SetBounceInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceInLeft);
+
+    /// <summary>
+    /// Applies the animate.css bounceInRight animation.
+    /// </summary>
+    public static void SetBounceInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceInRight);
+
+    /// <summary>
+    /// Applies the animate.css bounceInUp animation.
+    /// </summary>
+    public static void SetBounceInUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceInUp);
+
+    /// <summary>
+    /// Applies a simple fade-in animation.
+    /// </summary>
+    public static void SetFadeIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFadeIn);
+
+    /// <summary>
+    /// Applies the animate.css fadeInDown animation.
+    /// </summary>
+    public static void SetFadeInDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(0f, -24f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInDownBig animation.
+    /// </summary>
+    public static void SetFadeInDownBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(0f, -240f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInLeft animation.
+    /// </summary>
+    public static void SetFadeInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(-24f, 0f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInLeftBig animation.
+    /// </summary>
+    public static void SetFadeInLeftBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(-240f, 0f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInRight animation.
+    /// </summary>
+    public static void SetFadeInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(24f, 0f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInRightBig animation.
+    /// </summary>
+    public static void SetFadeInRightBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(240f, 0f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInUp animation.
+    /// </summary>
+    public static void SetFadeInUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(0f, 24f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInUpBig animation.
+    /// </summary>
+    public static void SetFadeInUpBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(0f, 240f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInTopLeft animation.
+    /// </summary>
+    public static void SetFadeInTopLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(-24f, -24f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInTopRight animation.
+    /// </summary>
+    public static void SetFadeInTopRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(24f, -24f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInBottomLeft animation.
+    /// </summary>
+    public static void SetFadeInBottomLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(-24f, 24f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css fadeInBottomRight animation.
+    /// </summary>
+    public static void SetFadeInBottomRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInOffset(new Vector3(24f, 24f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css zoomIn animation. (Compatibility alias for fade-in zoom variant.)
+    /// </summary>
+    public static void SetFadeInZoom(Control element, double milliseconds) =>
+        SetZoomIn(element, milliseconds);
+
+    /// <summary>
+    /// Applies the animate.css flipInX animation.
+    /// </summary>
+    public static void SetFlipInX(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFlipInX, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css flipInY animation.
+    /// </summary>
+    public static void SetFlipInY(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFlipInY, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css lightSpeedInLeft animation.
+    /// </summary>
+    public static void SetLightSpeedInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateLightSpeedIn(-1));
+
+    /// <summary>
+    /// Applies the animate.css lightSpeedInRight animation.
+    /// </summary>
+    public static void SetLightSpeedInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateLightSpeedIn(1));
+
+    /// <summary>
+    /// Applies the animate.css rotateIn animation.
+    /// </summary>
+    public static void SetRotateIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateIn( -90f, new Vector2(0.5f, 0.5f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css rotateInDownLeft animation.
+    /// </summary>
+    public static void SetRotateInDownLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateIn(-45f, new Vector2(0f, 1f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css rotateInDownRight animation.
+    /// </summary>
+    public static void SetRotateInDownRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateIn(45f, new Vector2(1f, 1f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css rotateInUpLeft animation.
+    /// </summary>
+    public static void SetRotateInUpLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateIn(-45f, new Vector2(0f, 0f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css rotateInUpRight animation.
+    /// </summary>
+    public static void SetRotateInUpRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateIn(45f, new Vector2(1f, 0f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css slideInDown animation.
+    /// </summary>
+    public static void SetSlideInDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(0f, -240f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css slideInLeft animation.
+    /// </summary>
+    public static void SetSlideInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(-240f, 0f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css slideInRight animation.
+    /// </summary>
+    public static void SetSlideInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(240f, 0f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css slideInUp animation.
+    /// </summary>
+    public static void SetSlideInUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(0f, 240f, 0f)));
+
+    /// <summary>
+    /// Applies the animate.css zoomIn animation.
+    /// </summary>
+    public static void SetZoomIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateZoomIn, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css zoomInDown animation.
+    /// </summary>
+    public static void SetZoomInDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomInDirectional(new Vector3(0f, -240f, 0f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css zoomInLeft animation.
+    /// </summary>
+    public static void SetZoomInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomInDirectional(new Vector3(-240f, 0f, 0f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css zoomInRight animation.
+    /// </summary>
+    public static void SetZoomInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomInDirectional(new Vector3(240f, 0f, 0f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css zoomInUp animation.
+    /// </summary>
+    public static void SetZoomInUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomInDirectional(new Vector3(0f, 240f, 0f)), ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css jackInTheBox animation.
+    /// </summary>
+    public static void SetJackInTheBox(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateJackInTheBox, ensureCenterPoint: true);
+
+    /// <summary>
+    /// Applies the animate.css rollIn animation.
+    /// </summary>
+    public static void SetRollIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateRollIn);
+
+    private static void Run(Control element, double milliseconds, Func<CompositionAnimationDefinition> definitionFactory, bool ensureCenterPoint = false)
+    {
+        element.Loaded += (_, _) =>
+        {
+            var visual = ElementComposition.GetElementVisual(element);
+            if (visual is null)
+            {
+                return;
+            }
+
+            var definition = definitionFactory();
+
+            if (definition.InitialOffset.HasValue)
+            {
+                visual.Offset = definition.InitialOffset.Value;
+            }
+
+            if (definition.InitialScale.HasValue)
+            {
+                visual.Scale = definition.InitialScale.Value;
+            }
+
+            if (definition.InitialOpacity.HasValue)
+            {
+                visual.Opacity = definition.InitialOpacity.Value;
+            }
+
+            if (definition.InitialRotation.HasValue)
+            {
+                visual.RotationAngle = definition.InitialRotation.Value;
+            }
+
+            if (definition.Anchor.HasValue)
+            {
+                CompositionAnimationHelpers.SetNormalizedCenterPoint(element, visual, definition.Anchor.Value);
+            }
+            else if (definition.EnsureCenterPoint || ensureCenterPoint ||
+                     (definition.ScaleFrames?.Length > 0) || (definition.RotationFrames?.Length > 0))
+            {
+                CompositionAnimationHelpers.EnsureCenterPoint(element, visual);
+            }
+
+            var duration = TimeSpan.FromMilliseconds(milliseconds);
+
+            if (definition.OffsetFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartVector3Animation(visual, "Offset", duration, definition.OffsetFrames);
+            }
+
+            if (definition.ScaleFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartVector3Animation(visual, "Scale", duration, definition.ScaleFrames);
+            }
+
+            if (definition.OpacityFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartScalarAnimation(visual, "Opacity", duration, definition.OpacityFrames);
+            }
+
+            if (definition.RotationFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartScalarAnimation(visual, "RotationAngle", duration, definition.RotationFrames);
+            }
+        };
+    }
+
+    private static CompositionAnimationDefinition CreateBackInDown() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0f, -240f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            initialOffset: new Vector3(0f, -240f, 0f),
+            initialScale: new Vector3(0.7f, 0.7f, 1f),
+            initialOpacity: 0.7f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBackInLeft() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(-240f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            initialOffset: new Vector3(-240f, 0f, 0f),
+            initialScale: new Vector3(0.7f, 0.7f, 1f),
+            initialOpacity: 0.7f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBackInRight() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(240f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            initialOffset: new Vector3(240f, 0f, 0f),
+            initialScale: new Vector3(0.7f, 0.7f, 1f),
+            initialOpacity: 0.7f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBackInUp() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0f, 240f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            initialOffset: new Vector3(0f, 240f, 0f),
+            initialScale: new Vector3(0.7f, 0.7f, 1f),
+            initialOpacity: 0.7f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBounceIn() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.3f, 0.3f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(1.1f, 1.1f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(0.9f, 0.9f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(1.03f, 1.03f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0.97f, 0.97f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialScale: new Vector3(0.3f, 0.3f, 1f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBounceInDown() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0f, -300f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(0f, 25f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.75f, new Vector3(0f, -10f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.9f, new Vector3(0f, 5f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(0f, -300f, 0f),
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateBounceInLeft() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(-300f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(25f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.75f, new Vector3(-10f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.9f, new Vector3(5f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(-300f, 0f, 0f),
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateBounceInRight() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(300f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(-25f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.75f, new Vector3(10f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.9f, new Vector3(-5f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(300f, 0f, 0f),
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateBounceInUp() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0f, 300f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(0f, -25f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.75f, new Vector3(0f, 10f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.9f, new Vector3(0f, -5f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(0f, 300f, 0f),
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateFadeIn() =>
+        new(
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateFadeInOffset(Vector3 startOffset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, startOffset),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: startOffset,
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateFlipInX() =>
+        new(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, CompositionAnimationHelpers.DegreesToRadians(90f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, CompositionAnimationHelpers.DegreesToRadians(-20f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, CompositionAnimationHelpers.DegreesToRadians(10f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, CompositionAnimationHelpers.DegreesToRadians(-5f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialRotation: CompositionAnimationHelpers.DegreesToRadians(90f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateFlipInY() =>
+        new(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, CompositionAnimationHelpers.DegreesToRadians(90f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, CompositionAnimationHelpers.DegreesToRadians(-20f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, CompositionAnimationHelpers.DegreesToRadians(10f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, CompositionAnimationHelpers.DegreesToRadians(-5f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialRotation: CompositionAnimationHelpers.DegreesToRadians(90f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateLightSpeedIn(int direction) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(direction * -200f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(direction * 30f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, CompositionAnimationHelpers.DegreesToRadians(direction * -30f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(direction * -200f, 0f, 0f),
+            initialRotation: CompositionAnimationHelpers.DegreesToRadians(direction * -30f),
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateRotateIn(float startAngle, Vector2 anchor)
+    {
+        var startRadians = CompositionAnimationHelpers.DegreesToRadians(startAngle);
+        return new CompositionAnimationDefinition(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, startRadians),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            anchor: anchor,
+            initialRotation: startRadians,
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+    }
+
+    private static CompositionAnimationDefinition CreateSlideIn(Vector3 startOffset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, startOffset),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            initialOffset: startOffset);
+
+    private static CompositionAnimationDefinition CreateZoomIn() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.3f, 0.3f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(1.05f, 1.05f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.5f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialScale: new Vector3(0.3f, 0.3f, 1f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateZoomInDirectional(Vector3 startOffset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, startOffset),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, startOffset * 0.2f),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.3f, 0.3f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(1.05f, 1.05f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: startOffset,
+            initialScale: new Vector3(0.3f, 0.3f, 1f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateJackInTheBox() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.1f, 0.1f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(0.8f, 0.8f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, CompositionAnimationHelpers.DegreesToRadians(30f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.5f, CompositionAnimationHelpers.DegreesToRadians(-10f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.7f, CompositionAnimationHelpers.DegreesToRadians(3f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.7f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            anchor: new Vector2(0.5f, 1f),
+            initialScale: new Vector3(0.1f, 0.1f, 1f),
+            initialRotation: CompositionAnimationHelpers.DegreesToRadians(30f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateRollIn() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(-240f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, CompositionAnimationHelpers.DegreesToRadians(-120f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(-240f, 0f, 0f),
+            initialRotation: CompositionAnimationHelpers.DegreesToRadians(-120f),
+            initialOpacity: 0f);
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/ExitAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/ExitAnimations.cs
@@ -1,0 +1,571 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Numerics;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides exit animation helpers inspired by animate.css.
+/// </summary>
+public static class ExitAnimations
+{
+    public static void SetBackOutDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackOutDown, ensureCenterPoint: true);
+
+    public static void SetBackOutLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackOutLeft, ensureCenterPoint: true);
+
+    public static void SetBackOutRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackOutRight, ensureCenterPoint: true);
+
+    public static void SetBackOutUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBackOutUp, ensureCenterPoint: true);
+
+    public static void SetBounceOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceOut, ensureCenterPoint: true);
+
+    public static void SetBounceOutDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceOutDown);
+
+    public static void SetBounceOutLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceOutLeft);
+
+    public static void SetBounceOutRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceOutRight);
+
+    public static void SetBounceOutUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateBounceOutUp);
+
+    public static void SetFadeOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFadeOut);
+
+    public static void SetFadeOutDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, 24f, 0f)));
+
+    public static void SetFadeOutDownBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, 240f, 0f)));
+
+    public static void SetFadeOutLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, 0f, 0f)));
+
+    public static void SetFadeOutLeftBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-240f, 0f, 0f)));
+
+    public static void SetFadeOutRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, 0f, 0f)));
+
+    public static void SetFadeOutRightBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(240f, 0f, 0f)));
+
+    public static void SetFadeOutUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, -24f, 0f)));
+
+    public static void SetFadeOutUpBig(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, -240f, 0f)));
+
+    public static void SetFadeOutTopLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, -24f, 0f)));
+
+    public static void SetFadeOutTopRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, -24f, 0f)));
+
+    public static void SetFadeOutBottomLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, 24f, 0f)));
+
+    public static void SetFadeOutBottomRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, 24f, 0f)));
+
+    public static void SetFlipOutX(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFlipOutX, ensureCenterPoint: true);
+
+    public static void SetFlipOutY(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFlipOutY, ensureCenterPoint: true);
+
+    public static void SetLightSpeedOutLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateLightSpeedOut(-1));
+
+    public static void SetLightSpeedOutRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateLightSpeedOut(1));
+
+    public static void SetRotateOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateOut(90f, new Vector2(0.5f, 0.5f)), ensureCenterPoint: true);
+
+    public static void SetRotateOutDownLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateOut(45f, new Vector2(0f, 1f)), ensureCenterPoint: true);
+
+    public static void SetRotateOutDownRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateOut(-45f, new Vector2(1f, 1f)), ensureCenterPoint: true);
+
+    public static void SetRotateOutUpLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateOut(-45f, new Vector2(0f, 0f)), ensureCenterPoint: true);
+
+    public static void SetRotateOutUpRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateOut(45f, new Vector2(1f, 0f)), ensureCenterPoint: true);
+
+    public static void SetSlideOutDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideOut(new Vector3(0f, 240f, 0f)));
+
+    public static void SetSlideOutLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideOut(new Vector3(-240f, 0f, 0f)));
+
+    public static void SetSlideOutRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideOut(new Vector3(240f, 0f, 0f)));
+
+    public static void SetSlideOutUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideOut(new Vector3(0f, -240f, 0f)));
+
+    public static void SetZoomOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateZoomOut, ensureCenterPoint: true);
+
+    public static void SetZoomOutDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(0f, 240f, 0f)), ensureCenterPoint: true);
+
+    public static void SetZoomOutLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(-240f, 0f, 0f)), ensureCenterPoint: true);
+
+    public static void SetZoomOutRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(240f, 0f, 0f)), ensureCenterPoint: true);
+
+    public static void SetZoomOutUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(0f, -240f, 0f)), ensureCenterPoint: true);
+
+    public static void SetHinge(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateHinge, ensureCenterPoint: true);
+
+    public static void SetRollOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateRollOut);
+
+    private static void Run(Control element, double milliseconds, Func<CompositionAnimationDefinition> definitionFactory, bool ensureCenterPoint = false)
+    {
+        element.Loaded += (_, _) =>
+        {
+            var visual = ElementComposition.GetElementVisual(element);
+            if (visual is null)
+            {
+                return;
+            }
+
+            var definition = definitionFactory();
+
+            if (definition.InitialOffset.HasValue)
+            {
+                visual.Offset = definition.InitialOffset.Value;
+            }
+
+            if (definition.InitialScale.HasValue)
+            {
+                visual.Scale = definition.InitialScale.Value;
+            }
+
+            if (definition.InitialOpacity.HasValue)
+            {
+                visual.Opacity = definition.InitialOpacity.Value;
+            }
+
+            if (definition.InitialRotation.HasValue)
+            {
+                visual.RotationAngle = definition.InitialRotation.Value;
+            }
+
+            if (definition.Anchor.HasValue)
+            {
+                CompositionAnimationHelpers.SetNormalizedCenterPoint(element, visual, definition.Anchor.Value);
+            }
+            else if (definition.EnsureCenterPoint || ensureCenterPoint ||
+                     (definition.ScaleFrames?.Length > 0) || (definition.RotationFrames?.Length > 0))
+            {
+                CompositionAnimationHelpers.EnsureCenterPoint(element, visual);
+            }
+
+            var duration = TimeSpan.FromMilliseconds(milliseconds);
+
+            if (definition.OffsetFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartVector3Animation(visual, "Offset", duration, definition.OffsetFrames);
+            }
+
+            if (definition.ScaleFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartVector3Animation(visual, "Scale", duration, definition.ScaleFrames);
+            }
+
+            if (definition.OpacityFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartScalarAnimation(visual, "Opacity", duration, definition.OpacityFrames);
+            }
+
+            if (definition.RotationFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartScalarAnimation(visual, "RotationAngle", duration, definition.RotationFrames);
+            }
+        };
+    }
+
+    private static CompositionAnimationDefinition CreateBackOutDown() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.7f, 0.7f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.2f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0.0f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0f, 240f, 0f))
+            },
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBackOutLeft() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.7f, 0.7f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.2f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0.0f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(-240f, 0f, 0f))
+            },
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBackOutRight() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.7f, 0.7f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.2f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0.0f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(240f, 0f, 0f))
+            },
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBackOutUp() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(0.7f, 0.7f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.7f, 0.7f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.2f, 0.7f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0.0f)
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0f, -240f, 0f))
+            },
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBounceOut() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.25f, new Vector3(0.9f, 0.9f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(1.1f, 1.1f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.75f, new Vector3(1.1f, 1.1f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.3f, 0.3f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateBounceOutDown() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(0f, -20f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(0f, 10f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.45f, new Vector3(0f, 10f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0f, 300f, 0f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.45f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            });
+
+    private static CompositionAnimationDefinition CreateBounceOutLeft() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(20f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(-10f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.45f, new Vector3(-10f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(-300f, 0f, 0f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.45f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            });
+
+    private static CompositionAnimationDefinition CreateBounceOutRight() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(-20f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(10f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.45f, new Vector3(10f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(300f, 0f, 0f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.45f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            });
+
+    private static CompositionAnimationDefinition CreateBounceOutUp() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.2f, new Vector3(0f, 20f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(0f, -10f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.45f, new Vector3(0f, -10f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0f, -300f, 0f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.45f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            });
+
+    private static CompositionAnimationDefinition CreateFadeOut() =>
+        new(
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateFadeOutOffset(Vector3 targetOffset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, targetOffset)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateFlipOutX() =>
+        new(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.3f, CompositionAnimationHelpers.DegreesToRadians(20f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, CompositionAnimationHelpers.DegreesToRadians(-90f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            ensureCenterPoint: true,
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateFlipOutY() =>
+        new(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.3f, CompositionAnimationHelpers.DegreesToRadians(-20f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, CompositionAnimationHelpers.DegreesToRadians(90f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            ensureCenterPoint: true,
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateLightSpeedOut(int direction) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(direction * 200f, 0f, 0f))
+            },
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, CompositionAnimationHelpers.DegreesToRadians(direction * 45f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateRotateOut(float endAngle, Vector2 anchor)
+    {
+        var endRadians = CompositionAnimationHelpers.DegreesToRadians(endAngle);
+        return new CompositionAnimationDefinition(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, endRadians)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            anchor: anchor,
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+    }
+
+    private static CompositionAnimationDefinition CreateSlideOut(Vector3 targetOffset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, targetOffset)
+            },
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateZoomOut() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(0.3f, 0.3f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.1f, 0.1f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.5f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            ensureCenterPoint: true,
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateZoomOutDirectional(Vector3 targetOffset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, targetOffset)
+            },
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(0.4f, 0.4f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.1f, 0.1f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            ensureCenterPoint: true,
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateHinge() =>
+        new(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.2f, CompositionAnimationHelpers.DegreesToRadians(80f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, CompositionAnimationHelpers.DegreesToRadians(60f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, CompositionAnimationHelpers.DegreesToRadians(80f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, CompositionAnimationHelpers.DegreesToRadians(60f)),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, CompositionAnimationHelpers.DegreesToRadians(80f))
+            },
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0f, 0f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0f, 300f, 0f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            anchor: new Vector2(0f, 0f),
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateRollOut() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(240f, 0f, 0f))
+            },
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, CompositionAnimationHelpers.DegreesToRadians(120f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f);
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/FadeAnimation.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/FadeAnimation.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Animations;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides fade animation helpers using composition animations.
+/// </summary>
+public static class FadeAnimation
+{
+    /// <summary>
+    /// Applies a fade-in animation to the element when loaded.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetFadeIn(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, 0.0f, 1.0f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a fade-out animation to the element when loaded.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetFadeOut(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, 1.0f, 0.0f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a custom fade animation to the element when loaded.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="fromOpacity">The starting opacity value (0.0 to 1.0).</param>
+    /// <param name="toOpacity">The ending opacity value (0.0 to 1.0).</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetCustomFade(Control element, double fromOpacity, double toOpacity, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, (float)fromOpacity, (float)toOpacity, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies an opacity animation to the visual.
+    /// </summary>
+    /// <param name="visual">The visual to animate.</param>
+    /// <param name="fromOpacity">The starting opacity value.</param>
+    /// <param name="toOpacity">The ending opacity value.</param>
+    /// <param name="duration">The duration of the animation.</param>
+    private static void Apply(Visual visual, float fromOpacity, float toOpacity, TimeSpan duration)
+    {
+        var compositionVisual = ElementComposition.GetElementVisual(visual);
+        if (compositionVisual is null)
+        {
+            return;
+        }
+
+        var compositor = compositionVisual.Compositor;
+
+        var opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
+        opacityAnimation.InsertKeyFrame(0.0f, fromOpacity);
+        opacityAnimation.InsertKeyFrame(1.0f, toOpacity);
+        opacityAnimation.Direction = PlaybackDirection.Normal;
+        opacityAnimation.Duration = duration;
+        opacityAnimation.IterationBehavior = AnimationIterationBehavior.Count;
+        opacityAnimation.IterationCount = 1;
+
+        compositionVisual.StartAnimation("Opacity", opacityAnimation);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/FramerMotionAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/FramerMotionAnimations.cs
@@ -1,0 +1,299 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Numerics;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides composition animations inspired by popular Framer Motion presets.
+/// </summary>
+public static class FramerMotionAnimations
+{
+    public static void SetFadeIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateFadeInDefinition);
+
+    public static void SetFadeInUp(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(0f, 40f, 0f)));
+
+    public static void SetFadeInDown(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(0f, -40f, 0f)));
+
+    public static void SetFadeInLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(-40f, 0f, 0f)));
+
+    public static void SetFadeInRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(40f, 0f, 0f)));
+
+    public static void SetSlideInFromLeft(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(-120f, 0f, 0f)));
+
+    public static void SetSlideInFromRight(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(120f, 0f, 0f)));
+
+    public static void SetSlideInFromTop(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(0f, -120f, 0f)));
+
+    public static void SetSlideInFromBottom(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateSlideIn(new Vector3(0f, 120f, 0f)));
+
+    public static void SetPopIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreatePopInDefinition, ensureCenterPoint: true);
+
+    public static void SetPopOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreatePopOutDefinition, ensureCenterPoint: true);
+
+    public static void SetSpringIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateSpringInDefinition);
+
+    public static void SetSpringOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateSpringOutDefinition);
+
+    public static void SetRotateIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateDefinition(-15f, 0f), ensureCenterPoint: true);
+
+    public static void SetRotateOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, () => CreateRotateDefinition(0f, 15f), ensureCenterPoint: true);
+
+    public static void SetScaleIn(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateScaleInDefinition, ensureCenterPoint: true);
+
+    public static void SetScaleOut(Control element, double milliseconds) =>
+        Run(element, milliseconds, CreateScaleOutDefinition, ensureCenterPoint: true);
+
+    private static void Run(Control element, double milliseconds, Func<CompositionAnimationDefinition> definitionFactory, bool ensureCenterPoint = false)
+    {
+        element.Loaded += (_, _) =>
+        {
+            var visual = ElementComposition.GetElementVisual(element);
+            if (visual is null)
+            {
+                return;
+            }
+
+            var definition = definitionFactory();
+
+            if (definition.InitialOffset.HasValue)
+            {
+                visual.Offset = definition.InitialOffset.Value;
+            }
+
+            if (definition.InitialScale.HasValue)
+            {
+                visual.Scale = definition.InitialScale.Value;
+            }
+
+            if (definition.InitialOpacity.HasValue)
+            {
+                visual.Opacity = definition.InitialOpacity.Value;
+            }
+
+            if (definition.InitialRotation.HasValue)
+            {
+                visual.RotationAngle = definition.InitialRotation.Value;
+            }
+
+            if (definition.Anchor.HasValue)
+            {
+                CompositionAnimationHelpers.SetNormalizedCenterPoint(element, visual, definition.Anchor.Value);
+            }
+            else if (definition.EnsureCenterPoint || ensureCenterPoint ||
+                     (definition.ScaleFrames?.Length > 0) || (definition.RotationFrames?.Length > 0))
+            {
+                CompositionAnimationHelpers.EnsureCenterPoint(element, visual);
+            }
+
+            var duration = TimeSpan.FromMilliseconds(milliseconds);
+
+            if (definition.OffsetFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartVector3Animation(visual, "Offset", duration, definition.OffsetFrames);
+            }
+
+            if (definition.ScaleFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartVector3Animation(visual, "Scale", duration, definition.ScaleFrames);
+            }
+
+            if (definition.OpacityFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartScalarAnimation(visual, "Opacity", duration, definition.OpacityFrames);
+            }
+
+            if (definition.RotationFrames is { Length: > 0 })
+            {
+                CompositionAnimationHelpers.StartScalarAnimation(visual, "RotationAngle", duration, definition.RotationFrames);
+            }
+        };
+    }
+
+    private static CompositionAnimationDefinition CreateFadeInDefinition() =>
+        new(
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateFadeInDirectional(Vector3 offset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, offset),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.7f, offset * 0.2f),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.7f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: offset,
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateSlideIn(Vector3 offset) =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, offset),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, offset * -0.1f),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            initialOffset: offset);
+
+    private static CompositionAnimationDefinition CreatePopInDefinition() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.8f, 0.8f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(1.1f, 1.1f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.7f, new Vector3(0.98f, 0.98f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialScale: new Vector3(0.8f, 0.8f, 1f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreatePopOutDefinition() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.3f, new Vector3(1.05f, 1.05f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.6f, 0.6f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.3f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateSpringInDefinition() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0f, 120f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(0f, -12f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(0f, 6f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.Zero)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.5f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialOffset: new Vector3(0f, 120f, 0f),
+            initialOpacity: 0f);
+
+    private static CompositionAnimationDefinition CreateSpringOutDefinition() =>
+        new(
+            offsetFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.Zero),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.3f, new Vector3(0f, -12f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(0f, 6f, 0f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0f, 140f, 0f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f);
+
+    private static CompositionAnimationDefinition CreateRotateDefinition(float startAngle, float endAngle)
+    {
+        var startRadians = CompositionAnimationHelpers.DegreesToRadians(startAngle);
+        var midRadians = CompositionAnimationHelpers.DegreesToRadians(endAngle * 0.6f);
+        var endRadians = CompositionAnimationHelpers.DegreesToRadians(endAngle);
+        var startVisible = Math.Abs(startAngle) < float.Epsilon;
+        var endVisible = Math.Abs(endAngle) < float.Epsilon;
+
+        return new CompositionAnimationDefinition(
+            rotationFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, startRadians),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, midRadians),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, endRadians)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, startVisible ? 1f : 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, endVisible ? 1f : 0f)
+            },
+            initialRotation: startRadians,
+            initialOpacity: startVisible ? 1f : 0f,
+            ensureCenterPoint: true);
+    }
+
+    private static CompositionAnimationDefinition CreateScaleInDefinition() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(0.95f, 0.95f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(1.02f, 1.02f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, Vector3.One)
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 0f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.5f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 1f)
+            },
+            initialScale: new Vector3(0.95f, 0.95f, 1f),
+            initialOpacity: 0f,
+            ensureCenterPoint: true);
+
+    private static CompositionAnimationDefinition CreateScaleOutDefinition() =>
+        new(
+            scaleFrames: new[]
+            {
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, Vector3.One),
+                new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(0.95f, 0.95f, 1f)),
+                new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(0.8f, 0.8f, 1f))
+            },
+            opacityFrames: new[]
+            {
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, 1f),
+                new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+            },
+            initialOpacity: 1f,
+            ensureCenterPoint: true);
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/RotateAnimation.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/RotateAnimation.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Animations;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides rotation animation helpers using composition animations.
+/// </summary>
+public static class RotateAnimation
+{
+    /// <summary>
+    /// Applies a clockwise rotation animation to the element when loaded (0 to 360 degrees).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetRotateClockwise(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, 0f, 360f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a counter-clockwise rotation animation to the element when loaded (0 to -360 degrees).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetRotateCounterClockwise(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, 0f, -360f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a rotate-in animation to the element when loaded (from -180 to 0 degrees).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetRotateIn(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, -180f, 0f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a rotate-out animation to the element when loaded (from 0 to 180 degrees).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetRotateOut(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, 0f, 180f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a flip animation to the element when loaded (180 degree rotation).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetFlip(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, 0f, 180f, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a swing animation to the element when loaded (back and forth rotation).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetSwing(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            ApplySwing(element, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a custom rotation animation to the element when loaded.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="fromAngle">The starting rotation angle in degrees.</param>
+    /// <param name="toAngle">The ending rotation angle in degrees.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetCustomRotate(Control element, double fromAngle, double toAngle, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, (float)fromAngle, (float)toAngle, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a rotation animation to the visual.
+    /// </summary>
+    /// <param name="visual">The visual to animate.</param>
+    /// <param name="fromAngle">The starting rotation angle in degrees.</param>
+    /// <param name="toAngle">The ending rotation angle in degrees.</param>
+    /// <param name="duration">The duration of the animation.</param>
+    private static void Apply(Visual visual, float fromAngle, float toAngle, TimeSpan duration)
+    {
+        var compositionVisual = ElementComposition.GetElementVisual(visual);
+        if (compositionVisual is null)
+        {
+            return;
+        }
+
+        var compositor = compositionVisual.Compositor;
+
+        var rotationAnimation = compositor.CreateScalarKeyFrameAnimation();
+        var fromRadians = CompositionAnimationHelpers.DegreesToRadians(fromAngle);
+        var toRadians = CompositionAnimationHelpers.DegreesToRadians(toAngle);
+        rotationAnimation.InsertKeyFrame(0.0f, fromRadians);
+        rotationAnimation.InsertKeyFrame(1.0f, toRadians);
+        rotationAnimation.Direction = PlaybackDirection.Normal;
+        rotationAnimation.Duration = duration;
+        rotationAnimation.IterationBehavior = AnimationIterationBehavior.Count;
+        rotationAnimation.IterationCount = 1;
+
+        compositionVisual.StartAnimation("RotationAngle", rotationAnimation);
+    }
+
+    /// <summary>
+    /// Applies a swing animation to the visual.
+    /// </summary>
+    /// <param name="visual">The visual to animate.</param>
+    /// <param name="duration">The duration of the animation.</param>
+    private static void ApplySwing(Visual visual, TimeSpan duration)
+    {
+        var compositionVisual = ElementComposition.GetElementVisual(visual);
+        if (compositionVisual is null)
+        {
+            return;
+        }
+
+        var compositor = compositionVisual.Compositor;
+
+        var rotationAnimation = compositor.CreateScalarKeyFrameAnimation();
+        rotationAnimation.InsertKeyFrame(0.0f, 0f);
+        rotationAnimation.InsertKeyFrame(0.25f, CompositionAnimationHelpers.DegreesToRadians(15f));
+        rotationAnimation.InsertKeyFrame(0.5f, 0f);
+        rotationAnimation.InsertKeyFrame(0.75f, CompositionAnimationHelpers.DegreesToRadians(-15f));
+        rotationAnimation.InsertKeyFrame(1.0f, 0f);
+        rotationAnimation.Direction = PlaybackDirection.Normal;
+        rotationAnimation.Duration = duration;
+        rotationAnimation.IterationBehavior = AnimationIterationBehavior.Count;
+        rotationAnimation.IterationCount = 1;
+
+        compositionVisual.StartAnimation("RotationAngle", rotationAnimation);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/ScaleAnimation.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/ScaleAnimation.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Numerics;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Animations;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides scale animation helpers using composition animations.
+/// </summary>
+public static class ScaleAnimation
+{
+    /// <summary>
+    /// Applies a scale-in animation to the element when loaded (from 0 to 1).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetScaleIn(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, new Vector3(0, 0, 0), Vector3.One, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a scale-out animation to the element when loaded (from 1 to 0).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetScaleOut(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, Vector3.One, new Vector3(0, 0, 0), TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a zoom-in animation to the element when loaded (from 1.5 to 1).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetZoomIn(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, new Vector3(1.5f, 1.5f, 1), Vector3.One, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a zoom-out animation to the element when loaded (from 1 to 1.5).
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetZoomOut(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, Vector3.One, new Vector3(1.5f, 1.5f, 1), TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a bounce animation to the element when loaded.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetBounce(Control element, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            ApplyBounce(element, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a custom scale animation to the element when loaded.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="fromScaleX">The starting X scale value.</param>
+    /// <param name="fromScaleY">The starting Y scale value.</param>
+    /// <param name="toScaleX">The ending X scale value.</param>
+    /// <param name="toScaleY">The ending Y scale value.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds.</param>
+    public static void SetCustomScale(Control element, double fromScaleX, double fromScaleY, double toScaleX, double toScaleY, double milliseconds)
+    {
+        element.Loaded += (_, _) =>
+        {
+            Apply(element, new Vector3((float)fromScaleX, (float)fromScaleY, 1), new Vector3((float)toScaleX, (float)toScaleY, 1), TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    /// <summary>
+    /// Applies a scale animation to the visual.
+    /// </summary>
+    /// <param name="visual">The visual to animate.</param>
+    /// <param name="fromScale">The starting scale value.</param>
+    /// <param name="toScale">The ending scale value.</param>
+    /// <param name="duration">The duration of the animation.</param>
+    private static void Apply(Visual visual, Vector3 fromScale, Vector3 toScale, TimeSpan duration)
+    {
+        var compositionVisual = ElementComposition.GetElementVisual(visual);
+        if (compositionVisual is null)
+        {
+            return;
+        }
+
+        var compositor = compositionVisual.Compositor;
+
+        var scaleAnimation = compositor.CreateVector3KeyFrameAnimation();
+        scaleAnimation.InsertKeyFrame(0.0f, fromScale);
+        scaleAnimation.InsertKeyFrame(1.0f, toScale);
+        scaleAnimation.Direction = PlaybackDirection.Normal;
+        scaleAnimation.Duration = duration;
+        scaleAnimation.IterationBehavior = AnimationIterationBehavior.Count;
+        scaleAnimation.IterationCount = 1;
+
+        compositionVisual.StartAnimation("Scale", scaleAnimation);
+    }
+
+    /// <summary>
+    /// Applies a bounce animation to the visual.
+    /// </summary>
+    /// <param name="visual">The visual to animate.</param>
+    /// <param name="duration">The duration of the animation.</param>
+    private static void ApplyBounce(Visual visual, TimeSpan duration)
+    {
+        var compositionVisual = ElementComposition.GetElementVisual(visual);
+        if (compositionVisual is null)
+        {
+            return;
+        }
+
+        var compositor = compositionVisual.Compositor;
+
+        var scaleAnimation = compositor.CreateVector3KeyFrameAnimation();
+        scaleAnimation.InsertKeyFrame(0.0f, new Vector3(0, 0, 0));
+        scaleAnimation.InsertKeyFrame(0.5f, new Vector3(1.1f, 1.1f, 1));
+        scaleAnimation.InsertKeyFrame(0.75f, new Vector3(0.9f, 0.9f, 1));
+        scaleAnimation.InsertKeyFrame(1.0f, Vector3.One);
+        scaleAnimation.Direction = PlaybackDirection.Normal;
+        scaleAnimation.Duration = duration;
+        scaleAnimation.IterationBehavior = AnimationIterationBehavior.Count;
+        scaleAnimation.IterationCount = 1;
+
+        compositionVisual.StartAnimation("Scale", scaleAnimation);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/SpecialAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/SpecialAnimations.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Numerics;
+using Avalonia.Controls;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Provides special animation helpers that do not fit other categories.
+/// </summary>
+public static class SpecialAnimations
+{
+    /// <summary>
+    /// Applies an animate.css style <c>flip</c> animation approximation using composition animations.
+    /// </summary>
+    /// <param name="element">The element to animate.</param>
+    /// <param name="milliseconds">Animation duration in milliseconds.</param>
+    public static void SetFlip(Control element, double milliseconds) =>
+        Run(element, milliseconds, ApplyFlip, ensureCenterPoint: true);
+
+    private static void Run(Control element, double milliseconds, Action<Control, CompositionVisual, TimeSpan> animation, bool ensureCenterPoint = false, Vector2? anchor = null)
+    {
+        element.Loaded += (_, _) =>
+        {
+            var visual = ElementComposition.GetElementVisual(element);
+            if (visual is null)
+            {
+                return;
+            }
+
+            if (anchor.HasValue)
+            {
+                CompositionAnimationHelpers.SetNormalizedCenterPoint(element, visual, anchor.Value);
+            }
+            else if (ensureCenterPoint)
+            {
+                CompositionAnimationHelpers.EnsureCenterPoint(element, visual);
+            }
+
+            animation(element, visual, TimeSpan.FromMilliseconds(milliseconds));
+        };
+    }
+
+    private static void ApplyFlip(Control element, CompositionVisual visual, TimeSpan duration)
+    {
+        var rotationFrames = new[]
+        {
+            new CompositionAnimationHelpers.ScalarKeyFrame(0.0f, CompositionAnimationHelpers.DegreesToRadians(-360f)),
+            new CompositionAnimationHelpers.ScalarKeyFrame(0.4f, CompositionAnimationHelpers.DegreesToRadians(-190f)),
+            new CompositionAnimationHelpers.ScalarKeyFrame(0.5f, CompositionAnimationHelpers.DegreesToRadians(-170f)),
+            new CompositionAnimationHelpers.ScalarKeyFrame(0.6f, CompositionAnimationHelpers.DegreesToRadians(-60f)),
+            new CompositionAnimationHelpers.ScalarKeyFrame(0.8f, CompositionAnimationHelpers.DegreesToRadians(-30f)),
+            new CompositionAnimationHelpers.ScalarKeyFrame(1.0f, 0f)
+        };
+
+        var scaleFrames = new[]
+        {
+            new CompositionAnimationHelpers.Vector3KeyFrame(0.0f, new Vector3(1f, 1f, 1f)),
+            new CompositionAnimationHelpers.Vector3KeyFrame(0.4f, new Vector3(1.0f, 1.0f, 1f)),
+            new CompositionAnimationHelpers.Vector3KeyFrame(0.5f, new Vector3(1.1f, 1.1f, 1f)),
+            new CompositionAnimationHelpers.Vector3KeyFrame(0.6f, new Vector3(1.1f, 1.1f, 1f)),
+            new CompositionAnimationHelpers.Vector3KeyFrame(0.8f, new Vector3(1.05f, 1.05f, 1f)),
+            new CompositionAnimationHelpers.Vector3KeyFrame(1.0f, new Vector3(1f, 1f, 1f))
+        };
+
+        CompositionAnimationHelpers.StartScalarAnimation(visual, "RotationAngle", duration, rotationFrames);
+        CompositionAnimationHelpers.StartVector3Animation(visual, "Scale", duration, scaleFrames);
+    }
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/aa368925-3a84-41f0-887d-28d5fad18f0b

# Composition Animation API Additions (PR 289)

## Overview
This branch introduces composition-powered animation helpers under the `Avalonia.Xaml.Interactions.Custom` namespace. The new APIs expose attached-style methods that wire animations to a `Control`'s `Loaded` event and drive opacity, translation, scale, and rotation using `ElementComposition`. The goal is to offer ready-to-use equivalents of popular Animate.css and Framer Motion presets while keeping authoring lightweight in XAML.

All helpers follow the same pattern:

- Each method name starts with `Set...` and accepts `(Control element, double milliseconds)` plus any extra parameters required by the effect.
- Calling the method (or using the corresponding XAML attached syntax) subscribes to `element.Loaded` and runs a predefined `CompositionAnimation` sequence once per load.
- Duration is always interpreted in milliseconds. Internally the helpers convert to `TimeSpan` and use single-run keyframe animations.
- Wherever rotation or scale is involved, `CompositionAnimationHelpers.EnsureCenterPoint` (or a normalized anchor) is applied to keep the motion visually centered.

Supporting infrastructure (`CompositionAnimationHelpers` and `CompositionAnimationDefinition`) is marked `internal` and therefore not part of the public surface, but it is worth noting that these helpers provide reusable keyframe builders, center-point calculation, and degree-to-radian conversion.

## Quick Start Usage

### Attach in XAML
```axaml
<UserControl xmlns="https://github.com/avaloniaui"
             xmlns:custom="using:Avalonia.Xaml.Interactions.Custom">
  <Border Width="220"
          Height="140"
          Background="#F5F5F5"
          custom:FadeAnimation.FadeIn="650" />
</UserControl>
```

### Combine Presets in XAML
```axaml
<WrapPanel xmlns="https://github.com/avaloniaui"
           xmlns:custom="using:Avalonia.Xaml.Interactions.Custom"
           ItemSpacing="16">
  <Border Width="180" Height="120" custom:EntranceAnimations.ZoomIn="900" />
  <Border Width="180" Height="120" custom:AttentionAnimations.HeartBeat="1200" />
  <Border Width="180" Height="120" custom:ExitAnimations.SlideOutLeft="700" />
</WrapPanel>
```

### Configure from Code
```csharp
using Avalonia.Xaml.Interactions.Custom;

public sealed partial class AnimatedCard : UserControl
{
    public AnimatedCard()
    {
        InitializeComponent();
        // Fade from transparent to opaque over 400 ms.
        FadeAnimation.SetCustomFade(this.CardHost, fromOpacity: 0.0, toOpacity: 1.0, milliseconds: 400);
        // Add a spring-like entrance for emphasis.
        FramerMotionAnimations.SetSpringIn(this.CardHost, 700);
    }
}
```

## API Surface
Each subsection lists every newly added method, grouped by preset families where applicable. Every entry takes `double milliseconds` unless noted otherwise.

### `FadeAnimation`
- `SetFadeIn(Control element, double milliseconds)`: fades opacity from 0 to 1 on load.
- `SetFadeOut(Control element, double milliseconds)`: fades opacity from 1 to 0 on load.
- `SetCustomFade(Control element, double fromOpacity, double toOpacity, double milliseconds)`: arbitrary opacity tween, useful for partial fades.

### `ScaleAnimation`
- `SetScaleIn(...)`: scales from zero to full size, centered.
- `SetScaleOut(...)`: scales from full size down to zero.
- `SetZoomIn(...)`: starts oversized (150%) and relaxes to 100%.
- `SetZoomOut(...)`: pushes to 150% scale.
- `SetBounce(...)`: elastic pop with overshoot/undershoot keyframes.
- `SetCustomScale(Control element, double fromScaleX, double fromScaleY, double toScaleX, double toScaleY, double milliseconds)`: custom two-axis scaling.

### `RotateAnimation`
- `SetRotateClockwise(...)`: spins 0 → 360 degrees.
- `SetRotateCounterClockwise(...)`: spins 0 → −360 degrees.
- `SetRotateIn(...)`: unwinds from −180 degrees to rest.
- `SetRotateOut(...)`: rotates out 0 → 180 degrees.
- `SetFlip(...)`: half-rotation flip effect.
- `SetSwing(...)`: oscillates between ±15 degrees.
- `SetCustomRotate(Control element, double fromAngle, double toAngle, double milliseconds)`: arbitrary degree sweep.

### `EntranceAnimations`
Preset entrance effects modeled after Animate.css. Each method pre-positions and/or scales the visual before the load animation begins.

**Back family (scale 70%, opacity 70%, offset 240 px, center point enforced)**
- `SetBackInDown`
- `SetBackInLeft`
- `SetBackInRight`
- `SetBackInUp`

**Bounce family (bouncy offsets, optional center point)**
- `SetBounceIn` (centered scale bounce)
- `SetBounceInDown`
- `SetBounceInLeft`
- `SetBounceInRight`
- `SetBounceInUp`

**Fade family (opacity tween plus directional offset variants)**
- `SetFadeIn`
- `SetFadeInDown`
- `SetFadeInDownBig`
- `SetFadeInLeft`
- `SetFadeInLeftBig`
- `SetFadeInRight`
- `SetFadeInRightBig`
- `SetFadeInUp`
- `SetFadeInUpBig`
- `SetFadeInTopLeft`
- `SetFadeInTopRight`
- `SetFadeInBottomLeft`
- `SetFadeInBottomRight`
- `SetFadeInZoom` (alias for `SetZoomIn`)

**Flip & LightSpeed (rotation with anchor and opacity ramp)**
- `SetFlipInX` (center anchored)
- `SetFlipInY` (center anchored)
- `SetLightSpeedInLeft`
- `SetLightSpeedInRight`

**Rotate family (custom anchor points)**
- `SetRotateIn`
- `SetRotateInDownLeft`
- `SetRotateInDownRight`
- `SetRotateInUpLeft`
- `SetRotateInUpRight`

**Slide family (directional translation)**
- `SetSlideInDown`
- `SetSlideInLeft`
- `SetSlideInRight`
- `SetSlideInUp`

**Zoom family (scale + opacity, center anchored)**
- `SetZoomIn`
- `SetZoomInDown`
- `SetZoomInLeft`
- `SetZoomInRight`
- `SetZoomInUp`

**Specials**
- `SetJackInTheBox` (scale + rotation wiggle)
- `SetRollIn` (offset + rotation roll)

### `AttentionAnimations`
Quick attention grabbers inspired by Animate.css. Duration controls the entire keyframe sequence.
- `SetBounce`
- `SetFlash`
- `SetPulse`
- `SetRubberBand`
- `SetShakeX`
- `SetShakeY`
- `SetHeadShake`
- `SetSwing` (top-anchored pivot)
- `SetTada`
- `SetWobble`
- `SetJello`
- `SetHeartBeat`

### `ExitAnimations`
Counterparts to the entrance presets. These set initial states on load and animate the element out, making them handy for page transitions when paired with delayed removal.

**Back family (scale down to 70%, offset 240 px)**
- `SetBackOutDown`
- `SetBackOutLeft`
- `SetBackOutRight`
- `SetBackOutUp`

**Bounce family (directional bounce-out curves)**
- `SetBounceOut`
- `SetBounceOutDown`
- `SetBounceOutLeft`
- `SetBounceOutRight`
- `SetBounceOutUp`

**Fade family (opacity drop with offsets)**
- `SetFadeOut`
- `SetFadeOutDown`
- `SetFadeOutDownBig`
- `SetFadeOutLeft`
- `SetFadeOutLeftBig`
- `SetFadeOutRight`
- `SetFadeOutRightBig`
- `SetFadeOutUp`
- `SetFadeOutUpBig`
- `SetFadeOutTopLeft`
- `SetFadeOutTopRight`
- `SetFadeOutBottomLeft`
- `SetFadeOutBottomRight`

**Flip & LightSpeed**
- `SetFlipOutX`
- `SetFlipOutY`
- `SetLightSpeedOutLeft`
- `SetLightSpeedOutRight`

**Rotate family (anchored rotations)**
- `SetRotateOut`
- `SetRotateOutDownLeft`
- `SetRotateOutDownRight`
- `SetRotateOutUpLeft`
- `SetRotateOutUpRight`

**Slide family**
- `SetSlideOutDown`
- `SetSlideOutLeft`
- `SetSlideOutRight`
- `SetSlideOutUp`

**Zoom family (scale to 0 while translating)**
- `SetZoomOut`
- `SetZoomOutDown`
- `SetZoomOutLeft`
- `SetZoomOutRight`
- `SetZoomOutUp`

**Specials**
- `SetHinge` (top-left anchored swing drop)
- `SetRollOut` (offset + rotation roll-out)

### `FramerMotionAnimations`
Framer Motion inspired entrance/exit helpers that focus on subtle spring dynamics and short travel distances.
- `SetFadeIn`
- `SetFadeInUp`
- `SetFadeInDown`
- `SetFadeInLeft`
- `SetFadeInRight`
- `SetSlideInFromLeft`
- `SetSlideInFromRight`
- `SetSlideInFromTop`
- `SetSlideInFromBottom`
- `SetPopIn` (scale + opacity overshoot)
- `SetPopOut`
- `SetSpringIn` (springy offset and scale)
- `SetSpringOut`
- `SetRotateIn`
- `SetRotateOut`
- `SetScaleIn`
- `SetScaleOut`

### `SpecialAnimations`
- `SetFlip(Control element, double milliseconds)`: animate.css-style flip that coordinates rotation and scale keyframes with center-point normalization.

## Practical Examples
The samples added to the test application demonstrate real-world compositions:

- `samples/BehaviorsTestApplication/Views/Pages/FadeAnimationView.axaml`: showcases fade-in/out and custom fades on typical form content.
- `samples/BehaviorsTestApplication/Views/Pages/ScaleAnimationView.axaml`: contrasts scale/zoom presets and bounce.
- `samples/BehaviorsTestApplication/Views/Pages/RotateAnimationView.axaml`: demonstrates rotations, swing, and flip in isolation.
- `samples/BehaviorsTestApplication/Views/Pages/EntranceAnimationsView.axaml`: grid of animate.css style entrances categorized by preset family.
- `samples/BehaviorsTestApplication/Views/Pages/AttentionAnimationsView.axaml`: tabbed gallery of pulse, shake, tada, etc.
- `samples/BehaviorsTestApplication/Views/Pages/ExitAnimationsView.axaml`: mirrors the entrance gallery with exit motions for choreography.
- `samples/BehaviorsTestApplication/Views/Pages/FramerMotionAnimationsView.axaml`: highlights subtle UI-friendly motion borrowed from Framer Motion.
- `samples/BehaviorsTestApplication/Views/Pages/SpecialAnimationsView.axaml`: shows the dedicated flip helper from `SpecialAnimations`.

## Implementation Notes
- Animations are composition driven, avoiding layout thrash and keeping the UI thread light.
- All keyframes are authored with normalized progress values, always running once per load (`IterationCount = 1`).
- Methods that manipulate rotation or scale ensure the center point (or a supplied anchor) is set before the animation runs, preventing unexpected pivoting.
- The helpers can be combined: attaching more than one preset to the same control simply queues multiple handlers on `Loaded`.
- Because the methods subscribe to `Loaded`, reparenting an element (or toggling visibility via `IsVisible`) can be used to re-trigger the animation.

