### PR TITLE
Bump Avalonia to 11.3.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AvaloniaVersion>11.3.6</AvaloniaVersion>
+    <AvaloniaVersion>11.3.8</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/samples/BehaviorsTestApplication/Behaviors/FilesDropHandler.cs
+++ b/samples/BehaviorsTestApplication/Behaviors/FilesDropHandler.cs
@@ -8,22 +8,22 @@ public sealed class FilesDropHandler : DropHandlerBase
 {
     public override bool Validate(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
     {
-        return e.Data.Contains(DataFormats.Files) && targetContext is MainWindowViewModel;
+        return e.DataTransfer.Contains(DataFormat.File) && targetContext is MainWindowViewModel;
     }
 
     public override bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
     {
-        if (!e.Data.Contains(DataFormats.Files) || targetContext is not MainWindowViewModel vm)
+        if (!e.DataTransfer.Contains(DataFormat.File) || targetContext is not MainWindowViewModel vm)
         {
             return false;
         }
 
-        var files = e.Data.GetFiles();
+        var files = e.DataTransfer.TryGetFiles();
         if (files is null)
         {
             return false;
         }
-            
+
         foreach (var file in files)
         {
             vm.FileItems?.Add(file.Path);

--- a/samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj
+++ b/samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj
@@ -19,6 +19,14 @@
     <UseBackingFields>true</UseBackingFields>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>IL3050;IL2026</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>IL3050;IL2026</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <AvaloniaResource Include="Assets\*" />
   </ItemGroup>

--- a/samples/BehaviorsTestApplication/Dialogs/SimpleDialog.axaml.cs
+++ b/samples/BehaviorsTestApplication/Dialogs/SimpleDialog.axaml.cs
@@ -8,7 +8,9 @@ public partial class SimpleDialog : Window
     public SimpleDialog()
     {
         InitializeComponent();
-        this.FindControl<Button>("CloseButton").Click += (_, _) => Close();
+        var closeButton = this.FindControl<Button>("CloseButton");
+        if (closeButton is not null)
+            closeButton.Click += (_, _) => Close();
     }
 
     private void InitializeComponent()

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -501,7 +501,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         if (args.Source is TextBox control)
         {
-            Greeting = control.Text ?? String.Empty;
+            Greeting = control.Text ?? string.Empty;
         }
     }
 

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Xaml.Interactions.Custom;
 using ReactiveUI;
+using Avalonia.Input;
 
 namespace BehaviorsTestApplication.ViewModels;
 
@@ -124,7 +125,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         GetClipboardTextCommand = ReactiveCommand.Create<string?>(GetClipboardText);
         GetClipboardDataCommand = ReactiveCommand.Create<object?>(GetClipboardData);
-        GetClipboardFormatsCommand = ReactiveCommand.Create<IEnumerable<string>?>(GetClipboardFormats);
+        GetClipboardFormatsCommand = ReactiveCommand.Create<IEnumerable<DataFormat>?>(GetClipboardFormats);
 
         UploadFilePath = string.Empty;
         UploadUrl = string.Empty;
@@ -338,9 +339,9 @@ public partial class MainWindowViewModel : ViewModelBase
     public ObservableCollection<string> ScreenEvents { get; }
 
     [Reactive] internal partial string MyString { get; set; }
-    
+
     [Reactive] public partial bool FocusFlag { get; set; }
-    
+
     [Reactive] public partial bool IsLoading { get; set; }
 
     [Reactive] public partial double Progress { get; set; }
@@ -471,11 +472,12 @@ public partial class MainWindowViewModel : ViewModelBase
         Console.WriteLine($"GetClipboardDataCommand: {data}");
     }
 
-    private void GetClipboardFormats(IEnumerable<string>? formats)
+    private void GetClipboardFormats(IEnumerable<DataFormat>? formats)
     {
         if (formats is not null)
         {
-            Console.WriteLine($"GetClipboardFormatsCommand: {string.Join(',', formats)}");
+            string[] formatNames = formats.Select(f => f.ToString()).ToArray();
+            Console.WriteLine($"GetClipboardFormatsCommand: {string.Join(',', formatNames)}");
         }
     }
 

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -97,16 +97,16 @@ public partial class MainWindowViewModel : ViewModelBase
 
         Values = Observable.Interval(TimeSpan.FromSeconds(1)).Select(_ => _value++);
 
-        MyString = "";
-        ValidatedText = "";
-        ValidatedNumber = 0m;
+        _myString = "";
+        _validatedText = "";
+        _validatedNumber = 0m;
         SelectedItem = null;
         ValidatedSlider = 0.0;
         ValidatedDate = DateTimeOffset.Now;
         ValidatedItem = null;
 
-        IsLoading = true;
-        Progress = 30;
+        _isLoading = true;
+        _progress = 30;
 
         DataContextChangedCommand = ReactiveCommand.Create(DataContextChanged);
 
@@ -127,23 +127,23 @@ public partial class MainWindowViewModel : ViewModelBase
         GetClipboardDataCommand = ReactiveCommand.Create<object?>(GetClipboardData);
         GetClipboardFormatsCommand = ReactiveCommand.Create<IEnumerable<DataFormat>?>(GetClipboardFormats);
 
-        UploadFilePath = string.Empty;
-        UploadUrl = string.Empty;
-        UploadCompleted = false;
+        _uploadFilePath = string.Empty;
+        _uploadUrl = string.Empty;
+        _uploadCompleted = false;
         UploadCompletedCommand = ReactiveCommand.Create<System.Net.Http.HttpResponseMessage>(OnUploadCompleted);
 
-        UploadStatusMessage = "Provide a file path and upload URL, then choose an upload strategy.";
+        _uploadStatusMessage = "Provide a file path and upload URL, then choose an upload strategy.";
         BeginUploadCommand = ReactiveCommand.Create(BeginUpload);
 
-        ActiveScreenSummary = "Active screen info will appear once the window is visible.";
-        ActiveScreenDiagnostics = string.Empty;
+        _activeScreenSummary = "Active screen info will appear once the window is visible.";
+        _activeScreenDiagnostics = string.Empty;
 
         TryPrepareSampleUploadDefaults();
 
-        Greeting = "Entered text will appear here";
+        _greeting = "Entered text will appear here";
         TextChangedCommand = ReactiveCommand.Create<TextChangedEventArgs>(OnTextChanged);
 
-        ScrollDemoItems = new ObservableCollection<string>
+        _scrollDemoItems = new ObservableCollection<string>
         {
             "Alpha",
             "Bravo",
@@ -208,10 +208,10 @@ public partial class MainWindowViewModel : ViewModelBase
         ScreenEvents = new ObservableCollection<string>();
         ContainerEventLog = new ObservableCollection<string>();
 
-        TaskStatusMessage = "Press Start to run a demo task.";
-        WriteableBitmapStatusMessage = "Render not requested yet.";
-        RenderTriggerMessage = "Waiting for trigger...";
-        WriteableBitmapTimerMessage = "Timer disabled.";
+        _taskStatusMessage = "Press Start to run a demo task.";
+        _writeableBitmapStatusMessage = "Render not requested yet.";
+        _renderTriggerMessage = "Waiting for trigger...";
+        _writeableBitmapTimerMessage = "Timer disabled.";
         IsWriteableBitmapTimerEnabled = false;
         WriteableBitmapTimerInterval = 500;
 
@@ -435,7 +435,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             Console.WriteLine($"OpenFilesCommand: {file.Name}, {file.Path}");
 
-            FileItems.Add(file.Path);
+            FileItems?.Add(file.Path);
         }
     }
 
@@ -443,7 +443,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         Console.WriteLine($"SaveFileCommand: {file}");
 
-        FileItems.Add(file);
+        FileItems?.Add(file);
     }
 
     private void OpenFolders(IEnumerable<IStorageFolder> folders)
