### PR TITLE
 ClickEventTrigger `HandledEventsToo` + `HandleEvent=False` Scenarios

### DIFF
--- a/docfx/articles/interactions-custom/input-element/click-event-trigger.md
+++ b/docfx/articles/interactions-custom/input-element/click-event-trigger.md
@@ -41,6 +41,18 @@ Use these two properties together depending on the behavior you need:
 
 `SourceControl` and `HandledEventsToo` are safe to change at runtime. The trigger reattaches its handlers automatically when either value changes.
 
+### Pointer Capture Guidance
+
+`ClickEventTrigger` now avoids pointer capture for `TextBox` sources and for non-invasive mode (`HandleEvent="False"`).
+
+Use this guidance:
+
+* If your source is editable (for example `TextBox`) and you need native drag-selection/caret behavior, set `HandleEvent="False"`.
+* If upstream handlers may mark events handled and you still want trigger actions, add `HandledEventsToo="True"`.
+* For non-editable controls, keep defaults unless you explicitly need native behavior to win.
+
+This prevents the trigger from stealing pointer ownership in text-editing scenarios while preserving action execution.
+
 ## Example
 
 ```xml

--- a/docfx/articles/interactions-custom/input-element/overview.md
+++ b/docfx/articles/interactions-custom/input-element/overview.md
@@ -24,4 +24,4 @@ The `InputElement` category contains the following interactions:
 * [TextInputMethodClientRequestedTrigger](text-input-method-client-requested-trigger.md)
 * [TextInputTrigger](text-input-trigger.md)
 
-The `ClickEventTrigger` article includes end-to-end examples that combine click emulation with `OpenFilePickerAction` and `SaveFilePickerAction`, wired to MVVM commands.
+The `ClickEventTrigger` article includes end-to-end examples for click emulation, `SourceControl`, `HandleEvent`/`HandledEventsToo` event-routing strategies, and picker actions wired to MVVM commands.

--- a/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
@@ -112,7 +112,7 @@
       <TextBlock Name="SourceControlStatus" Text="SourceControl status: click the source target." />
 
       <TextBlock FontWeight="Bold" Text="HandledEventsToo" />
-      <TextBlock Text="Source controls use HandleEvent=False so native control behavior remains intact." />
+      <TextBlock Text="Source controls use HandleEvent=False so native control behavior remains intact (for TextBox, drag-selection still works)." />
       <StackPanel Orientation="Horizontal" Spacing="8">
         <Button Name="HandledEventsTooSourceTarget"
                 Width="300"
@@ -124,6 +124,11 @@
                                     PropertyName="Text"
                                     Value="Button source trigger fired with HandleEvent=False." />
             </ClickEventTrigger>
+            <RoutedEventTriggerBehavior RoutedEvent="{x:Static Button.ClickEvent}">
+              <ChangePropertyAction TargetObject="HandledEventsTooButtonSourceClickEventStatus"
+                                    PropertyName="Text"
+                                    Value="Button source raised Button.ClickEvent." />
+            </RoutedEventTriggerBehavior>
           </Interaction.Behaviors>
         </Button>
 
@@ -146,6 +151,7 @@
         </Border>
       </StackPanel>
       <TextBlock Name="HandledEventsTooButtonSourceStatus" Text="Button source status: waiting..." />
+      <TextBlock Name="HandledEventsTooButtonSourceClickEventStatus" Text="Button source click-event status: waiting..." />
       <TextBlock Name="HandledEventsTooButtonHostStatus" Text="Button host status: waiting..." />
 
       <StackPanel Orientation="Horizontal" Spacing="8">
@@ -158,6 +164,11 @@
                                     PropertyName="Text"
                                     Value="TextBox source trigger fired with HandleEvent=False." />
             </ClickEventTrigger>
+            <RoutedEventTriggerBehavior RoutedEvent="{x:Static Button.ClickEvent}">
+              <ChangePropertyAction TargetObject="HandledEventsTooTextBoxSourceClickEventStatus"
+                                    PropertyName="Text"
+                                    Value="TextBox source raised Button.ClickEvent." />
+            </RoutedEventTriggerBehavior>
           </Interaction.Behaviors>
         </TextBox>
 
@@ -180,6 +191,7 @@
         </Border>
       </StackPanel>
       <TextBlock Name="HandledEventsTooTextBoxSourceStatus" Text="TextBox source status: waiting..." />
+      <TextBlock Name="HandledEventsTooTextBoxSourceClickEventStatus" Text="TextBox source click-event status: waiting..." />
       <TextBlock Name="HandledEventsTooTextBoxHostStatus" Text="TextBox host status: waiting..." />
 
       <TextBlock FontWeight="Bold" Text="IsDefault / IsCancel" />

--- a/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml
@@ -111,6 +111,77 @@
       </StackPanel>
       <TextBlock Name="SourceControlStatus" Text="SourceControl status: click the source target." />
 
+      <TextBlock FontWeight="Bold" Text="HandledEventsToo" />
+      <TextBlock Text="Source controls use HandleEvent=False so native control behavior remains intact." />
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Button Name="HandledEventsTooSourceTarget"
+                Width="300"
+                Height="48"
+                Content="HandledEventsToo button source">
+          <Interaction.Behaviors>
+            <ClickEventTrigger HandleEvent="False" HandledEventsToo="True">
+              <ChangePropertyAction TargetObject="HandledEventsTooButtonSourceStatus"
+                                    PropertyName="Text"
+                                    Value="Button source trigger fired with HandleEvent=False." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+        </Button>
+
+        <Border Name="HandledEventsTooHostTarget"
+                Width="300"
+                Height="72"
+                Background="LightSkyBlue"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger SourceControl="HandledEventsTooSourceTarget" HandledEventsToo="True">
+              <ChangePropertyAction TargetObject="HandledEventsTooButtonHostStatus"
+                                    PropertyName="Text"
+                                    Value="HandledEventsToo host fired from the button source." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Host target (Button source)" />
+        </Border>
+      </StackPanel>
+      <TextBlock Name="HandledEventsTooButtonSourceStatus" Text="Button source status: waiting..." />
+      <TextBlock Name="HandledEventsTooButtonHostStatus" Text="Button host status: waiting..." />
+
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <TextBox Name="HandledEventsTooTextBoxSourceTarget"
+                 Width="300"
+                 Text="HandledEventsToo TextBox source (click me)">
+          <Interaction.Behaviors>
+            <ClickEventTrigger HandleEvent="False" HandledEventsToo="True">
+              <ChangePropertyAction TargetObject="HandledEventsTooTextBoxSourceStatus"
+                                    PropertyName="Text"
+                                    Value="TextBox source trigger fired with HandleEvent=False." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+        </TextBox>
+
+        <Border Name="HandledEventsTooTextBoxHostTarget"
+                Width="300"
+                Height="72"
+                Background="CadetBlue"
+                CornerRadius="4"
+                Focusable="True">
+          <Interaction.Behaviors>
+            <ClickEventTrigger SourceControl="HandledEventsTooTextBoxSourceTarget" HandledEventsToo="True">
+              <ChangePropertyAction TargetObject="HandledEventsTooTextBoxHostStatus"
+                                    PropertyName="Text"
+                                    Value="HandledEventsToo host fired from the TextBox source." />
+            </ClickEventTrigger>
+          </Interaction.Behaviors>
+          <TextBlock HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     Text="Host target (TextBox source)" />
+        </Border>
+      </StackPanel>
+      <TextBlock Name="HandledEventsTooTextBoxSourceStatus" Text="TextBox source status: waiting..." />
+      <TextBlock Name="HandledEventsTooTextBoxHostStatus" Text="TextBox host status: waiting..." />
+
       <TextBlock FontWeight="Bold" Text="IsDefault / IsCancel" />
       <TextBlock Text="Focus the TextBox and press Enter or Escape." />
       <TextBox Name="KeyboardSource"

--- a/src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs
@@ -246,8 +246,11 @@ public class ClickEventTrigger : StyledElementTrigger<Control>
 
     private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
-        _isPressed = false;
-        _ownsPointerCapture = false;
+        if (_ownsPointerCapture)
+        {
+            _isPressed = false;
+            _ownsPointerCapture = false;
+        }
     }
 
     private void OnLostFocus(object? sender, RoutedEventArgs e)

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml
@@ -49,6 +49,46 @@
     </StackPanel>
 
     <StackPanel Orientation="Horizontal" Spacing="8">
+      <Button Name="HandledEventsTooSourceTarget" Width="220" Height="36" Content="HandledEventsToo button source" />
+      <Border Name="HandledEventsTooHostTarget" Width="220" Height="70" Background="SkyBlue" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger SourceControl="HandledEventsTooSourceTarget">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnHandledEventsTooClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <TextBox Name="HandledEventsTooTextBoxSourceTarget" Width="220" Text="HandledEventsToo TextBox source" />
+      <Border Name="HandledEventsTooTextBoxHostTarget" Width="220" Height="70" Background="CadetBlue" Focusable="True">
+        <Interaction.Behaviors>
+          <ClickEventTrigger SourceControl="HandledEventsTooTextBoxSourceTarget">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnHandledEventsTooTextBoxClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Border>
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <Button Name="HandleEventFalseButtonTarget" Width="220" Height="36" Content="HandleEvent=False button">
+        <Interaction.Behaviors>
+          <ClickEventTrigger HandleEvent="False" HandledEventsToo="True">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnHandleEventFalseButtonClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </Button>
+
+      <TextBox Name="HandleEventFalseTextBoxTarget" Width="220" Text="HandleEvent=False TextBox">
+        <Interaction.Behaviors>
+          <ClickEventTrigger HandleEvent="False" HandledEventsToo="True">
+            <CallMethodAction TargetObject="{Binding}" MethodName="OnHandleEventFalseTextBoxClicked" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+      </TextBox>
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Spacing="8">
       <Border Name="SpaceReleaseTarget" Width="220" Height="70" Background="AliceBlue" Focusable="True">
         <Interaction.Behaviors>
           <ClickEventTrigger ClickMode="Release">

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
@@ -1,4 +1,7 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
 
@@ -8,6 +11,12 @@ public partial class ClickEventTrigger001 : Window
     public int PressClicks { get; private set; }
     public int ModifierClicks { get; private set; }
     public int SourceControlClicks { get; private set; }
+    public int HandledEventsTooClicks { get; private set; }
+    public int HandledEventsTooTextBoxClicks { get; private set; }
+    public int HandleEventFalseButtonClicks { get; private set; }
+    public int HandleEventFalseTextBoxClicks { get; private set; }
+    public int HandleEventFalseButtonNativeClicks { get; private set; }
+    public int HandleEventFalseTextBoxBubbledKeyUp { get; private set; }
     public int SpaceReleaseClicks { get; private set; }
     public int SpacePressClicks { get; private set; }
     public int DefaultClicks { get; private set; }
@@ -18,6 +27,28 @@ public partial class ClickEventTrigger001 : Window
     {
         InitializeComponent();
         DataContext = this;
+        HandleEventFalseButtonTarget.Click += OnHandleEventFalseButtonNativeClick;
+
+        AddHandler(
+            InputElement.PointerPressedEvent,
+            OnHandledEventsTooWindowPointerPressed,
+            RoutingStrategies.Tunnel);
+        AddHandler(
+            InputElement.PointerReleasedEvent,
+            OnHandledEventsTooWindowPointerReleased,
+            RoutingStrategies.Tunnel);
+        AddHandler(
+            InputElement.KeyDownEvent,
+            OnHandledEventsTooWindowKeyDown,
+            RoutingStrategies.Tunnel);
+        AddHandler(
+            InputElement.KeyUpEvent,
+            OnHandledEventsTooWindowKeyUp,
+            RoutingStrategies.Tunnel);
+        AddHandler(
+            InputElement.KeyUpEvent,
+            OnHandleEventFalseWindowKeyUp,
+            RoutingStrategies.Bubble);
     }
 
     public void OnReleaseClicked() => ReleaseClicks++;
@@ -28,6 +59,14 @@ public partial class ClickEventTrigger001 : Window
 
     public void OnSourceControlClicked() => SourceControlClicks++;
 
+    public void OnHandledEventsTooClicked() => HandledEventsTooClicks++;
+
+    public void OnHandledEventsTooTextBoxClicked() => HandledEventsTooTextBoxClicks++;
+
+    public void OnHandleEventFalseButtonClicked() => HandleEventFalseButtonClicks++;
+
+    public void OnHandleEventFalseTextBoxClicked() => HandleEventFalseTextBoxClicks++;
+
     public void OnSpaceReleaseClicked() => SpaceReleaseClicks++;
 
     public void OnSpacePressClicked() => SpacePressClicks++;
@@ -37,4 +76,65 @@ public partial class ClickEventTrigger001 : Window
     public void OnCancelClicked() => CancelClicks++;
 
     public void OnFlyoutClicked() => FlyoutClicks++;
+
+    private void OnHandledEventsTooWindowPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (IsHandledEventsTooSource(e.Source))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void OnHandledEventsTooWindowPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (IsHandledEventsTooSource(e.Source))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void OnHandledEventsTooWindowKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Space && IsSourceInsideTarget(e.Source, HandledEventsTooTextBoxSourceTarget))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void OnHandledEventsTooWindowKeyUp(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Space && IsSourceInsideTarget(e.Source, HandledEventsTooTextBoxSourceTarget))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void OnHandleEventFalseWindowKeyUp(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Space && IsSourceInsideTarget(e.Source, HandleEventFalseTextBoxTarget))
+        {
+            HandleEventFalseTextBoxBubbledKeyUp++;
+        }
+    }
+
+    private void OnHandleEventFalseButtonNativeClick(object? sender, RoutedEventArgs e)
+    {
+        HandleEventFalseButtonNativeClicks++;
+    }
+
+    private bool IsHandledEventsTooSource(object? source)
+    {
+        return IsSourceInsideTarget(source, HandledEventsTooSourceTarget)
+            || IsSourceInsideTarget(source, HandledEventsTooTextBoxSourceTarget);
+    }
+
+    private static bool IsSourceInsideTarget(object? source, Visual target)
+    {
+        if (source is not Visual sourceVisual)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(sourceVisual, target) || target.IsVisualAncestorOf(sourceVisual);
+    }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs
@@ -16,6 +16,8 @@ public partial class ClickEventTrigger001 : Window
     public int HandleEventFalseButtonClicks { get; private set; }
     public int HandleEventFalseTextBoxClicks { get; private set; }
     public int HandleEventFalseButtonNativeClicks { get; private set; }
+    public int HandleEventFalseButtonClickEvents { get; private set; }
+    public int HandleEventFalseTextBoxClickEvents { get; private set; }
     public int HandleEventFalseTextBoxBubbledKeyUp { get; private set; }
     public int SpaceReleaseClicks { get; private set; }
     public int SpacePressClicks { get; private set; }
@@ -28,6 +30,8 @@ public partial class ClickEventTrigger001 : Window
         InitializeComponent();
         DataContext = this;
         HandleEventFalseButtonTarget.Click += OnHandleEventFalseButtonNativeClick;
+        HandleEventFalseButtonTarget.AddHandler(Button.ClickEvent, OnHandleEventFalseButtonClickEvent, RoutingStrategies.Bubble);
+        HandleEventFalseTextBoxTarget.AddHandler(Button.ClickEvent, OnHandleEventFalseTextBoxClickEvent, RoutingStrategies.Bubble);
 
         AddHandler(
             InputElement.PointerPressedEvent,
@@ -120,6 +124,22 @@ public partial class ClickEventTrigger001 : Window
     private void OnHandleEventFalseButtonNativeClick(object? sender, RoutedEventArgs e)
     {
         HandleEventFalseButtonNativeClicks++;
+    }
+
+    private void OnHandleEventFalseButtonClickEvent(object? sender, RoutedEventArgs e)
+    {
+        if (IsSourceInsideTarget(e.Source, HandleEventFalseButtonTarget))
+        {
+            HandleEventFalseButtonClickEvents++;
+        }
+    }
+
+    private void OnHandleEventFalseTextBoxClickEvent(object? sender, RoutedEventArgs e)
+    {
+        if (IsSourceInsideTarget(e.Source, HandleEventFalseTextBoxTarget))
+        {
+            HandleEventFalseTextBoxClickEvents++;
+        }
     }
 
     private bool IsHandledEventsTooSource(object? source)

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless;
@@ -201,6 +202,7 @@ public class ClickEventTriggerTests
 
         Assert.Equal(1, window.HandleEventFalseButtonClicks);
         Assert.Equal(1, window.HandleEventFalseButtonNativeClicks);
+        Assert.Equal(1, window.HandleEventFalseButtonClickEvents);
     }
 
     [AvaloniaFact]
@@ -227,7 +229,27 @@ public class ClickEventTriggerTests
         });
 
         Assert.Equal(1, window.HandleEventFalseTextBoxClicks);
+        Assert.Equal(1, window.HandleEventFalseTextBoxClickEvents);
         Assert.Equal(1, window.HandleEventFalseTextBoxBubbledKeyUp);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_HandleEventFalse_TextBox_AllowsPointerDragSelection()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        var textBox = window.HandleEventFalseTextBoxTarget;
+        textBox.Focus();
+        textBox.CaretIndex = 0;
+
+        var y = textBox.Bounds.Height / 2;
+        window.MouseDown(textBox, new Point(4, y), MouseButton.Left);
+        window.MouseMove(textBox, new Point(textBox.Bounds.Width - 6, y), RawInputModifiers.LeftMouseButton);
+        window.MouseUp(textBox, new Point(textBox.Bounds.Width - 6, y), MouseButton.Left);
+
+        Assert.True(Math.Abs(textBox.SelectionEnd - textBox.SelectionStart) > 0);
     }
 
     [AvaloniaFact]

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -1,8 +1,10 @@
+using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactions.Custom;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
@@ -80,6 +82,152 @@ public class ClickEventTriggerTests
 
         window.Click(window.SourceControlSourceTarget);
         Assert.Equal(1, window.SourceControlClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_HandledEventsToo_DefaultFalse_AndPropertyChange_RewiresHandlers_ForButtonAndTextBoxSources()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        var buttonTrigger = Avalonia.Xaml.Interactivity.Interaction.GetBehaviors(window.HandledEventsTooHostTarget)
+            .OfType<ClickEventTrigger>()
+            .Single();
+        var textBoxTrigger = Avalonia.Xaml.Interactivity.Interaction.GetBehaviors(window.HandledEventsTooTextBoxHostTarget)
+            .OfType<ClickEventTrigger>()
+            .Single();
+
+        Assert.False(buttonTrigger.HandledEventsToo);
+        Assert.False(textBoxTrigger.HandledEventsToo);
+
+        window.Click(window.HandledEventsTooSourceTarget);
+        Assert.Equal(0, window.HandledEventsTooClicks);
+        window.Click(window.HandledEventsTooTextBoxSourceTarget);
+        Assert.Equal(0, window.HandledEventsTooTextBoxClicks);
+
+        buttonTrigger.HandledEventsToo = true;
+        textBoxTrigger.HandledEventsToo = true;
+
+        window.Click(window.HandledEventsTooSourceTarget);
+        Assert.Equal(1, window.HandledEventsTooClicks);
+        window.Click(window.HandledEventsTooTextBoxSourceTarget);
+        Assert.Equal(1, window.HandledEventsTooTextBoxClicks);
+
+        buttonTrigger.HandledEventsToo = false;
+        textBoxTrigger.HandledEventsToo = false;
+
+        window.Click(window.HandledEventsTooSourceTarget);
+        Assert.Equal(1, window.HandledEventsTooClicks);
+        window.Click(window.HandledEventsTooTextBoxSourceTarget);
+        Assert.Equal(1, window.HandledEventsTooTextBoxClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_HandledEventsToo_AlsoControlsKeyboardHandlers()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        var textBoxTrigger = Avalonia.Xaml.Interactivity.Interaction.GetBehaviors(window.HandledEventsTooTextBoxHostTarget)
+            .OfType<ClickEventTrigger>()
+            .Single();
+
+        window.HandledEventsTooTextBoxSourceTarget.Focus();
+        window.HandledEventsTooTextBoxSourceTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandledEventsTooTextBoxSourceTarget
+        });
+        window.HandledEventsTooTextBoxSourceTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandledEventsTooTextBoxSourceTarget
+        });
+        Assert.Equal(0, window.HandledEventsTooTextBoxClicks);
+
+        textBoxTrigger.HandledEventsToo = true;
+
+        window.HandledEventsTooTextBoxSourceTarget.Focus();
+        window.HandledEventsTooTextBoxSourceTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandledEventsTooTextBoxSourceTarget
+        });
+        window.HandledEventsTooTextBoxSourceTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandledEventsTooTextBoxSourceTarget
+        });
+        Assert.Equal(1, window.HandledEventsTooTextBoxClicks);
+
+        textBoxTrigger.HandledEventsToo = false;
+
+        window.HandledEventsTooTextBoxSourceTarget.Focus();
+        window.HandledEventsTooTextBoxSourceTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandledEventsTooTextBoxSourceTarget
+        });
+        window.HandledEventsTooTextBoxSourceTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandledEventsTooTextBoxSourceTarget
+        });
+        Assert.Equal(1, window.HandledEventsTooTextBoxClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_HandleEventFalse_Button_PreservesNativeClick()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.Click(window.HandleEventFalseButtonTarget);
+
+        Assert.Equal(1, window.HandleEventFalseButtonClicks);
+        Assert.Equal(1, window.HandleEventFalseButtonNativeClicks);
+    }
+
+    [AvaloniaFact]
+    public void ClickEventTrigger_HandleEventFalse_TextBox_PreservesKeyBubbling()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.HandleEventFalseTextBoxTarget.Focus();
+        window.HandleEventFalseTextBoxTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandleEventFalseTextBoxTarget
+        });
+        window.HandleEventFalseTextBoxTarget.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.None,
+            Source = window.HandleEventFalseTextBoxTarget
+        });
+
+        Assert.Equal(1, window.HandleEventFalseTextBoxClicks);
+        Assert.Equal(1, window.HandleEventFalseTextBoxBubbledKeyUp);
     }
 
     [AvaloniaFact]

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -234,6 +234,19 @@ public class ClickEventTriggerTests
     }
 
     [AvaloniaFact]
+    public void ClickEventTrigger_HandleEventFalse_TextBox_PointerClick_FiresTriggerAndClickEvent()
+    {
+        var window = new ClickEventTrigger001();
+
+        window.Show();
+
+        window.Click(window.HandleEventFalseTextBoxTarget);
+
+        Assert.Equal(1, window.HandleEventFalseTextBoxClicks);
+        Assert.Equal(1, window.HandleEventFalseTextBoxClickEvents);
+    }
+
+    [AvaloniaFact]
     public void ClickEventTrigger_HandleEventFalse_TextBox_AllowsPointerDragSelection()
     {
         var window = new ClickEventTrigger001();


### PR DESCRIPTION
# PR Summary: ClickEventTrigger `HandledEventsToo` + `HandleEvent=False` Scenarios

## Branch
- `feature/click-event-trigger-handled-events-too`
- Base: `master` (`c589ddee`)

## Problem Statement
`ClickEventTrigger` already provided button-like click semantics, but it did not expose a way to subscribe to already-handled routed events. This made some composition scenarios harder, especially when:
- source controls (for example `Button`/`TextBox`) or upstream handlers marked input events as handled;
- a host trigger should still react to a `SourceControl` event stream;
- users wanted to preserve native control behavior via `HandleEvent="False"` while still running trigger actions.

## Solution Overview
1. Added a new `HandledEventsToo` styled property to `ClickEventTrigger` (default: `false`).
2. Wired `HandledEventsToo` into all routed input subscriptions used by the trigger (pointer/keyboard/focus and root key handling).
3. Ensured runtime property changes rewire handlers (same intent as `SourceControl` updates).
4. Added targeted tests for:
   - default behavior + runtime toggle rewiring,
   - `Button` and `TextBox` source scenarios,
   - `HandleEvent=False` behavior preservation.
5. Updated sample XAML and DocFX documentation with when/why/how guidance and concrete examples.
6. Added pointer-capture safety for text-editing scenarios (`TextBox` drag-selection) by avoiding trigger-owned capture when it would interfere with native behavior.

## Commit Breakdown (granular)

### 1) Core behavior
- **Commit**: `cd23bb01`
- **Message**: `feat(custom): add HandledEventsToo support to ClickEventTrigger`
- **File**:
  - `src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs`
- **Highlights**:
  - Added `HandledEventsTooProperty` and `HandledEventsToo` CLR wrapper.
  - Passed `HandledEventsToo` into every `AddHandler(...)` call used by the trigger.
  - Updated root key subscription to use explicit routing + `HandledEventsToo`.
  - On `HandledEventsToo` change, force detach/reattach handlers.
  - Reset pressed state (`_isPressed`) during forced reattach to avoid stale state.

### 2) Tests
- **Commit**: `e1414d8e`
- **Message**: `test(custom): add HandledEventsToo and HandleEvent=false coverage`
- **Files**:
  - `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml`
  - `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs`
  - `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs`
- **Highlights**:
  - Added `Button` source for handled-events-too scenario.
  - Added `TextBox` source for handled-events-too scenario.
  - Added dedicated `HandleEvent=False` test controls (`Button` + `TextBox`).
  - Added counters and routed handlers in fixture to assert behavior.
  - Added separate tests:
    - `ClickEventTrigger_HandledEventsToo_DefaultFalse_AndPropertyChange_RewiresHandlers_ForButtonAndTextBoxSources`
    - `ClickEventTrigger_HandledEventsToo_AlsoControlsKeyboardHandlers`
    - `ClickEventTrigger_HandleEventFalse_Button_PreservesNativeClick`
    - `ClickEventTrigger_HandleEventFalse_TextBox_PreservesKeyBubbling`

### 3) Sample app
- **Commit**: `a92df204`
- **Message**: `feat(samples): add HandleEvent and HandledEventsToo trigger examples`
- **File**:
  - `samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml`
- **Highlights**:
  - Added `HandledEventsToo` section demonstrating:
    - `Button` source trigger with `HandleEvent="False"` + `HandledEventsToo="True"`.
    - `TextBox` source trigger with `HandleEvent="False"` + `HandledEventsToo="True"`.
    - host triggers using `SourceControl` + `HandledEventsToo="True"`.
  - Added status text outputs to visualize behavior.

### 4) Docs
- **Commit**: `fec046bd`
- **Message**: `docs(input-element): document HandledEventsToo usage and examples`
- **Files**:
  - `docfx/articles/interactions-custom/input-element/click-event-trigger.md`
  - `docfx/articles/interactions-custom/input-element/overview.md`
- **Highlights**:
  - Added `HandledEventsToo` to property table.
  - Added an explicit strategy section (`HandleEvent` vs `HandledEventsToo`) including guidance matrix.
  - Added Button/TextBox examples and `SourceControl`+`HandledEventsToo` scenario.
  - Updated overview to mention routing strategy documentation.

## API / Behavior Changes

### New property
- `ClickEventTrigger.HandledEventsToo` (`bool`, default `false`)

### Runtime behavior
- Changing `HandledEventsToo` while attached now re-registers trigger handlers immediately.
- `SourceControl` and `HandledEventsToo` can be adjusted dynamically without reattaching the behavior.

## Compatibility Notes
- Default behavior is preserved (`HandledEventsToo=false`): existing apps should behave the same unless property is explicitly set.
- `HandleEvent=false` remains the recommended option when native control behavior should not be suppressed.
- For `TextBox` sources, the trigger does not take pointer capture; this preserves drag-selection/caret interactions.

## Validation Performed

### Focused trigger tests
- Command:
  - `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --filter ClickEventTrigger --nologo`
- Result:
  - Passed: 14, Failed: 0, Skipped: 0

### Unit test project
- Command:
  - `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --nologo`
- Result:
  - Passed: 33, Failed: 0, Skipped: 2

### Sample app build
- Command:
  - `dotnet build samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj --nologo`
- Result:
  - Succeeded
  - Existing warnings in DragAndDrop project (obsolete API usage), unrelated to this PR.

## Doc Build Note
A DocFX build was attempted and failed due existing unrelated metadata/parser issues in interactivity docs generation (for example `AvaloniaObjectBehaviorsExtensions.cs` with `#if !DOCFX` extension-member syntax). This was pre-existing and not part of this change set.

## Changed Files (this branch)
- `src/Xaml.Behaviors.Interactions.Custom/InputElement/Triggers/ClickEventTrigger.cs`
- `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml`
- `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTrigger001.axaml.cs`
- `tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs`
- `samples/BehaviorsTestApplication/Views/Pages/ClickEventTriggerView.axaml`
- `docfx/articles/interactions-custom/input-element/click-event-trigger.md`
- `docfx/articles/interactions-custom/input-element/overview.md`

## Post-Branch Follow-up (not yet committed in original four commits)
- `ClickEventTrigger` now raises `Button.ClickEvent` for non-`Button` sources before executing actions.
- Pointer-capture behavior was adjusted:
  - capture is skipped when `HandleEvent="False"`;
  - capture is skipped for `TextBox` sources even if `HandleEvent="True"`;
  - capture release happens only when capture was owned by the trigger.
- Added/updated validation for:
  - `Button` source click-event emission;
  - `TextBox` source click-event emission;
  - `TextBox` drag-selection via pointer drag while trigger is attached.