### PR TITLE
Add `ClickEventTrigger` for Button-Like Click Semantics on Any `Control`

### DIFF
--- a/docfx/articles/interactions-custom/input-element/click-event-trigger.md
+++ b/docfx/articles/interactions-custom/input-element/click-event-trigger.md
@@ -16,6 +16,7 @@ It supports:
 
 | Property | Type | Description |
 | --- | --- | --- |
+| `SourceControl` | `Control?` | Optional external source control (resolved by name). If set, click handling and execution use that control instead of the associated object. |
 | `ClickMode` | `ClickMode` | Determines whether the click fires on press or release. Default is `Release`. |
 | `KeyModifiers` | `KeyModifiers?` | Optional exact key-modifier filter. `null` means no filter. |
 | `IsDefault` | `bool` | If `true`, Enter on the visual root can trigger click when the control is visible and enabled. |
@@ -23,6 +24,8 @@ It supports:
 | `Flyout` | `FlyoutBase?` | Optional explicit flyout to toggle on click. |
 | `UseAttachedFlyout` | `bool` | If `true`, uses `FlyoutBase.AttachedFlyout` when `Flyout` is not set. Default is `true`. |
 | `HandleEvent` | `bool` | If `true`, marks handled at button-like decision points. Default is `true`. |
+
+If `SourceControl` is not set, `ClickEventTrigger` uses the associated object.
 
 ## Example
 
@@ -36,6 +39,32 @@ It supports:
         </ClickEventTrigger>
     </Interaction.Behaviors>
 </Border>
+```
+
+## SourceControl Example
+
+```xml
+<StackPanel Orientation="Horizontal" Spacing="8">
+    <Border Name="SourceControlSourceTarget"
+            Width="300"
+            Height="72"
+            Background="LightCyan"
+            Focusable="True" />
+
+    <Border Width="300"
+            Height="72"
+            Background="PowderBlue"
+            Focusable="True">
+        <Interaction.Behaviors>
+            <ClickEventTrigger SourceControl="SourceControlSourceTarget">
+                <InvokeCommandAction Command="{Binding SourceControlClickCommand}" />
+            </ClickEventTrigger>
+        </Interaction.Behaviors>
+        <TextBlock HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Behavior host (source is external)" />
+    </Border>
+</StackPanel>
 ```
 
 ## Open/Save Picker + MVVM Commands

--- a/docfx/articles/interactions-custom/input-element/click-event-trigger.md
+++ b/docfx/articles/interactions-custom/input-element/click-event-trigger.md
@@ -1,0 +1,112 @@
+# ClickEventTrigger
+
+`ClickEventTrigger` emulates Avalonia `Button` click semantics on any `Control`.
+
+It supports:
+
+* Pointer click handling with `ClickMode` (`Release` / `Press`)
+* Keyboard activation (`Enter`, `Space`)
+* Optional `IsDefault` and `IsCancel` root key handling
+* Optional flyout toggle behavior
+* Optional exact `KeyModifiers` filtering
+
+> Access-key internals are intentionally not emulated. This trigger uses only public Avalonia APIs.
+
+## Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `ClickMode` | `ClickMode` | Determines whether the click fires on press or release. Default is `Release`. |
+| `KeyModifiers` | `KeyModifiers?` | Optional exact key-modifier filter. `null` means no filter. |
+| `IsDefault` | `bool` | If `true`, Enter on the visual root can trigger click when the control is visible and enabled. |
+| `IsCancel` | `bool` | If `true`, Escape on the visual root can trigger click when the control is visible and enabled. |
+| `Flyout` | `FlyoutBase?` | Optional explicit flyout to toggle on click. |
+| `UseAttachedFlyout` | `bool` | If `true`, uses `FlyoutBase.AttachedFlyout` when `Flyout` is not set. Default is `true`. |
+| `HandleEvent` | `bool` | If `true`, marks handled at button-like decision points. Default is `true`. |
+
+## Example
+
+```xml
+<Border Background="LightSteelBlue" Width="260" Height="70" Focusable="True">
+    <Interaction.Behaviors>
+        <ClickEventTrigger ClickMode="Release"
+                           IsDefault="True"
+                           KeyModifiers="{x:Null}">
+            <InvokeCommandAction Command="{Binding SubmitCommand}" />
+        </ClickEventTrigger>
+    </Interaction.Behaviors>
+</Border>
+```
+
+## Open/Save Picker + MVVM Commands
+
+`ClickEventTrigger` can execute storage-provider picker actions on non-button controls while keeping command handling in the ViewModel.
+
+```xml
+<StackPanel Spacing="8">
+    <Border Width="300" Height="72" Background="LightGreen" Focusable="True">
+        <Interaction.Behaviors>
+            <ClickEventTrigger>
+                <OpenFilePickerAction Command="{Binding OpenFilesCommand}"
+                                      Title="Open Files from ClickEventTrigger"
+                                      SuggestedFileName="TriggerSample"
+                                      AllowMultiple="True"
+                                      FileTypeFilter="Text Files|*.txt|Markdown Files|*.md|All Files|*.*" />
+            </ClickEventTrigger>
+        </Interaction.Behaviors>
+        <TextBlock HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Open Files (ClickEventTrigger)" />
+    </Border>
+
+    <Border Width="300" Height="72" Background="LightSalmon" Focusable="True">
+        <Interaction.Behaviors>
+            <ClickEventTrigger>
+                <SaveFilePickerAction Command="{Binding SaveFileCommand}"
+                                      InputConverter="{x:Static StorageItemToPathConverter.Instance}"
+                                      Title="Save File from ClickEventTrigger"
+                                      SuggestedFileName="TriggerSample"
+                                      DefaultExtension="txt"
+                                      FileTypeChoices="Text Files (*.txt)|*.txt|Markdown Files (*.md)|*.md|All Files (*.*)|*.*" />
+            </ClickEventTrigger>
+        </Interaction.Behaviors>
+        <TextBlock HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Save File (ClickEventTrigger)" />
+    </Border>
+
+    <ListBox Height="140" ItemsSource="{Binding FileItems}" />
+</StackPanel>
+```
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Avalonia.Platform.Storage;
+using ReactiveUI;
+
+public ICommand OpenFilesCommand { get; }
+public ICommand SaveFileCommand { get; }
+public ObservableCollection<Uri> FileItems { get; } = new();
+
+public MainWindowViewModel()
+{
+    OpenFilesCommand = ReactiveCommand.Create<IEnumerable<IStorageItem>>(files =>
+    {
+        foreach (IStorageItem file in files)
+        {
+            if (file.Path is { } path)
+            {
+                FileItems.Add(path);
+            }
+        }
+    });
+
+    SaveFileCommand = ReactiveCommand.Create<Uri>(file =>
+    {
+        FileItems.Add(file);
+    });
+}
+```

