### PR TITLE
doc(list-reorder-drag-behavior): Update Usage detail to reflect actua…

### DIFF
--- a/docfx/articles/draggable/list-reorder-drag-behavior.md
+++ b/docfx/articles/draggable/list-reorder-drag-behavior.md
@@ -12,13 +12,21 @@
 
 ## Usage
 
-Attach the behavior to the `ItemsControl`.
+Attach the behavior to individual items of the `ItemsControl`.
 
 ```xml
 <ListBox ItemsSource="{Binding Items}">
-    <Interaction.Behaviors>
-        <ListReorderDragBehavior />
-    </Interaction.Behaviors>
+    <ListBox.Styles>
+        <Style Selector="ListBoxItem">
+            <Setter Property="(Interaction.Behaviors)">
+                <BehaviorCollectionTemplate>
+                    <BehaviorCollection>
+                        <ListReorderDragBehavior Orientation="Vertical" />
+                    </BehaviorCollection>
+                </BehaviorCollectionTemplate>
+            </Setter>
+        </Style>
+    </ListBox.Styles>
     
     <ListBox.ItemTemplate>
         <DataTemplate>


### PR DESCRIPTION
…l implementation

Originally, ListReorderDragBehaviour was instructed to be applied on the ListBox itself, which is not correct and should be applied to the individual ListBoxItem instead (as seen in the sample application)