### PR TITLE
Allow unselecting items when using drag behavior

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -142,11 +142,12 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
             if (e.Source is Control control
                 && AssociatedObject?.DataContext == control.DataContext)
             {
-                if ((control as ISelectable
+                if ((e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Meta | KeyModifiers.Shift)) == 0
+                    && ((control as ISelectable
                     ?? control.Parent as ISelectable
                     ?? control.FindLogicalAncestorOfType<ISelectable>())
                         ?.IsSelected
-                    ?? false)
+                    ?? false))
                 {
                     e.Handled = true; //avoid deselection on drag
                 }


### PR DESCRIPTION
Ensure the user is not pressing a multi-selection key modifier before stopping the pointer pressed event propagation, allowing deselecting already selected items.

Otherwise it is not possible to deselect an already selected item when using a drag behavior.