@@ -452,7 +452,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             Console.WriteLine($"OpenFoldersCommand: {folder.Name}, {folder.Path}");
 
-            FileItems.Add(folder.Path);
+            FileItems?.Add(folder.Path);
 
             // Set the first folder as DocumentsFolder to demonstrate SuggestedStartLocation usage
             if (DocumentsFolder is null)
@@ -501,7 +501,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         if (args.Source is TextBox control)
         {
-            Greeting = control.Text;
+            Greeting = control.Text ?? String.Empty;
         }
     }
 

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -435,7 +435,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             Console.WriteLine($"OpenFilesCommand: {file.Name}, {file.Path}");
 
-            FileItems.Add(file.Path);
+            FileItems?.Add(file.Path);
         }
     }
 
@@ -443,7 +443,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         Console.WriteLine($"SaveFileCommand: {file}");
 
-        FileItems.Add(file);
+        FileItems?.Add(file);
     }
 
     private void OpenFolders(IEnumerable<IStorageFolder> folders)
@@ -452,7 +452,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             Console.WriteLine($"OpenFoldersCommand: {folder.Name}, {folder.Path}");
 
-            FileItems.Add(folder.Path);
+            FileItems?.Add(folder.Path);
 
             // Set the first folder as DocumentsFolder to demonstrate SuggestedStartLocation usage
             if (DocumentsFolder is null)
@@ -501,7 +501,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         if (args.Source is TextBox control)
         {
-            Greeting = control.Text;
+            Greeting = control.Text ?? String.Empty;
         }
     }
 

--- a/samples/BehaviorsTestApplication/Views/Pages/DragLeaveEventTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/DragLeaveEventTriggerView.axaml.cs
@@ -34,9 +34,9 @@ public partial class DragLeaveEventTriggerView : UserControl
             return;
         }
 
-        var data = new DataObject();
-        data.Set(DataFormats.Text, "DragLeave sample");
-        await DragDrop.DoDragDrop(e, data, DragDropEffects.Copy);
+        var data = new DataTransfer();
+        data.Add(DataTransferItem.CreateText("DragLeave sample"));
+        await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Copy);
     }
 
     private void InitializeComponent()

--- a/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SetClipboardDataObjectActionView.axaml
@@ -13,7 +13,7 @@
     <Button x:Name="SetDataButton" Content="Set Clipboard Data Object" Margin="5">
       <Interaction.Behaviors>
         <EventTriggerBehavior EventName="Click" SourceObject="SetDataButton">
-          <SetClipboardDataObjectAction DataObject="{Binding}" />
+          <SetClipboardDataObjectAction DataTransfer="{Binding}" />
         </EventTriggerBehavior>
       </Interaction.Behaviors>
     </Button>

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/ExitAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/ExitAnimations.cs
@@ -16,7 +16,7 @@ public static class ExitAnimations
     /// Applies a "back out down" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBackOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutDown, ensureCenterPoint: true);
 
@@ -24,15 +24,15 @@ public static class ExitAnimations
     /// Applies a "back out left" animation to the specified control over the given duration.
     /// </summary>
     /// <param name="element">The control to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBackOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutLeft, ensureCenterPoint: true);
 
     /// <summary>
     /// Applies a "Back Out Right" animation to the specified UI element over the given duration.   
     /// </summary>
-    /// <param name="element">The UI element to which the animation will be applied</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBackOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutRight, ensureCenterPoint: true);
 
@@ -40,7 +40,7 @@ public static class ExitAnimations
     /// Applies a "back out up" animation to the specified UI element over the given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBackOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutUp, ensureCenterPoint: true);
 