--- a/docfx/articles/interactions-custom/input-element/overview.md
+++ b/docfx/articles/interactions-custom/input-element/overview.md
@@ -3,6 +3,7 @@
 The `InputElement` category contains the following interactions:
 
 * [CapturePointerAction](capture-pointer-action.md)
+* [ClickEventTrigger](click-event-trigger.md)
 * [DoubleTappedTrigger](double-tapped-trigger.md)
 * [GotFocusTrigger](got-focus-trigger.md)
 * [HoldingTrigger](holding-trigger.md)
@@ -22,3 +23,5 @@ The `InputElement` category contains the following interactions:
 * [TappedTrigger](tapped-trigger.md)
 * [TextInputMethodClientRequestedTrigger](text-input-method-client-requested-trigger.md)
 * [TextInputTrigger](text-input-trigger.md)
+
+The `ClickEventTrigger` article includes end-to-end examples that combine click emulation with `OpenFilePickerAction` and `SaveFilePickerAction`, wired to MVVM commands.

--- a/docfx/articles/interactions-custom/input-element/toc.yml
+++ b/docfx/articles/interactions-custom/input-element/toc.yml
@@ -2,6 +2,8 @@
   href: overview.md
 - name: CapturePointerAction
   href: capture-pointer-action.md
+- name: ClickEventTrigger
+  href: click-event-trigger.md
 - name: DoubleTappedTrigger
   href: double-tapped-trigger.md
 - name: GotFocusTrigger

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -204,6 +204,9 @@
       <TabItem Header="ButtonClickEventTriggerBehavior">
         <pages:ButtonClickEventTriggerBehaviorView />
       </TabItem>
+      <TabItem Header="ClickEventTrigger">
+        <pages:ClickEventTriggerView />
+      </TabItem>
       <TabItem Header="Advanced Behavior">
         <pages:AdvancedView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
