### PR TITLE
Add visibility check before sending drop events

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
@@ -153,52 +153,41 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     private void OnDragStarted()
     {
         UpdateOver(false);
-
-        // If the content is not visible then we must not send drop events.
         var target = AssociatedObject;
         if (target is null || !target.IsEffectivelyVisible)
         {
             UpdateWantsDrop(false);
             return;
         }
-        
         var svc = ManagedDragDropService.Instance;
         var compatible = AllowDrop && Handler is not null && svc.IsDragging && string.Equals(svc.DataFormat, AcceptDataFormat, StringComparison.Ordinal);
         if (compatible)
         {
-            var target = AssociatedObject;
             try
             {
-                if (target is not null)
+                Point local = default;
+                if (target.GetVisualRoot() is TopLevel tl)
                 {
-                    Point local = default;
-                    if (target.GetVisualRoot() is TopLevel tl)
-                    {
-                        var pTop = tl.PointToClient(svc.ScreenPosition);
-                        local = tl.TranslatePoint(pTop, target) ?? default;
-                    }
-                    var e = CreateDragEventArgs(DragDrop.DragEnterEvent, local, svc);
-                    if (e is null)
-                    {
-                        compatible = false;
-                    }
-                    else
-                    {
-                        bool valid;
-                        try
-                        {
-                            valid = Handler!.Validate(target, e, svc.Payload, Context ?? target.DataContext, null);
-                        }
-                        catch
-                        {
-                            valid = false;
-                        }
-                        compatible = valid;
-                    }
+                    var pTop = tl.PointToClient(svc.ScreenPosition);
+                    local = tl.TranslatePoint(pTop, target) ?? default;
+                }
+                var e = CreateDragEventArgs(DragDrop.DragEnterEvent, local, svc);
+                if (e is null)
+                {
+                    compatible = false;
                 }
                 else
                 {
-                    compatible = false;
+                    bool valid;
+                    try
+                    {
+                        valid = Handler!.Validate(target, e, svc.Payload, Context ?? target.DataContext, null);
+                    }
+                    catch
+                    {
+                        valid = false;
+                    }
+                    compatible = valid;
                 }
             }
             catch
@@ -215,6 +204,16 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
         var target = AssociatedObject;
         if (target is null || !AllowDrop)
             return;
+        if (!target.IsEffectivelyVisible)
+        {
+            if (_isOver)
+            {
+                UpdateOver(false);
+                InvokeHandlerLeave();
+            }
+            UpdateWantsDrop(false);
+            return;
+        }
 
         var svc = ManagedDragDropService.Instance;
         if (!svc.IsDragging || !string.Equals(svc.DataFormat, AcceptDataFormat, StringComparison.Ordinal))
@@ -259,6 +258,14 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
         var target = AssociatedObject;
         if (target is null)
             return;
+        if (!target.IsEffectivelyVisible)
+        {
+            if (_isOver)
+                InvokeHandlerLeave();
+            UpdateOver(false);
+            UpdateWantsDrop(false);
+            return;
+        }
 
         try
         {
@@ -319,10 +326,10 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     {
         try
         {
-            var data = new DataTransfer();
-            if (svc.PayloadKey is not null)
+            var data = new DataObject();
+            if (svc.Payload is not null && svc.DataFormat is { })
             {
-                data.Add(DataTransferItem.Create(ContextDropBehaviorBase.ContextDataTransferFormat, svc.PayloadKey));
+                data.Set(svc.DataFormat, svc.Payload);
             }
             // Use Interactive (base for Control) as required by DragEventArgs
             var target = AssociatedObject as Interactive;
@@ -343,7 +350,7 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
         var handler = Handler;
         var target = AssociatedObject;
         var svc = ManagedDragDropService.Instance;
-        if (handler is null || target is null || !AllowDrop || !svc.IsDragging || !string.Equals(svc.DataFormat, AcceptDataFormat, StringComparison.Ordinal))
+        if (handler is null || target is null || !target.IsEffectivelyVisible || !AllowDrop || !svc.IsDragging || !string.Equals(svc.DataFormat, AcceptDataFormat, StringComparison.Ordinal))
             return;
         var tl = target.GetVisualRoot() as TopLevel;
         if (tl is null) return;
@@ -358,7 +365,7 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     {
         var handler = Handler;
         var target = AssociatedObject;
-        if (handler is null || target is null)
+        if (handler is null || target is null || !target.IsEffectivelyVisible)
             return;
         var e = CreateDragEventArgs(DragDrop.DragOverEvent, localPosition, svc);
         if (e is not null)
@@ -369,7 +376,7 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     {
         var handler = Handler;
         var target = AssociatedObject;
-        if (handler is null || target is null || !_isOver)
+        if (handler is null || target is null || !target.IsEffectivelyVisible || !_isOver)
             return;
         var tl = target.GetVisualRoot() as TopLevel;
         if (tl is null) return;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ManagedDragDrop/ManagedContextDropBehavior.cs
@@ -153,6 +153,15 @@ public class ManagedContextDropBehavior : StyledElementBehavior<Control>
     private void OnDragStarted()
     {
         UpdateOver(false);
+
+        // If the content is not visible then we must not send drop events.
+        var target = AssociatedObject;
+        if (target is null || !target.IsEffectivelyVisible)
+        {
+            UpdateWantsDrop(false);
+            return;
+        }
+        
         var svc = ManagedDragDropService.Instance;
         var compatible = AllowDrop && Handler is not null && svc.IsDragging && string.Equals(svc.DataFormat, AcceptDataFormat, StringComparison.Ordinal);
         if (compatible)


### PR DESCRIPTION
Prevent drop events when the target content is not visible.