@@ -48,7 +48,7 @@ public static class ExitAnimations
     /// Applies a "bounce out" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBounceOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOut, ensureCenterPoint: true);
 
@@ -56,7 +56,7 @@ public static class ExitAnimations
     /// Applies a "bounce out down" animation effect to the specified control over a given duration.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBounceOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutDown);
 
@@ -64,7 +64,7 @@ public static class ExitAnimations
     /// Applies a "bounce out left" animation to the specified control over the given duration.
     /// </summary>
     /// <param name="element">The control to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBounceOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutLeft);
 
@@ -72,7 +72,7 @@ public static class ExitAnimations
     /// Applies a "bounce out right" animation effect to the specified control over the given duration.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the animation effect will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBounceOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutRight);
 
@@ -80,7 +80,7 @@ public static class ExitAnimations
     /// Applies a "bounce out up" animation effect to the specified control over a given duration.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetBounceOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutUp);
 
@@ -88,7 +88,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified UI element over the given duration.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the fade-out animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the fade-out animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFadeOut);
 
@@ -96,7 +96,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it downward over the specified duration.
     /// </summary>
     /// <param name="element">The control to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, 24f, 0f)));
 
@@ -104,7 +104,7 @@ public static class ExitAnimations
     /// Applies a "fade out and move down" animation effect to the specified UI element over the given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation effect will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutDownBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, 240f, 0f)));
 
@@ -113,7 +113,7 @@ public static class ExitAnimations
     /// specified duration.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, 0f, 0f)));
 
@@ -121,7 +121,7 @@ public static class ExitAnimations
     /// Applies a "fade out to the left" animation effect to the specified control.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutLeftBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-240f, 0f, 0f)));
 
@@ -129,7 +129,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified UI element, moving it to the right over the specified duration.
     /// </summary>
     /// <param name="element">The UI element to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the fade-out animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the fade-out animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, 0f, 0f)));
 
@@ -137,7 +137,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it to the right while fading out.
     /// </summary>
     /// <param name="element">The control to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutRightBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(240f, 0f, 0f)));
 
@@ -145,7 +145,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it upward as it fades.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, -24f, 0f)));
 
@@ -153,7 +153,7 @@ public static class ExitAnimations
     /// Applies a "fade out and move up" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation effect will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutUpBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, -240f, 0f)));
 
@@ -161,7 +161,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it upward and left as it fades.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutTopLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, -24f, 0f)));
 
@@ -169,7 +169,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it upward and right as it fades.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutTopRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, -24f, 0f)));
 
@@ -177,7 +177,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it downward and left as it fades.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutBottomLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, 24f, 0f)));
 
@@ -185,7 +185,7 @@ public static class ExitAnimations
     /// Applies a fade-out animation to the specified control, moving it downward and right as it fades.
     /// </summary>
     /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFadeOutBottomRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, 24f, 0f)));
 
@@ -193,7 +193,7 @@ public static class ExitAnimations
     /// Applies a "flip out X" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFlipOutX(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFlipOutX, ensureCenterPoint: true);
 
@@ -201,7 +201,7 @@ public static class ExitAnimations
     /// Applies a "flip out Y" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetFlipOutY(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFlipOutY, ensureCenterPoint: true);
 
@@ -209,7 +209,7 @@ public static class ExitAnimations
     /// Applies a "light speed out left" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetLightSpeedOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateLightSpeedOut(-1));
 
@@ -217,7 +217,7 @@ public static class ExitAnimations
     /// Applies a "light speed out right" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetLightSpeedOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateLightSpeedOut(1));
 
@@ -225,7 +225,7 @@ public static class ExitAnimations
     /// Applies a "Rotate out" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetRotateOut(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(90f, new Vector2(0.5f, 0.5f)), ensureCenterPoint: true);
 
@@ -233,7 +233,7 @@ public static class ExitAnimations
     /// Applies a "Rotate Out Down Left" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetRotateOutDownLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(45f, new Vector2(0f, 1f)), ensureCenterPoint: true);
 
@@ -241,7 +241,7 @@ public static class ExitAnimations
     /// Applies a "Rotate Out Down Right" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetRotateOutDownRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(-45f, new Vector2(1f, 1f)), ensureCenterPoint: true);
 
@@ -249,7 +249,7 @@ public static class ExitAnimations
     /// Applies a "Rotate Out Up Left" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetRotateOutUpLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(-45f, new Vector2(0f, 0f)), ensureCenterPoint: true);
 
@@ -257,7 +257,7 @@ public static class ExitAnimations
     /// Applies a "Rotate Out Up Right" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetRotateOutUpRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(45f, new Vector2(1f, 0f)), ensureCenterPoint: true);
 
@@ -265,7 +265,7 @@ public static class ExitAnimations
     /// Applies a "Slide Out Down" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetSlideOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(0f, 240f, 0f)));
 
@@ -273,7 +273,7 @@ public static class ExitAnimations
     /// Applies a "Slide Out Left" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetSlideOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(-240f, 0f, 0f)));
 
@@ -281,7 +281,7 @@ public static class ExitAnimations
     /// Applies a "Slide Out Right" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetSlideOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(240f, 0f, 0f)));
 
@@ -289,7 +289,7 @@ public static class ExitAnimations
     /// Applies a "Slide Out Up" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetSlideOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(0f, -240f, 0f)));
 
@@ -297,7 +297,7 @@ public static class ExitAnimations
     /// Applies a "Zoom out" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetZoomOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateZoomOut, ensureCenterPoint: true);
 
@@ -305,7 +305,7 @@ public static class ExitAnimations
     /// Applies a "Zoom out down" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetZoomOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(0f, 240f, 0f)), ensureCenterPoint: true);
 