@@ -1,0 +1,202 @@
+<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ClickEventTriggerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:primitives="using:Avalonia.Controls.Primitives"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d"
+             d:DesignWidth="900"
+             d:DesignHeight="700">
+  <ScrollViewer>
+    <StackPanel Spacing="8" Margin="10">
+      <TextBlock FontSize="18" FontWeight="Bold" Text="ClickEventTrigger" />
+      <TextBlock Text="Emulates Button click semantics on non-button controls." />
+
+      <TextBlock FontWeight="Bold" Text="ClickMode: Release vs Press" />
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Border Name="ReleaseTarget"
+                Width="250"
+                Height="72"
+                Background="LightSteelBlue"
+                CornerRadius="4"
+                Focusable="True"
+                VerticalAlignment="Center">
+          <Interaction.Behaviors>
+            <ClickEventTrigger ClickMode="Release">
+              <ChangePropertyAction TargetObject="ReleaseStatus"
+                                    PropertyName="Text"
+                                    Value="Release target clicked." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Release (click on pointer up)" />
+        </Border>
+
+        <Border Name="PressTarget"
+                Width="250"
+                Height="72"
+                Background="PeachPuff"
+                CornerRadius="4"
+                Focusable="True"
+                VerticalAlignment="Center">
+          <Interaction.Behaviors>
+            <ClickEventTrigger ClickMode="Press">
+              <ChangePropertyAction TargetObject="PressStatus"
+                                    PropertyName="Text"
+                                    Value="Press target clicked." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Press (click on pointer down)" />
+        </Border>
+      </StackPanel>
+      <TextBlock Name="ReleaseStatus" Text="Release status: waiting..." />
+      <TextBlock Name="PressStatus" Text="Press status: waiting..." />
+
+      <TextBlock FontWeight="Bold" Text="KeyModifiers Filter" />
+      <Border Name="ModifierTarget"
+              Width="350"
+              Height="72"
+              Background="LightGoldenrodYellow"
+              CornerRadius="4"
+              Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger KeyModifiers="Control">
+            <ChangePropertyAction TargetObject="ModifierStatus"
+                                  PropertyName="Text"
+                                  Value="Modifier target clicked with Control." />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+        <TextBlock HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Ctrl+Click required" />
+      </Border>
+      <TextBlock Name="ModifierStatus" Text="Modifier status: waiting..." />
+
+      <TextBlock FontWeight="Bold" Text="IsDefault / IsCancel" />
+      <TextBlock Text="Focus the TextBox and press Enter or Escape." />
+      <TextBox Name="KeyboardSource"
+               Width="350"
+               Watermark="Focus here, then press Enter (default) or Escape (cancel)." />
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Border Name="DefaultTarget"
+                Width="250"
+                Height="62"
+                Background="Honeydew"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger IsDefault="True">
+              <ChangePropertyAction TargetObject="DefaultCancelStatus"
+                                    PropertyName="Text"
+                                    Value="Default target activated." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Default target (Enter)" />
+        </Border>
+        <Border Name="CancelTarget"
+                Width="250"
+                Height="62"
+                Background="MistyRose"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger IsCancel="True">
+              <ChangePropertyAction TargetObject="DefaultCancelStatus"
+                                    PropertyName="Text"
+                                    Value="Cancel target activated." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Cancel target (Escape)" />
+        </Border>
+      </StackPanel>
+      <TextBlock Name="DefaultCancelStatus" Text="Default/Cancel status: waiting..." />
+
+      <TextBlock FontWeight="Bold" Text="Flyout Toggle" />
+      <Border Name="FlyoutTarget"
+              Width="320"
+              Height="72"
+              Background="Lavender"
+              CornerRadius="4"
+              Focusable="True">
+        <primitives:FlyoutBase.AttachedFlyout>
+          <Flyout>
+            <StackPanel Margin="10" Spacing="4">
+              <TextBlock FontWeight="Bold" Text="Attached Flyout" />
+              <TextBlock Text="Click the target again to close." />
+            </StackPanel>
+          </Flyout>
+        </primitives:FlyoutBase.AttachedFlyout>
+        <Interaction.Behaviors>
+          <ClickEventTrigger>
+            <ChangePropertyAction TargetObject="FlyoutStatus"
+                                  PropertyName="Text"
+                                  Value="Flyout target clicked; flyout toggled." />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+        <TextBlock HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Click to toggle attached flyout" />
+      </Border>
+      <TextBlock Name="FlyoutStatus" Text="Flyout status: waiting..." />
+
+      <TextBlock FontWeight="Bold" Text="Open/Save File Picker with MVVM Commands" />
+      <TextBlock Text="These targets use ClickEventTrigger + picker actions bound to OpenFilesCommand and SaveFileCommand." />
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Border Name="OpenFilePickerTarget"
+                Width="300"
+                Height="72"
+                Background="LightGreen"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger>
+              <OpenFilePickerAction Command="{Binding OpenFilesCommand}"
+                                    Title="Open Files from ClickEventTrigger"
+                                    SuggestedFileName="TriggerSample"
+                                    AllowMultiple="True"
+                                    FileTypeFilter="Text Files|*.txt|Markdown Files|*.md|All Files|*.*" />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Open Files (ClickEventTrigger)" />
+        </Border>
+
+        <Border Name="SaveFilePickerTarget"
+                Width="300"
+                Height="72"
+                Background="LightSalmon"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger>
+              <SaveFilePickerAction Command="{Binding SaveFileCommand}"
+                                    InputConverter="{x:Static StorageItemToPathConverter.Instance}"
+                                    Title="Save File from ClickEventTrigger"
+                                    SuggestedFileName="TriggerSample"
+                                    DefaultExtension="txt"
+                                    FileTypeChoices="Text Files (*.txt)|*.txt|Markdown Files (*.md)|*.md|All Files (*.*)|*.*" />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Save File (ClickEventTrigger)" />
+        </Border>
+      </StackPanel>
+
+      <TextBlock FontWeight="SemiBold" Text="MVVM output (OpenFilesCommand / SaveFileCommand):" />
+      <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="4">
+        <ListBox Height="140" ItemsSource="{Binding FileItems}" />
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
@@ -77,6 +77,40 @@
       </Border>
       <TextBlock Name="ModifierStatus" Text="Modifier status: waiting..." />
 
+      <TextBlock FontWeight="Bold" Text="SourceControl (External Source Resolution)" />
+      <TextBlock Text="Behavior is attached to the right target, but listens on the left source via SourceControl." />
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Border Name="SourceControlSourceTarget"
+                Width="300"
+                Height="72"
+                Background="LightCyan"
+                CornerRadius="4"
+                Focusable="True">
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Source target (click me)" />
+        </Border>
+
+        <Border Name="SourceControlHostTarget"
+                Width="300"
+                Height="72"
+                Background="PowderBlue"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger SourceControl="SourceControlSourceTarget">
+              <ChangePropertyAction TargetObject="SourceControlStatus"
+                                    PropertyName="Text"
+                                    Value="SourceControl example fired from the external source target." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Host target (behavior attached here)" />
+        </Border>
+      </StackPanel>
+      <TextBlock Name="SourceControlStatus" Text="SourceControl status: click the source target." />
+
       <TextBlock FontWeight="Bold" Text="IsDefault / IsCancel" />
       <TextBlock Text="Focus the TextBox and press Enter or Escape." />
       <TextBox Name="KeyboardSource"