@@ -313,7 +313,7 @@ public static class ExitAnimations
     /// Applies a "Zoom out left" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetZoomOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(-240f, 0f, 0f)), ensureCenterPoint: true);
 
@@ -321,7 +321,7 @@ public static class ExitAnimations
     /// Applies a "Zoom out right" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetZoomOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(240f, 0f, 0f)), ensureCenterPoint: true);
 
@@ -329,7 +329,7 @@ public static class ExitAnimations
     /// Applies a "Zoom out up" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetZoomOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(0f, -240f, 0f)), ensureCenterPoint: true);
 
@@ -337,7 +337,7 @@ public static class ExitAnimations
     /// Applies a "Hinge" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetHinge(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateHinge, ensureCenterPoint: true);
 
@@ -345,7 +345,7 @@ public static class ExitAnimations
     /// Applies a "Roll out" animation effect to the specified UI element over a given duration.
     /// </summary>
     /// <param name="element">The UI element to which the animation will be applied.</param>
-    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Minimum allowed value is 1ms and maximum allowed value is 24 days.</param>
     public static void SetRollOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateRollOut);
 

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/ExitAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/ExitAnimations.cs
@@ -12,129 +12,340 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// </summary>
 public static class ExitAnimations
 {
+    /// <summary>
+    /// Applies a "back out down" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetBackOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutDown, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "back out left" animation to the specified control over the given duration.
+    /// </summary>
+    /// <param name="element">The control to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetBackOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutLeft, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Back Out Right" animation to the specified UI element over the given duration.   
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetBackOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutRight, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "back out up" animation to the specified UI element over the given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetBackOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBackOutUp, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "bounce out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetBounceOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOut, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "bounce out down" animation effect to the specified control over a given duration.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
     public static void SetBounceOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutDown);
 
+    /// <summary>
+    /// Applies a "bounce out left" animation to the specified control over the given duration.
+    /// </summary>
+    /// <param name="element">The control to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetBounceOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutLeft);
 
+    /// <summary>
+    /// Applies a "bounce out right" animation effect to the specified control over the given duration.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the animation effect will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
     public static void SetBounceOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutRight);
 
+    /// <summary>
+    /// Applies a "bounce out up" animation effect to the specified control over a given duration.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
     public static void SetBounceOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateBounceOutUp);
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified UI element over the given duration.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the fade-out animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFadeOut);
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it downward over the specified duration.
+    /// </summary>
+    /// <param name="element">The control to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, 24f, 0f)));
 
+    /// <summary>
+    /// Applies a "fade out and move down" animation effect to the specified UI element over the given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation effect will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutDownBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, 240f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified <see cref="Control"/> element, moving it to the left over the
+    /// specified duration.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "fade out to the left" animation effect to the specified control.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutLeftBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-240f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified UI element, moving it to the right over the specified duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the fade-out animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it to the right while fading out.
+    /// </summary>
+    /// <param name="element">The control to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutRightBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(240f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it upward as it fades.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, -24f, 0f)));
 
+    /// <summary>
+    /// Applies a "fade out and move up" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation effect will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutUpBig(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(0f, -240f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it upward and left as it fades.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutTopLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, -24f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it upward and right as it fades.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutTopRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, -24f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it downward and left as it fades.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutBottomLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(-24f, 24f, 0f)));
 
+    /// <summary>
+    /// Applies a fade-out animation to the specified control, moving it downward and right as it fades.
+    /// </summary>
+    /// <param name="element">The <see cref="Control"/> to which the fade-out animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a positive value.</param>
     public static void SetFadeOutBottomRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeOutOffset(new Vector3(24f, 24f, 0f)));
 
+    /// <summary>
+    /// Applies a "flip out X" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFlipOutX(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFlipOutX, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "flip out Y" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFlipOutY(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFlipOutY, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "light speed out left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetLightSpeedOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateLightSpeedOut(-1));
 
+    /// <summary>
+    /// Applies a "light speed out right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetLightSpeedOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateLightSpeedOut(1));
 
+    /// <summary>
+    /// Applies a "Rotate out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateOut(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(90f, new Vector2(0.5f, 0.5f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Rotate Out Down Left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateOutDownLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(45f, new Vector2(0f, 1f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Rotate Out Down Right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateOutDownRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(-45f, new Vector2(1f, 1f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Rotate Out Up Left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateOutUpLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(-45f, new Vector2(0f, 0f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Rotate Out Up Right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateOutUpRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateOut(45f, new Vector2(1f, 0f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Slide Out Down" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(0f, 240f, 0f)));
 
+    /// <summary>
+    /// Applies a "Slide Out Left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(-240f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "Slide Out Right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(240f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "Slide Out Up" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideOut(new Vector3(0f, -240f, 0f)));
 
+    /// <summary>
+    /// Applies a "Zoom out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetZoomOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateZoomOut, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Zoom out down" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetZoomOutDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(0f, 240f, 0f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Zoom out left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetZoomOutLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(-240f, 0f, 0f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Zoom out right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetZoomOutRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(240f, 0f, 0f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Zoom out up" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetZoomOutUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateZoomOutDirectional(new Vector3(0f, -240f, 0f)), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Hinge" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetHinge(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateHinge, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "Roll out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRollOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateRollOut);
 

--- a/src/Xaml.Behaviors.Interactions.Custom/Composition/FramerMotionAnimations.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Composition/FramerMotionAnimations.cs
@@ -12,54 +12,139 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// </summary>
 public static class FramerMotionAnimations
 {
+    /// <summary>
+    /// Applies a "fade in" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeIn(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateFadeInDefinition);
 
+    /// <summary>
+    /// Applies a "fade in up" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeInUp(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(0f, 40f, 0f)));
 
+    /// <summary>
+    /// Applies a "fade in down" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeInDown(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(0f, -40f, 0f)));
 
+    /// <summary>
+    /// Applies a "fade in left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeInLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(-40f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "fade in right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetFadeInRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateFadeInDirectional(new Vector3(40f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "slide in from left" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideInFromLeft(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideIn(new Vector3(-120f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "slide in from right" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideInFromRight(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideIn(new Vector3(120f, 0f, 0f)));
 
+    /// <summary>
+    /// Applies a "slide in from top" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideInFromTop(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideIn(new Vector3(0f, -120f, 0f)));
 
+    /// <summary>
+    /// Applies a "slide in from bottom" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSlideInFromBottom(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateSlideIn(new Vector3(0f, 120f, 0f)));
 
+    /// <summary>
+    /// Applies a "pop in" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetPopIn(Control element, double milliseconds) =>
         Run(element, milliseconds, CreatePopInDefinition, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "pop out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetPopOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreatePopOutDefinition, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "spring in" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSpringIn(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateSpringInDefinition);
 
+    /// <summary>
+    /// Applies a "spring out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetSpringOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateSpringOutDefinition);
 
+    /// <summary>
+    /// Applies a "rotate in" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateIn(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateDefinition(-15f, 0f), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "rotate out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetRotateOut(Control element, double milliseconds) =>
         Run(element, milliseconds, () => CreateRotateDefinition(0f, 15f), ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "scale in" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetScaleIn(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateScaleInDefinition, ensureCenterPoint: true);
 
+    /// <summary>
+    /// Applies a "scale out" animation effect to the specified UI element over a given duration.
+    /// </summary>
+    /// <param name="element">The UI element to which the animation will be applied.</param>
+    /// <param name="milliseconds">The duration of the animation, in milliseconds. Must be a non-negative value.</param>
     public static void SetScaleOut(Control element, double milliseconds) =>
         Run(element, milliseconds, CreateScaleOutDefinition, ensureCenterPoint: true);
 

--- a/src/Xaml.Behaviors.Interactions.Custom/Transitions/AddTransitionAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Transitions/AddTransitionAction.cs
@@ -7,7 +7,7 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Adds a <see cref="Transition"/> to the <see cref="StyledElement.Transitions"/> collection.
+/// Adds a <see cref="Transition"/> to the <see cref="Animatable.Transitions"/> collection.
 /// </summary>
 public class AddTransitionAction : StyledElementAction
 {

--- a/src/Xaml.Behaviors.Interactions.Custom/Transitions/ClearTransitionsAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Transitions/ClearTransitionsAction.cs
@@ -6,7 +6,7 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Clears the <see cref="StyledElement.Transitions"/> collection.
+/// Clears the <see cref="Animation.Animatable.Transitions"/> collection.
 /// </summary>
 public class ClearTransitionsAction : StyledElementAction
 {

--- a/src/Xaml.Behaviors.Interactions.Custom/Transitions/RemoveTransitionAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Transitions/RemoveTransitionAction.cs
@@ -7,7 +7,7 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Removes a <see cref="Transition"/> from the <see cref="StyledElement.Transitions"/> collection.
+/// Removes a <see cref="Transition"/> from the <see cref="Animatable.Transitions"/> collection.
 /// </summary>
 public class RemoveTransitionAction : StyledElementAction
 {

--- a/src/Xaml.Behaviors.Interactions.Custom/Transitions/TransitionsBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Transitions/TransitionsBehavior.cs
@@ -7,7 +7,7 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Sets the <see cref="StyledElement.Transitions"/> collection on the associated control when attached.
+/// Sets the <see cref="Animatable.Transitions"/> collection on the associated control when attached.
 /// </summary>
 public class TransitionsBehavior : AttachedToVisualTreeBehavior<Control>
 {

--- a/src/Xaml.Behaviors.Interactions.Custom/Transitions/TransitionsChangedTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Transitions/TransitionsChangedTrigger.cs
@@ -9,7 +9,7 @@ using Avalonia.Xaml.Interactivity;
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Executes actions whenever the <see cref="StyledElement.Transitions"/> property changes.
+/// Executes actions whenever the <see cref="Animatable.Transitions"/> property changes.
 /// </summary>
 public class TransitionsChangedTrigger : DisposingTrigger<Control>
 {

--- a/src/Xaml.Behaviors.Interactions.Custom/ViewModel/SetViewModelPropertyAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/ViewModel/SetViewModelPropertyAction.cs
@@ -66,8 +66,8 @@ public class SetViewModelPropertyAction : StyledElementAction
         {
             return false;
         }
-        
-        PropertyHelper.UpdatePropertyValue(target, propertyName, Value);
+
+        PropertyHelper.UpdatePropertyValue(target, propertyName!, Value);
         return true;
     }
 }

--- a/src/Xaml.Behaviors.Interactions.Custom/ViewModel/SetViewModelPropertyOnLoadBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/ViewModel/SetViewModelPropertyOnLoadBehavior.cs
@@ -59,6 +59,6 @@ public class SetViewModelPropertyOnLoadBehavior : StyledElementBehavior<Control>
             return;
         }
 
-        PropertyHelper.UpdatePropertyValue(target, propertyName, Value);
+        PropertyHelper.UpdatePropertyValue(target, propertyName!, Value);
     }
 }

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/AddPreviewFilesAction.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/AddPreviewFilesAction.cs
@@ -42,12 +42,12 @@ public sealed class AddPreviewFilesAction : StyledElementAction
             return false;
         }
 
-        if (!e.Data.Contains(DataFormats.Files))
+        if (!e.DataTransfer.Contains(DataFormat.File))
         {
             return false;
         }
 
-        var files = e.Data.GetFiles();
+        var files = e.DataTransfer.TryGetFiles();
         if (files is null)
         {
             return false;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContentControlFilesDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContentControlFilesDropBehavior.cs
@@ -17,13 +17,13 @@ public sealed class ContentControlFilesDropBehavior : DropBehaviorBase
     /// <summary>
     /// Identifies the <seealso cref="ContentDuringDrag"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<object?> ContentDuringDragProperty = 
+    public static readonly StyledProperty<object?> ContentDuringDragProperty =
         AvaloniaProperty.Register<ContentControlFilesDropBehavior, object?>(nameof(ContentDuringDrag));
 
     /// <summary>
     /// Identifies the <seealso cref="BackgroundDuringDrag"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<IBrush?> BackgroundDuringDragProperty = 
+    public static readonly StyledProperty<IBrush?> BackgroundDuringDragProperty =
         AvaloniaProperty.Register<ContentControlFilesDropBehavior, IBrush?>(nameof(BackgroundDuringDrag));
 
     /// <summary>
@@ -83,7 +83,7 @@ public sealed class ContentControlFilesDropBehavior : DropBehaviorBase
         public override void Drop(object? sender, DragEventArgs e, object? sourceContext, object? targetContext)
         {
             base.Drop(sender, e, sourceContext, targetContext);
-            
+
             ClearDragValues(sender);
         }
 
@@ -93,7 +93,7 @@ public sealed class ContentControlFilesDropBehavior : DropBehaviorBase
             object? targetContext,
             object? state)
         {
-            return e.Data.Contains(DataFormats.Files);
+            return e.DataTransfer.Contains(DataFormat.File);
         }
 
         public override bool Execute(object? sender,
@@ -102,12 +102,12 @@ public sealed class ContentControlFilesDropBehavior : DropBehaviorBase
             object? targetContext,
             object? state)
         {
-            if (!e.Data.Contains(DataFormats.Files))
+            if (!e.DataTransfer.Contains(DataFormat.File))
             {
                 return false;
             }
 
-            var files = e.Data.GetFiles();
+            var files = e.DataTransfer.TryGetFiles();
             if (files is null)
             {
                 return false;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -103,6 +103,8 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
 
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value)
     {
+        // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
         var data = new DataObject();
         data.Set(ContextDropBehaviorBase.DataFormat, value!);
 
@@ -126,6 +128,7 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
         }
 
         await DragDrop.DoDragDrop(triggerEvent, data, effect);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private void Released()
@@ -199,7 +202,7 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
                 }
 
                 var context = Context ?? AssociatedObject?.DataContext;
-                    
+
                 OnBeforeDragDrop(sender, _triggerEvent, context);
 
                 await DoDragDrop(_triggerEvent, context);

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragWithDirectionBehavior.cs
@@ -104,6 +104,8 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
 
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value, string direction)
     {
+        // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
         var data = new DataObject();
         data.Set(ContextDropBehavior.DataFormat, value!);
         data.Set("direction", direction);
@@ -128,6 +130,7 @@ public sealed class ContextDragWithDirectionBehavior : StyledElementBehavior<Con
         }
 
         await DragDrop.DoDragDrop(triggerEvent, data, effect);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private void Released()

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDropBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDropBehaviorBase.cs
@@ -66,7 +66,7 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
     /// <param name="sourceContext"></param>
     /// <param name="targetContext"></param>
     protected abstract void OnEnter(object? sender, DragEventArgs e, object? sourceContext, object? targetContext);
-    
+
     /// <summary>
     /// Called when the drag leaves the target.
     /// </summary>
@@ -94,9 +94,12 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
 
     private void DragEnter(object? sender, DragEventArgs e)
     {
-        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat) 
-            ? e.Data.Get(ContextDropBehavior.DataFormat) 
+        // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
+        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat)
+            ? e.Data.Get(ContextDropBehavior.DataFormat)
             : null;