--- a/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class ClickEventTriggerView : UserControl
+{
+    public ClickEventTriggerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs
@@ -1,0 +1,436 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Avalonia.Xaml.Interactivity;
+
+namespace Avalonia.Xaml.Interactions.Custom;
+
+/// <summary>
+/// Trigger that emulates <see cref="Button"/> click semantics on any <see cref="Control"/>.
+/// </summary>
+public class ClickEventTrigger : StyledElementTrigger<Control>
+{
+    private bool _isPressed;
+    private IInputElement? _rootInputElement;
+
+    /// <summary>
+    /// Identifies the <see cref="ClickMode"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<ClickMode> ClickModeProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, ClickMode>(nameof(ClickMode), ClickMode.Release);
+
+    /// <summary>
+    /// Identifies the <see cref="KeyModifiers"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<KeyModifiers?> KeyModifiersProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, KeyModifiers?>(nameof(KeyModifiers));
+
+    /// <summary>
+    /// Identifies the <see cref="IsDefault"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsDefaultProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, bool>(nameof(IsDefault));
+
+    /// <summary>
+    /// Identifies the <see cref="IsCancel"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsCancelProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, bool>(nameof(IsCancel));
+
+    /// <summary>
+    /// Identifies the <see cref="Flyout"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<FlyoutBase?> FlyoutProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, FlyoutBase?>(nameof(Flyout));
+
+    /// <summary>
+    /// Identifies the <see cref="UseAttachedFlyout"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> UseAttachedFlyoutProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, bool>(nameof(UseAttachedFlyout), true);
+
+    /// <summary>
+    /// Identifies the <see cref="HandleEvent"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> HandleEventProperty =
+        AvaloniaProperty.Register<ClickEventTrigger, bool>(nameof(HandleEvent), true);
+
+    /// <summary>
+    /// Gets or sets how this trigger reacts to pointer and keyboard clicks.
+    /// </summary>
+    public ClickMode ClickMode
+    {
+        get => GetValue(ClickModeProperty);
+        set => SetValue(ClickModeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets required key modifiers for click execution.
+    /// </summary>
+    public KeyModifiers? KeyModifiers
+    {
+        get => GetValue(KeyModifiersProperty);
+        set => SetValue(KeyModifiersProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether Enter on the visual root should invoke this trigger.
+    /// </summary>
+    public bool IsDefault
+    {
+        get => GetValue(IsDefaultProperty);
+        set => SetValue(IsDefaultProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether Escape on the visual root should invoke this trigger.
+    /// </summary>
+    public bool IsCancel
+    {
+        get => GetValue(IsCancelProperty);
+        set => SetValue(IsCancelProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets an explicit flyout instance used for toggle-on-click behavior.
+    /// </summary>
+    [ResolveByName]
+    public FlyoutBase? Flyout
+    {
+        get => GetValue(FlyoutProperty);
+        set => SetValue(FlyoutProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether to fallback to <see cref="FlyoutBase.AttachedFlyoutProperty"/> when <see cref="Flyout"/> is not set.
+    /// </summary>
+    public bool UseAttachedFlyout
+    {
+        get => GetValue(UseAttachedFlyoutProperty);
+        set => SetValue(UseAttachedFlyoutProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether handled semantics should be applied to routed events.
+    /// </summary>
+    public bool HandleEvent
+    {
+        get => GetValue(HandleEventProperty);
+        set => SetValue(HandleEventProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree()
+    {
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Bubble);
+            AssociatedObject.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Bubble);
+            AssociatedObject.AddHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost, RoutingStrategies.Direct);
+            AssociatedObject.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Bubble);
+            AssociatedObject.AddHandler(InputElement.KeyUpEvent, OnKeyUp, RoutingStrategies.Bubble);
+            AssociatedObject.AddHandler(InputElement.LostFocusEvent, OnLostFocus, RoutingStrategies.Bubble);
+
+            UpdateRootSubscription();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        DetachRootSubscription();
+
+        if (AssociatedObject is not null)
+        {
+            AssociatedObject.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);
+            AssociatedObject.RemoveHandler(InputElement.PointerReleasedEvent, OnPointerReleased);
+            AssociatedObject.RemoveHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost);
+            AssociatedObject.RemoveHandler(InputElement.KeyDownEvent, OnKeyDown);
+            AssociatedObject.RemoveHandler(InputElement.KeyUpEvent, OnKeyUp);
+            AssociatedObject.RemoveHandler(InputElement.LostFocusEvent, OnLostFocus);
+        }
+
+        _isPressed = false;
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == IsDefaultProperty || change.Property == IsCancelProperty)
+        {
+            UpdateRootSubscription();
+        }
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (AssociatedObject is not { IsEffectivelyEnabled: true } associatedObject
+            || !e.GetCurrentPoint(associatedObject).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        if (IsFlyoutOpenForAssociatedObject())
+        {
+            SetHandled(e);
+            ExecuteClick(e.KeyModifiers);
+            return;
+        }
+
+        _isPressed = true;
+        e.Pointer?.Capture(associatedObject);
+        SetHandled(e);
+
+        if (ClickMode == ClickMode.Press)
+        {
+            ExecuteClick(e.KeyModifiers);
+        }
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_isPressed && e.InitialPressMouseButton == MouseButton.Left)
+        {
+            _isPressed = false;
+            e.Pointer?.Capture(null);
+            SetHandled(e);
+
+            if (ClickMode == ClickMode.Release && IsPointerWithinAssociatedObject(e))
+            {
+                ExecuteClick(e.KeyModifiers);
+            }
+        }
+    }
+
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        _isPressed = false;
+    }
+
+    private void OnLostFocus(object? sender, RoutedEventArgs e)
+    {
+        _isPressed = false;
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (AssociatedObject is not { IsEffectivelyEnabled: true } associatedObject)
+        {
+            return;
+        }
+
+        switch (e.Key)
+        {
+            case Key.Enter:
+                if (associatedObject.IsFocused && ExecuteClick(e.KeyModifiers))
+                {
+                    SetHandled(e);
+                }
+                break;
+            case Key.Space:
+                if (associatedObject.IsFocused)
+                {
+                    if (ClickMode == ClickMode.Press)
+                    {
+                        ExecuteClick(e.KeyModifiers);
+                    }
+
+                    _isPressed = true;
+                    SetHandled(e);
+                }
+                break;
+            case Key.Escape:
+                if (TryGetResolvedFlyout() is { } flyout && IsFlyoutOpenForAssociatedObject(flyout))
+                {
+                    flyout.Hide();
+                }
+                break;
+        }
+    }
+
+    private void OnKeyUp(object? sender, KeyEventArgs e)
+    {
+        if (AssociatedObject is not { IsEffectivelyEnabled: true } associatedObject)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Space && associatedObject.IsFocused)
+        {
+            if (ClickMode == ClickMode.Release)
+            {
+                ExecuteClick(e.KeyModifiers);
+            }
+
+            _isPressed = false;
+            SetHandled(e);
+        }
+    }
+
+    private void OnRootKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (AssociatedObject is null
+            || (!IsDefault && !IsCancel)
+            || !AssociatedObject.IsEffectivelyVisible
+            || !AssociatedObject.IsEffectivelyEnabled
+            || IsSourceInsideAssociatedObject(e.Source))
+        {
+            return;
+        }
+
+        if (IsDefault && e.Key == Key.Enter && ExecuteClick(e.KeyModifiers))
+        {
+            SetHandled(e);
+        }
+        else if (IsCancel && e.Key == Key.Escape && ExecuteClick(e.KeyModifiers))
+        {
+            SetHandled(e);
+        }
+    }
+
+    private bool ExecuteClick(KeyModifiers currentModifiers)
+    {
+        if (!IsEnabled || AssociatedObject is not { IsEffectivelyEnabled: true } associatedObject || !MatchesModifiers(currentModifiers))
+        {
+            return false;
+        }
+
+        ToggleFlyout(associatedObject);
+
+        var clickArgs = new RoutedEventArgs(Button.ClickEvent, associatedObject);
+        Interaction.ExecuteActions(associatedObject, Actions, clickArgs);
+        return true;
+    }
+
+    private void ToggleFlyout(Control associatedObject)
+    {
+        var flyout = TryGetResolvedFlyout();
+        if (flyout is null)
+        {
+            return;
+        }
+
+        if (IsFlyoutOpenForAssociatedObject(flyout))
+        {
+            flyout.Hide();
+        }
+        else
+        {
+            flyout.ShowAt(associatedObject);
+        }
+    }
+
+    private FlyoutBase? TryGetResolvedFlyout()
+    {
+        if (Flyout is not null)
+        {
+            return Flyout;
+        }
+
+        return UseAttachedFlyout && AssociatedObject is not null
+            ? FlyoutBase.GetAttachedFlyout(AssociatedObject)
+            : null;
+    }
+
+    private bool IsFlyoutOpenForAssociatedObject()
+    {
+        return IsFlyoutOpenForAssociatedObject(TryGetResolvedFlyout());
+    }
+
+    private bool IsFlyoutOpenForAssociatedObject(FlyoutBase? flyout)
+    {
+        return flyout is not null
+               && flyout.IsOpen
+               && ReferenceEquals(flyout.Target, AssociatedObject);
+    }
+
+    private bool IsPointerWithinAssociatedObject(PointerReleasedEventArgs e)
+    {
+        if (AssociatedObject is null)
+        {
+            return false;
+        }
+
+        var position = e.GetPosition(AssociatedObject);
+        foreach (var visual in AssociatedObject.GetVisualsAt(position))
+        {
+            if (ReferenceEquals(visual, AssociatedObject) || AssociatedObject.IsVisualAncestorOf(visual))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool MatchesModifiers(KeyModifiers currentModifiers)
+    {
+        var requiredModifiers = KeyModifiers;
+        return requiredModifiers is null || requiredModifiers.Value == currentModifiers;
+    }
+
+    private bool IsSourceInsideAssociatedObject(object? source)
+    {
+        if (AssociatedObject is null || source is not Visual sourceVisual)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(sourceVisual, AssociatedObject) || AssociatedObject.IsVisualAncestorOf(sourceVisual);
+    }
+
+    private void SetHandled(RoutedEventArgs e)
+    {
+        if (HandleEvent)
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void UpdateRootSubscription()
+    {
+        if (AssociatedObject is null)
+        {
+            return;
+        }
+
+        if (!IsDefault && !IsCancel)
+        {
+            DetachRootSubscription();
+            return;
+        }
+
+        var rootInputElement = AssociatedObject.GetVisualRoot() as IInputElement;
+        if (ReferenceEquals(_rootInputElement, rootInputElement))
+        {
+            return;
+        }
+
+        DetachRootSubscription();
+
+        if (rootInputElement is null)
+        {
+            return;
+        }
+
+        _rootInputElement = rootInputElement;
+        _rootInputElement.AddHandler(InputElement.KeyDownEvent, OnRootKeyDown);
+    }
+
+    private void DetachRootSubscription()
+    {
+        if (_rootInputElement is null)
+        {
+            return;
+        }
+
+        _rootInputElement.RemoveHandler(InputElement.KeyDownEvent, OnRootKeyDown);
+        _rootInputElement = null;
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml
@@ -1,0 +1,87 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:custom="clr-namespace:Avalonia.Xaml.Interactions.UnitTests.Custom"
+        xmlns:primitives="using:Avalonia.Controls.Primitives"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Custom.ClickEventTrigger001"
+        x:DataType="custom:ClickEventTrigger001"
+        Title="ClickEventTrigger001"
+        Width="1000"
+        Height="800">
+  <StackPanel Margin="10" Spacing="8">
+    <TextBox Name="FocusSource" Width="420" Text="Focus source for root key handling" />
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <Border Name="ReleaseTarget" Width="220" Height="70" Background="LightSteelBlue" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger ClickMode="Release">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnReleaseClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+      <Border Name="OutsideTarget" Width="220" Height="70" Background="LightGray" Focusable="True" />
+    </StackPanel>
+
+    <Border Name="PressTarget" Width="220" Height="70" Background="PeachPuff" Focusable="True">
+      <Interaction.Behaviors>
+        <ClickEventTrigger ClickMode="Press" HandleEvent="False">
+          <CallMethodAction TargetObject="{Binding}" MethodName="OnPressClicked" />
+        </ClickEventTrigger>
+      </Interaction.Behaviors>
+    </Border>
+
+    <Border Name="ModifierTarget" Width="220" Height="70" Background="LightGoldenrodYellow" Focusable="True">
+      <Interaction.Behaviors>
+        <ClickEventTrigger KeyModifiers="Control">
+          <CallMethodAction TargetObject="{Binding}" MethodName="OnModifierClicked" />
+        </ClickEventTrigger>
+      </Interaction.Behaviors>
+    </Border>
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <Border Name="SpaceReleaseTarget" Width="220" Height="70" Background="AliceBlue" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger ClickMode="Release">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnSpaceReleaseClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+      <Border Name="SpacePressTarget" Width="220" Height="70" Background="LavenderBlush" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger ClickMode="Press">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnSpacePressClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <Border Name="DefaultTarget" Width="220" Height="70" Background="Honeydew" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger IsDefault="True">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnDefaultClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+      <Border Name="CancelTarget" Width="220" Height="70" Background="MistyRose" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger IsCancel="True">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnCancelClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+    </StackPanel>
+
+    <Border Name="FlyoutTarget" Width="260" Height="70" Background="Thistle" Focusable="True">
+      <primitives:FlyoutBase.AttachedFlyout>
+        <Flyout OverlayDismissEventPassThrough="True">
+          <TextBlock Margin="10" Text="Flyout content" />
+        </Flyout>
+      </primitives:FlyoutBase.AttachedFlyout>
+      <Interaction.Behaviors>
+        <ClickEventTrigger>
+          <CallMethodAction TargetObject="{Binding}" MethodName="OnFlyoutClicked" />
+        </ClickEventTrigger>
+      </Interaction.Behaviors>
+    </Border>
+  </StackPanel>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml
@@ -38,6 +38,17 @@
     </Border>
 
     <StackPanel Orientation="Horizontal" Spacing="8">
+      <Border Name="SourceControlSourceTarget" Width="220" Height="70" Background="LightCyan" Focusable="True" />
+      <Border Name="SourceControlHostTarget" Width="220" Height="70" Background="PowderBlue" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger SourceControl="SourceControlSourceTarget">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnSourceControlClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
       <Border Name="SpaceReleaseTarget" Width="220" Height="70" Background="AliceBlue" Focusable="True">
         <Interaction.Behaviors>
           <ClickEventTrigger ClickMode="Release">

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public partial class ClickEventTrigger001 : Window
+{
+    public int ReleaseClicks { get; private set; }
+    public int PressClicks { get; private set; }
+    public int ModifierClicks { get; private set; }
+    public int SpaceReleaseClicks { get; private set; }
+    public int SpacePressClicks { get; private set; }
+    public int DefaultClicks { get; private set; }
+    public int CancelClicks { get; private set; }
+    public int FlyoutClicks { get; private set; }
+
+    public ClickEventTrigger001()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+
+    public void OnReleaseClicked() => ReleaseClicks++;
+
+    public void OnPressClicked() => PressClicks++;
+
+    public void OnModifierClicked() => ModifierClicks++;
+
+    public void OnSpaceReleaseClicked() => SpaceReleaseClicks++;
+
+    public void OnSpacePressClicked() => SpacePressClicks++;
+
+    public void OnDefaultClicked() => DefaultClicks++;
+
+    public void OnCancelClicked() => CancelClicks++;
+
+    public void OnFlyoutClicked() => FlyoutClicks++;
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
@@ -7,6 +7,7 @@ public partial class ClickEventTrigger001 : Window
     public int ReleaseClicks { get; private set; }
     public int PressClicks { get; private set; }
     public int ModifierClicks { get; private set; }
+    public int SourceControlClicks { get; private set; }
     public int SpaceReleaseClicks { get; private set; }
     public int SpacePressClicks { get; private set; }
     public int DefaultClicks { get; private set; }
@@ -24,6 +25,8 @@ public partial class ClickEventTrigger001 : Window
     public void OnPressClicked() => PressClicks++;
 
     public void OnModifierClicked() => ModifierClicks++;
+
+    public void OnSourceControlClicked() => SourceControlClicks++;
 
     public void OnSpaceReleaseClicked() => SpaceReleaseClicks++;
 

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -1,0 +1,166 @@
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class ClickEventTriggerTests
+{
+    [AvaloniaFact]
+    public void ClickEventTrigger_ReleaseMode_DoesNotFireWhenReleasedOutside()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.MouseDown(window.ReleaseTarget, new Point(10, 10), MouseButton.Left);
+        window.MouseUp(window.OutsideTarget, new Point(10, 10), MouseButton.Left);
+
+        Assert.Equal(0, window.ReleaseClicks);
+
+        window.Click(window.ReleaseTarget);
+
+        Assert.Equal(1, window.ReleaseClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_ReleaseMode_DoesNotLeakPressedStateAcrossInteractions()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.MouseDown(window.ReleaseTarget, new Point(10, 10), MouseButton.Left);
+        window.MouseUp(window.OutsideTarget, new Point(10, 10), MouseButton.Left);
+        Assert.Equal(0, window.ReleaseClicks);
+
+        window.MouseDown(window.OutsideTarget, new Point(10, 10), MouseButton.Left);
+        window.MouseUp(window.ReleaseTarget, new Point(10, 10), MouseButton.Left);
+        Assert.Equal(0, window.ReleaseClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_PressMode_FiresOnPointerDown()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.MouseDown(window.PressTarget, new Point(10, 10), MouseButton.Left);
+
+        Assert.Equal(1, window.PressClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_KeyModifiers_FilterBlocksAndAllows()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.Click(window.ModifierTarget);
+        Assert.Equal(0, window.ModifierClicks);
+
+        window.Click(window.ModifierTarget, MouseButton.Left, RawInputModifiers.Control);
+        Assert.Equal(1, window.ModifierClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_SpaceHandling_WorksForPressAndReleaseModes()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.SpaceReleaseTarget.Focus();
+        window.SpaceReleaseTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.SpaceReleaseTarget
+        });
+        window.SpaceReleaseTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.SpaceReleaseTarget
+        });
+        Assert.Equal(1, window.SpaceReleaseClicks);
+
+        window.SpacePressTarget.Focus();
+        window.SpacePressTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.SpacePressTarget
+        });
+        window.SpacePressTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.SpacePressTarget
+        });
+        Assert.Equal(1, window.SpacePressClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_IsDefault_RootEnter_TriggersAndDoesNotDuplicate()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.FocusSource.Focus();
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Assert.Equal(1, window.DefaultClicks);
+
+        window.DefaultTarget.Focus();
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Assert.Equal(2, window.DefaultClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_IsCancel_RootEscape_TriggersAndDoesNotDuplicate()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.FocusSource.Focus();
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+        Assert.Equal(1, window.CancelClicks);
+
+        window.CancelTarget.Focus();
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+        Assert.Equal(1, window.CancelClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_Flyout_TogglesOpenAndClose()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        var flyout = FlyoutBase.GetAttachedFlyout(window.FlyoutTarget);
+        Assert.NotNull(flyout);
+        Assert.False(flyout!.IsOpen);
+
+        window.Click(window.FlyoutTarget);
+
+        Assert.True(flyout.IsOpen);
+        Assert.Equal(1, window.FlyoutClicks);
+
+        window.Click(window.FlyoutTarget);
+
+        Assert.False(flyout.IsOpen);
+        Assert.Equal(2, window.FlyoutClicks);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -69,6 +69,20 @@ public class ClickEventTriggerTests
     }
 
     [AvaloniaFact]
+    public void ClickEventTrigger_SourceControl_UsesExternalSourceControl()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.Click(window.SourceControlHostTarget);
+        Assert.Equal(0, window.SourceControlClicks);
+
+        window.Click(window.SourceControlSourceTarget);
+        Assert.Equal(1, window.SourceControlClicks);
+    }
+
+    [AvaloniaFact]
     public void ClickEventTrigger_SpaceHandling_WorksForPressAndReleaseModes()
     {
         var window = new ClickEventTrigger001();

--- a/tools/CheckDocs/Program.cs
+++ b/tools/CheckDocs/Program.cs
@@ -20,12 +20,12 @@ class Program
         MSBuildLocator.RegisterDefaults();
 
         var rootDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
-        var solutionPath = Path.Combine(rootDir, "AvaloniaBehaviors.sln");
+        var solutionPath = ResolveSolutionPath(rootDir);
         var docsPath = Path.Combine(rootDir, "docfx/articles");
 
-        if (!File.Exists(solutionPath))
+        if (solutionPath is null)
         {
-            Console.WriteLine($"Error: Solution not found at {solutionPath}");
+            Console.WriteLine($"Error: Solution not found at {Path.Combine(rootDir, "AvaloniaBehaviors.sln")} or {Path.Combine(rootDir, "AvaloniaBehaviors.slnx")}");
             return;
         }
 
@@ -169,5 +169,22 @@ class Program
     static string ToKebabCase(string name)
     {
         return Regex.Replace(name, "(?<!^)([A-Z][a-z]|(?<=[a-z])[A-Z])", "-$1").ToLower();
+    }
+
+    static string? ResolveSolutionPath(string rootDir)
+    {
+        var slnPath = Path.Combine(rootDir, "AvaloniaBehaviors.sln");
+        if (File.Exists(slnPath))
+        {
+            return slnPath;
+        }
+
+        var slnxPath = Path.Combine(rootDir, "AvaloniaBehaviors.slnx");
+        if (File.Exists(slnxPath))
+        {
+            return slnxPath;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
# PR Summary: `ClickEventTrigger` with Button-Like Semantics + `SourceControl` API

## Branch
- Feature branch: `feature/click-event-trigger`
- Base branch: `master`

## Motivation
Non-button controls in Avalonia do not expose `Click` semantics directly.  
This PR adds `ClickEventTrigger` so any `Control` can execute actions/commands with button-like pointer and keyboard behavior.

## Scope
This PR delivers:
- `ClickEventTrigger` in `Xaml.Behaviors.Interactions.Custom`.
- Headless unit tests for click semantics and source redirection.
- Sample page scenarios (including MVVM open/save picker integration).
- Documentation for API and usage.
- `CheckDocs` compatibility with `.slnx` repositories.

This PR intentionally does **not** add `ClickEventBehavior` alias type.

## Breaking API Change
`ClickEventTrigger` source redirection is now:
- `SourceControl` (`Control?`, `[ResolveByName]`)

Removed:
- `SourceObject` (`object?`)
- `SourceInputElement` (if present in local iterations)

Behavior:
- If `SourceControl` is set, click handling and action execution use that control.
- If unset, behavior defaults to `AssociatedObject`.

Migration:
- Replace `SourceObject="SomeControl"` with `SourceControl="SomeControl"` in XAML.

## Runtime Implementation
**File:** `src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs`

Implemented button-like click emulation on `StyledElementTrigger<Control>` with:
- `ClickMode` (`Release`/`Press`)
- exact `KeyModifiers` filter (`null` means no filter)
- `IsDefault` / `IsCancel` root key handling
- `Flyout` + `UseAttachedFlyout` toggle behavior
- `HandleEvent` handled-state control
- `SourceControl`-based source resolution and handler wiring
- normalized action args: `new RoutedEventArgs(Button.ClickEvent, resolvedSourceControl)`

Semantics preserved:
- left-button pointer click rules
- release-inside hit testing
- space/enter keyboard activation
- pressed-state reset on capture lost / focus lost
- duplicate suppression for root Enter/Escape when key source is inside source subtree

## Tests
**Files:**
- `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml`
- `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs`
- `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs`

Coverage includes:
- release mode outside-target suppression
- press mode pointer-down activation
- key-modifier filter allow/block
- space press/release behavior by click mode
- default/cancel root handling with duplicate suppression
- flyout open/close toggling
- pressed-state leakage regression
- `SourceControl` external-source routing (`host` does not fire, source does fire)

## Sample Updates
**File:** `samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml`

Sample page now demonstrates:
- `ClickMode=Release` and `ClickMode=Press`
- `KeyModifiers`
- `IsDefault` / `IsCancel`
- flyout toggling
- `SourceControl` external source scenario
- MVVM open/save picker actions:
  - `OpenFilePickerAction` -> `OpenFilesCommand`
  - `SaveFilePickerAction` -> `SaveFileCommand`

## Documentation Updates
**File:** `docfx/articles/interactions-custom/input-element/click-event-trigger.md`

Updated docs to:
- document `SourceControl` (`Control?`) in the property table
- describe fallback to `AssociatedObject`
- include a `SourceControl` example
- keep open/save picker MVVM examples

## Validation
Executed on `feature/click-event-trigger`:

1. `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --filter "FullyQualifiedName~ClickEventTriggerTests"`
- Passed: 9
- Failed: 0
- Skipped: 0

2. `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj`
- Passed: 29
- Failed: 0
- Skipped: 2

3. `dotnet build samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj`
- Build succeeded with 0 warnings, 0 errors.

4. `dotnet run --project tools/CheckDocs/CheckDocs.csproj`
- Completed successfully.
- Output ends with: `All classes appear to be documented!`

## Notes
- Existing external warnings during validation:
  - `NU1701` warnings from `CheckDocs` dependencies.
  - Existing obsolete drag-and-drop API warnings during test build.
- These warnings are outside this feature’s scope.