+#pragma warning restore CS0618 // Type or member is obsolete
         var targetContext = Context ?? AssociatedObject?.DataContext;
         OnEnter(sender, e, sourceContext, targetContext);
     }
@@ -108,18 +111,24 @@ public abstract class ContextDropBehaviorBase : StyledElementBehavior<Control>
 
     private void DragOver(object? sender, DragEventArgs e)
     {
-        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat) 
-            ? e.Data.Get(ContextDropBehavior.DataFormat) 
+        // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
+        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat)
+            ? e.Data.Get(ContextDropBehavior.DataFormat)
             : null;
+#pragma warning restore CS0618 // Type or member is obsolete
         var targetContext = Context ?? AssociatedObject?.DataContext;
         OnOver(sender, e, sourceContext, targetContext);
     }
 
     private void Drop(object? sender, DragEventArgs e)
     {
-        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat) 
-            ? e.Data.Get(ContextDropBehavior.DataFormat) 
+        // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
+        var sourceContext = e.Data.Contains(ContextDropBehavior.DataFormat)
+            ? e.Data.Get(ContextDropBehavior.DataFormat)
             : null;
+#pragma warning restore CS0618 // Type or member is obsolete
         var targetContext = Context ?? AssociatedObject?.DataContext;
         OnDrop(sender, e, sourceContext, targetContext);
     }

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/FilesDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/FilesDropBehavior.cs
@@ -27,18 +27,18 @@ public sealed class FilesDropBehavior : DropBehaviorBase
         /// <inheritdoc />
         public override bool Validate(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
-            return e.Data.Contains(DataFormats.Files);
+            return e.DataTransfer.Contains(DataFormat.File);
         }
 
         /// <inheritdoc />
         public override bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
-            if (!e.Data.Contains(DataFormats.Files))
+            if (!e.DataTransfer.Contains(DataFormat.File))
             {
                 return false;
             }
 
-            var files = e.Data.GetFiles();
+            var files = e.DataTransfer.TryGetFiles();
             if (files is null)
             {
                 return false;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/FilesPreviewBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/FilesPreviewBehavior.cs
@@ -50,12 +50,12 @@ public sealed class FilesPreviewBehavior : DragAndDropEventsBehavior
 
     private void UpdatePreview(DragEventArgs e)
     {
-        if (!e.Data.Contains(DataFormats.Files))
+        if (!e.DataTransfer.Contains(DataFormat.File))
         {
             return;
         }
 
-        var files = e.Data.GetFiles();
+        var files = e.DataTransfer.TryGetFiles();
         if (files is null)
         {
             return;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
@@ -273,7 +273,8 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     {
         _isOver = over;
         var target = AssociatedObject;
-        if (target is null) return;
+        if (target is null)
+            return;
         var cls = OverClass;
         if (!string.IsNullOrWhiteSpace(cls))
         {
@@ -310,6 +311,8 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     {
         try
         {
+            // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
             var data = new DataObject();
             if (svc.Payload is not null && svc.DataFormat is { })
             {
@@ -317,10 +320,12 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
             }
             // Use Interactive (base for Control) as required by DragEventArgs
             var target = AssociatedObject as Interactive;
-            if (target is null) return null;
+            if (target is null)
+                return null;
             var e = new DragEventArgs(routedEvent, data, target, localPosition, KeyModifiers.None);
             // Propagate current requested effects so handlers can decide behavior
             e.DragEffects = svc.Effects;
+#pragma warning disable CS0618 // Type or member is obsolete
             return e;
         }
         catch
@@ -337,7 +342,8 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
         if (handler is null || target is null || !AllowDrop || !svc.IsDragging || !string.Equals(svc.DataFormat, AcceptDataFormat, StringComparison.Ordinal))
             return;
         var tl = target.GetVisualRoot() as TopLevel;
-        if (tl is null) return;
+        if (tl is null)
+            return;
         var pTop = tl.PointToClient(svc.ScreenPosition);
         var pLocal = tl.TranslatePoint(pTop, target) ?? default;
         var e = CreateDragEventArgs(DragDrop.DragEnterEvent, pLocal, svc);
@@ -363,7 +369,8 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
         if (handler is null || target is null || !_isOver)
             return;
         var tl = target.GetVisualRoot() as TopLevel;
-        if (tl is null) return;
+        if (tl is null)
+            return;
         var pTop = tl.PointToClient(svc.ScreenPosition);
         var pLocal = tl.TranslatePoint(pTop, target) ?? default;
         var e = CreateDragEventArgs(DragDrop.DropEvent, pLocal, svc);
@@ -375,7 +382,8 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     {
         var handler = Handler;
         var target = AssociatedObject;
-        if (handler is null || target is null) return;
+        if (handler is null || target is null)
+            return;
         handler.Leave(target, new RoutedEventArgs());
     }
 }

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
@@ -325,7 +325,7 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
             var e = new DragEventArgs(routedEvent, data, target, localPosition, KeyModifiers.None);
             // Propagate current requested effects so handlers can decide behavior
             e.DragEffects = svc.Effects;
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             return e;
         }
         catch

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/PanelDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/PanelDropBehavior.cs
@@ -23,16 +23,21 @@ public sealed class PanelDropBehavior : DropBehaviorBase
     {
         public override bool Validate(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
+            // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
             return e.Data.Contains(ContextDropBehavior.DataFormat) && e.Data.Get(ContextDropBehavior.DataFormat) is Control && sender is Panel;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public override bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
+            // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
             if (sender is not Panel target || e.Data.Get(ContextDropBehavior.DataFormat) is not Control control)
             {
                 return false;
             }
-
+#pragma warning restore CS0618 // Type or member is obsolete
             if (control.Parent is Panel source)
             {
                 source.Children.Remove(control);

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/TextDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/TextDropBehavior.cs
@@ -27,18 +27,18 @@ public sealed class TextDropBehavior : DropBehaviorBase
         /// <inheritdoc />
         public override bool Validate(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
-            return e.Data.Contains(DataFormats.Text);
+            return e.DataTransfer.Contains(DataFormat.Text);
         }
 
         /// <inheritdoc />
         public override bool Execute(object? sender, DragEventArgs e, object? sourceContext, object? targetContext, object? state)
         {
-            if (!e.Data.Contains(DataFormats.Text))
+            if (!e.DataTransfer.Contains(DataFormat.Text))
             {
                 return false;
             }
 
-            var text = e.Data.GetText();
+            var text = e.DataTransfer.TryGetText();
             if (text is null)
             {
                 return false;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/TypedDragBehaviorBase.cs
@@ -68,6 +68,8 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
 
     private async Task DoDragDrop(PointerEventArgs triggerEvent, object? value)
     {
+        // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
         var data = new DataObject();
         data.Set(ContextDropBehaviorBase.DataFormat, value!);
 
@@ -91,6 +93,7 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
         }
 
         await DragDrop.DoDragDrop(triggerEvent, data, effect);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private void AssociatedObject_PointerPressed(object? sender, PointerPressedEventArgs e)
@@ -98,7 +101,7 @@ public abstract class TypedDragBehaviorBase : StyledElementBehavior<Control>
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
         if (properties.IsLeftButtonPressed)
         {
-            if (e.Source is Control control 
+            if (e.Source is Control control
                 && AssociatedObject?.DataContext == control.DataContext
                 && DataType is not null
                 && DataType.IsInstanceOfType(control.DataContext))

--- a/src/Xaml.Behaviors.Interactions/Clipboard/GetClipboardDataAction.cs
+++ b/src/Xaml.Behaviors.Interactions/Clipboard/GetClipboardDataAction.cs
@@ -88,8 +88,10 @@ public class GetClipboardDataAction : InvokeCommandActionBase
             {
                 return;
             }
-
+            // TODO: change to new Avalonia drag'n'drop API
+#pragma warning disable CS0618 // Type or member is obsolete
             data = await clipboard.GetDataAsync(Format);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
         catch (Exception)
         {

--- a/src/Xaml.Behaviors.Interactions/Clipboard/GetClipboardFormatsAction.cs
+++ b/src/Xaml.Behaviors.Interactions/Clipboard/GetClipboardFormatsAction.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
@@ -63,8 +65,8 @@ public class GetClipboardFormatsAction : InvokeCommandActionBase
         {
             return;
         }
-        
-        string[]? formats = null;
+
+        IReadOnlyList<DataFormat>? formats = null;
 
         try
         {
@@ -74,7 +76,7 @@ public class GetClipboardFormatsAction : InvokeCommandActionBase
                 return;
             }
 
-            formats = await clipboard.GetFormatsAsync();
+            formats = await clipboard.GetDataFormatsAsync();
         }
         catch (Exception)
         {

--- a/src/Xaml.Behaviors.Interactions/Clipboard/GetClipboardTextAction.cs
+++ b/src/Xaml.Behaviors.Interactions/Clipboard/GetClipboardTextAction.cs
@@ -74,7 +74,7 @@ public class GetClipboardTextAction : InvokeCommandActionBase
                 return;
             }
 
-            text = await clipboard.GetTextAsync();
+            text = await clipboard.TryGetTextAsync();
         }
         catch (Exception)
         {

--- a/src/Xaml.Behaviors.Interactions/Clipboard/SetClipboardDataObjectAction.cs
+++ b/src/Xaml.Behaviors.Interactions/Clipboard/SetClipboardDataObjectAction.cs
@@ -66,7 +66,7 @@ public class SetClipboardDataObjectAction : Interactivity.StyledElementAction
 
     private async Task SetClipboardDataObjectAsync(Visual visual)
     {
-        if (IsEnabled != true || DataTransfer is null)
+        if (!IsEnabled || DataTransfer is null)
         {
             return;
         }

--- a/src/Xaml.Behaviors.Interactions/Clipboard/SetClipboardDataObjectAction.cs
+++ b/src/Xaml.Behaviors.Interactions/Clipboard/SetClipboardDataObjectAction.cs
@@ -30,20 +30,20 @@ public class SetClipboardDataObjectAction : Interactivity.StyledElementAction
         get => GetValue(ClipboardProperty);
         set => SetValue(ClipboardProperty, value);
     }
-    
+
     /// <summary>
-    /// Identifies the <seealso cref="IDataObject"/> avalonia property.
+    /// Identifies the <seealso cref="IAsyncDataTransfer"/> avalonia property.
     /// </summary>
-    public static readonly StyledProperty<IDataObject?> DataObjectProperty =
-        AvaloniaProperty.Register<SetClipboardDataObjectAction, IDataObject?>(nameof(DataObject));
+    public static readonly StyledProperty<IAsyncDataTransfer?> DataTransferProperty =
+        AvaloniaProperty.Register<SetClipboardDataObjectAction, IAsyncDataTransfer?>(nameof(DataTransfer));
 
     /// <summary>
     /// Gets or sets the text to set to the clipboard. This is an avalonia property.
     /// </summary>
-    public IDataObject? DataObject
+    public IAsyncDataTransfer? DataTransfer
     {
-        get => GetValue(DataObjectProperty);
-        set => SetValue(DataObjectProperty, value);
+        get => GetValue(DataTransferProperty);
+        set => SetValue(DataTransferProperty, value);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class SetClipboardDataObjectAction : Interactivity.StyledElementAction
 
     private async Task SetClipboardDataObjectAsync(Visual visual)
     {
-        if (IsEnabled != true || DataObject is null)
+        if (IsEnabled != true || DataTransfer is null)
         {
             return;
         }
@@ -79,7 +79,7 @@ public class SetClipboardDataObjectAction : Interactivity.StyledElementAction
                 return;
             }
 
-            await clipboard.SetDataObjectAsync(DataObject);
+            await clipboard.SetDataAsync(DataTransfer);
         }
         catch (Exception)
         {

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerSuggestedStartLocationHelper.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerSuggestedStartLocationHelper.cs
@@ -27,7 +27,7 @@ internal static class PickerSuggestedStartLocationHelper
             return null;
         }
 
-        if (!TryCreateUri(suggestedStartLocationPath, out var uri))
+        if (!TryCreateUri(suggestedStartLocationPath!, out var uri))
         {
             return null;
         }
@@ -66,8 +66,9 @@ internal static class PickerSuggestedStartLocationHelper
 
     private static bool TryCreateUri(string path, out Uri uri)
     {
-        if (Uri.TryCreate(path, UriKind.Absolute, out uri))
+        if (Uri.TryCreate(path, UriKind.Absolute, out var newUri))
         {
+            uri = newUri;
             return true;
         }
 

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerSuggestedStartLocationHelper.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerSuggestedStartLocationHelper.cs
@@ -27,7 +27,7 @@ internal static class PickerSuggestedStartLocationHelper
             return null;
         }
 
-        if (!TryCreateUri(suggestedStartLocationPath, out var uri))
+        if (!TryCreateUri(suggestedStartLocationPath!, out var uri))
         {
             return null;
         }


### PR DESCRIPTION
This is an attempt to bump Avalonia to 11.3.8.

There were some changes to the drag and drop API in Avalonia. and I have tried to adapt the code accordingly. However, I couldn't figure out how to make context drag work with the new API, so I've suppressed the warnings and added TODO statements.

Additionally, I fixed as many compiler warnings as possible to make it easier to spot remaining problems.