### PR TITLE
Add command CanExecute observation for picker behaviors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>12.0.0.1</VersionPrefix>
+    <VersionPrefix>12.0.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AvaloniaVersion>12.0.0</AvaloniaVersion>
-    <AvaloniaDataGridVersion>12.0.0</AvaloniaDataGridVersion>
+    <AvaloniaVersion>12.0.5</AvaloniaVersion>
+    <AvaloniaDataGridVersion>12.0.1</AvaloniaDataGridVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,9 +19,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="ReactiveGenerator" Version="0.12.0" />
-    <PackageVersion Include="ReactiveUI" Version="22.2.1" />
+    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.core" Version="3.2.2" />

--- a/docfx/articles/avalonia-v12-migration.md
+++ b/docfx/articles/avalonia-v12-migration.md
@@ -8,7 +8,7 @@ This branch migrates `Avalonia.Xaml.Behaviors` to stable Avalonia 12 packages.
 - Xaml.Behaviors package line: `12.0.5`
 - Avalonia package line: `12.0.5`
 - Avalonia DataGrid package: `12.0.1`
-- ReactiveUI.Avalonia package: `11.4.12`
+- ReactiveUI.Avalonia package: `12.0.3`
 - Minimum Avalonia target framework in this repository: `net8.0`
 
 ## Official references

--- a/docfx/articles/avalonia-v12-migration.md
+++ b/docfx/articles/avalonia-v12-migration.md
@@ -1,25 +1,26 @@
-# Avalonia 12.0.0 Migration
+# Avalonia 12 Migration
 
-This branch migrates `Avalonia.Xaml.Behaviors` to stable Avalonia 12.0.0 packages.
+This branch migrates `Avalonia.Xaml.Behaviors` to stable Avalonia 12 packages.
 
 ## Baseline
 
 - Branch: `avalonia-v12`
-- Avalonia package line: `12.0.0`
-- Avalonia DataGrid package: `12.0.0`
+- Xaml.Behaviors package line: `12.0.5`
+- Avalonia package line: `12.0.5`
+- Avalonia DataGrid package: `12.0.1`
 - ReactiveUI.Avalonia package: `11.4.12`
 - Minimum Avalonia target framework in this repository: `net8.0`
 
 ## Official references
 
 - Avalonia breaking changes and migration notes for v12
-- Avalonia `12.0.0` release notes
+- Avalonia 12 release notes
 - Avalonia headless testing guidance for renderer-backed screenshots
 
 ## Migration plan
 
 1. Move all Avalonia-consuming projects to `net8.0+`.
-2. Upgrade central package versions to the stable Avalonia 12.0.0 set supported by the current ecosystem.
+2. Upgrade central package versions to the stable Avalonia 12 set supported by the current ecosystem.
 3. Apply source-level API migrations from the Avalonia v12 breaking changes.
 4. Fix sample applications and unit tests for Avalonia 12 runtime and headless-test changes.
 5. Rebuild the full solution and re-run focused test coverage.
@@ -27,7 +28,7 @@ This branch migrates `Avalonia.Xaml.Behaviors` to stable Avalonia 12.0.0 package
 ## Applied changes
 
 - Removed legacy `netstandard2.0` targets from Avalonia-dependent projects.
-- Updated package management to stable Avalonia 12.0.0 packages and added `Avalonia.Skia` where renderer-backed headless tests require it.
+- Updated package management to stable Avalonia 12 packages and added `Avalonia.Skia` where renderer-backed headless tests require it.
 - Migrated `IBinding` usages to `BindingBase`.
 - Replaced `Gestures.*` routed events with `InputElement.*`.
 - Replaced `SystemDecorations` with `WindowDecorations`.

--- a/docfx/articles/drag-and-drop/drag-drop-commands-behavior.md
+++ b/docfx/articles/drag-and-drop/drag-drop-commands-behavior.md
@@ -14,10 +14,11 @@
 | CanExecuteDragLeaveCommand | `bool` | Read-only value that observes whether DragLeaveCommand can execute without an event-specific parameter. |
 | DropCommand | `ICommand` | Gets or sets the command invoked on drop. |
 | CanExecuteDropCommand | `bool` | Read-only value that observes whether DropCommand can execute without an event-specific parameter. |
+| CanExecuteCommandParameter | `object` | Optional parameter used to evaluate all drag-and-drop commands before event-specific parameters are available. |
 | PassEventArgsToCommand | `bool` | Specifies whether the event args should be passed to the command. Default is true. |
 
-The `CanExecute*Command` properties are evaluated before a specific drag event is available, so they call `CanExecute(null)`.
-If a command's `CanExecute` requires `DragEventArgs`, keep the control enabled independently or make `CanExecute` tolerate `null`.
+When `PassEventArgsToCommand` is `true` and `CanExecuteCommandParameter` is not set, the `CanExecute*Command` properties report `true` without calling `CanExecute(null)` because the real `DragEventArgs` parameter is not available yet.
+Set `CanExecuteCommandParameter` when command availability should still be observed before a drag event exists.
 When `PassEventArgsToCommand` is `true`, execution still checks and executes the command with the current `DragEventArgs`.
 
 ## Usage
@@ -29,7 +30,7 @@ When `PassEventArgsToCommand` is `true`, execution still checks and executes the
         IsEnabled="{Binding #DropCommands.CanExecuteDropCommand}">
     <Interaction.Behaviors>
         <DragDropCommandsBehavior x:Name="DropCommands"
-                                  PassEventArgsToCommand="False"
+                                  CanExecuteCommandParameter="{Binding CurrentDropTarget}"
                                   DropCommand="{Binding DropCommand}" />
     </Interaction.Behaviors>
 </Border>

--- a/docfx/articles/drag-and-drop/drag-drop-commands-behavior.md
+++ b/docfx/articles/drag-and-drop/drag-drop-commands-behavior.md
@@ -7,32 +7,29 @@
 | Property | Type | Description |
 | --- | --- | --- |
 | DragEnterCommand | `ICommand` | Gets or sets the command invoked on drag enter. |
+| CanExecuteDragEnterCommand | `bool` | Read-only value that observes whether DragEnterCommand can execute without an event-specific parameter. |
 | DragOverCommand | `ICommand` | Gets or sets the command invoked on drag over. |
+| CanExecuteDragOverCommand | `bool` | Read-only value that observes whether DragOverCommand can execute without an event-specific parameter. |
 | DragLeaveCommand | `ICommand` | Gets or sets the command invoked on drag leave. |
+| CanExecuteDragLeaveCommand | `bool` | Read-only value that observes whether DragLeaveCommand can execute without an event-specific parameter. |
 | DropCommand | `ICommand` | Gets or sets the command invoked on drop. |
+| CanExecuteDropCommand | `bool` | Read-only value that observes whether DropCommand can execute without an event-specific parameter. |
 | PassEventArgsToCommand | `bool` | Specifies whether the event args should be passed to the command. Default is true. |
 
-## Usage
-
-```xml
-<Border Background="LightGray" Height="100" Width="100">
-    <Interaction.Behaviors>
-        <DragDropCommandsBehavior DropCommand="{Binding DropCommand}" />
-    </Interaction.Behaviors>
-</Border>
-```
-
-*   **`EnterCommand`**
-*   **`LeaveCommand`**
-*   **`OverCommand`**
-*   **`DropCommand`**
+The `CanExecute*Command` properties are evaluated before a specific drag event is available, so they call `CanExecute(null)`.
+If a command's `CanExecute` requires `DragEventArgs`, keep the control enabled independently or make `CanExecute` tolerate `null`.
+When `PassEventArgsToCommand` is `true`, execution still checks and executes the command with the current `DragEventArgs`.
 
 ## Usage
 
 ```xml
-<Border>
+<Border Background="LightGray"
+        Height="100"
+        Width="100"
+        IsEnabled="{Binding #DropCommands.CanExecuteDropCommand}">
     <Interaction.Behaviors>
-        <DragDropCommandsBehavior EnterCommand="{Binding EnterCommand}"
+        <DragDropCommandsBehavior x:Name="DropCommands"
+                                  PassEventArgsToCommand="False"
                                   DropCommand="{Binding DropCommand}" />
     </Interaction.Behaviors>
 </Border>

--- a/docfx/articles/interactions-custom/execute-command/execute-command-behavior-base.md
+++ b/docfx/articles/interactions-custom/execute-command/execute-command-behavior-base.md
@@ -8,8 +8,20 @@ Base class for behaviors that execute a command.
 | --- | --- | --- |
 | TopLevel | TopLevel | The TopLevel to focus when FocusTopLevel is true. |
 | Command | ICommand | The command to execute. |
+| CanExecuteCommand | bool | Read-only value that observes whether Command can execute with the current command parameter. |
 | CommandParameter | object | The command parameter. |
 | FocusTopLevel | bool | If true, the TopLevel will be focused after the command is executed. |
 | FocusControl | Control | The control to focus after the command is executed. |
 | SourceControl | Control | The control to use as the source for the behavior. If not set, the AssociatedObject is used. |
 
+Bind the associated control's `IsEnabled` property to `CanExecuteCommand` when the behavior, rather than the control itself, owns the command:
+
+```xml
+<Border IsEnabled="{Binding #TapCommand.CanExecuteCommand}">
+    <Interaction.Behaviors>
+        <ExecuteCommandOnTappedBehavior x:Name="TapCommand"
+                                        Command="{Binding OpenCommand}"
+                                        CommandParameter="{Binding SelectedItem}" />
+    </Interaction.Behaviors>
+</Border>
+```

--- a/docfx/articles/interactions/storage-provider-interactions.md
+++ b/docfx/articles/interactions/storage-provider-interactions.md
@@ -37,6 +37,20 @@ This is useful when the picker is opened from a non-button surface such as a pan
 </Border>
 ```
 
+Use `UseCommandCanExecuteForIsEnabled` when the action should automatically bind the trigger's associated control to `CanExecuteCommand`:
+
+```xml
+<Border>
+    <Interaction.Behaviors>
+        <ClickEventTrigger>
+            <OpenFilePickerAction Title="Select a file"
+                                  Command="{Binding OpenFilesCommand}"
+                                  UseCommandCanExecuteForIsEnabled="True" />
+        </ClickEventTrigger>
+    </Interaction.Behaviors>
+</Border>
+```
+
 ## Behaviors
 
 For convenience, specialized behaviors are provided for common controls like `Button` and `MenuItem`. These behaviors automatically handle the `Click` event.
@@ -69,7 +83,19 @@ Bind the associated control's enabled state to it when you want command availabi
 </Button>
 ```
 
-The sample application includes a `Picker CanExecuteCommand` page that shows all six picker behaviors and a panel-hosted picker action with their associated controls bound to `CanExecuteCommand`.
+Use `UseCommandCanExecuteForIsEnabled` when the behavior should create that binding for the associated control:
+
+```xml
+<Button Content="Open File">
+    <Interaction.Behaviors>
+        <ButtonOpenFilePickerBehavior Title="Select a file"
+                                      Command="{Binding OpenFilesCommand}"
+                                      UseCommandCanExecuteForIsEnabled="True" />
+    </Interaction.Behaviors>
+</Button>
+```
+
+The sample application includes a `Picker CanExecuteCommand` page that shows all six picker behaviors and a panel-hosted picker action using command `CanExecute` state.
 
 ### MenuItem Behaviors
 
@@ -94,3 +120,4 @@ Common properties available on these actions and behaviors include:
 *   **`FileTypeFilter`**: A collection of file types to filter by.
 *   **`SuggestedStartLocation`**: The initial location for the picker.
 *   **`CanExecuteCommand`**: (Actions and behaviors) Whether the configured command can execute with the current command parameter.
+*   **`UseCommandCanExecuteForIsEnabled`**: (Actions and behaviors) Whether the associated control should automatically follow `CanExecuteCommand` through `IsEnabled`.

--- a/docfx/articles/interactions/storage-provider-interactions.md
+++ b/docfx/articles/interactions/storage-provider-interactions.md
@@ -22,6 +22,21 @@ These actions can be attached to any event trigger and will open the correspondi
 </Button>
 ```
 
+Picker actions inherit `CanExecuteCommand`, which observes `Command.CanExecute(CommandParameter)`.
+This is useful when the picker is opened from a non-button surface such as a panel click trigger:
+
+```xml
+<Border IsEnabled="{Binding #OpenPanelPicker.CanExecuteCommand}">
+    <Interaction.Behaviors>
+        <ClickEventTrigger>
+            <OpenFilePickerAction x:Name="OpenPanelPicker"
+                                  Title="Select a file"
+                                  Command="{Binding OpenFilesCommand}" />
+        </ClickEventTrigger>
+    </Interaction.Behaviors>
+</Border>
+```
+
 ## Behaviors
 
 For convenience, specialized behaviors are provided for common controls like `Button` and `MenuItem`. These behaviors automatically handle the `Click` event.
@@ -39,6 +54,22 @@ For convenience, specialized behaviors are provided for common controls like `Bu
     </Interaction.Behaviors>
 </Button>
 ```
+
+Picker behaviors inherit `CanExecuteCommand`, which observes `Command.CanExecute(CommandParameter)`.
+Bind the associated control's enabled state to it when you want command availability to drive the control:
+
+```xml
+<Button Content="Open File"
+        IsEnabled="{Binding #OpenFilePicker.CanExecuteCommand}">
+    <Interaction.Behaviors>
+        <ButtonOpenFilePickerBehavior x:Name="OpenFilePicker"
+                                      Title="Select a file"
+                                      Command="{Binding OpenFilesCommand}" />
+    </Interaction.Behaviors>
+</Button>
+```
+
+The sample application includes a `Picker CanExecuteCommand` page that shows all six picker behaviors and a panel-hosted picker action with their associated controls bound to `CanExecuteCommand`.
 
 ### MenuItem Behaviors
 
@@ -62,3 +93,4 @@ Common properties available on these actions and behaviors include:
 *   **`AllowMultiple`**: (Open File only) Whether to allow selecting multiple files.
 *   **`FileTypeFilter`**: A collection of file types to filter by.
 *   **`SuggestedStartLocation`**: The initial location for the picker.
+*   **`CanExecuteCommand`**: (Actions and behaviors) Whether the configured command can execute with the current command parameter.

--- a/docfx/articles/interactions/storage-provider-interactions.md
+++ b/docfx/articles/interactions/storage-provider-interactions.md
@@ -22,7 +22,7 @@ These actions can be attached to any event trigger and will open the correspondi
 </Button>
 ```
 
-Picker actions inherit `CanExecuteCommand`, which observes `Command.CanExecute(CommandParameter)`.
+Picker actions inherit `CanExecuteCommand`, which observes command availability.
 This is useful when the picker is opened from a non-button surface such as a panel click trigger:
 
 ```xml
@@ -31,11 +31,14 @@ This is useful when the picker is opened from a non-button surface such as a pan
         <ClickEventTrigger>
             <OpenFilePickerAction x:Name="OpenPanelPicker"
                                   Title="Select a file"
-                                  Command="{Binding OpenFilesCommand}" />
+                                  Command="{Binding OpenFilesCommand}"
+                                  CanExecuteCommandParameter="OpenFiles" />
         </ClickEventTrigger>
     </Interaction.Behaviors>
 </Border>
 ```
+
+Picker actions normally execute the command with the picker result. Set `CanExecuteCommandParameter` when the command has a global availability state that should be observed before a picker result exists.
 
 Use `UseCommandCanExecuteForIsEnabled` when the action should automatically bind the trigger's associated control to `CanExecuteCommand`:
 
@@ -45,6 +48,7 @@ Use `UseCommandCanExecuteForIsEnabled` when the action should automatically bind
         <ClickEventTrigger>
             <OpenFilePickerAction Title="Select a file"
                                   Command="{Binding OpenFilesCommand}"
+                                  CanExecuteCommandParameter="OpenFiles"
                                   UseCommandCanExecuteForIsEnabled="True" />
         </ClickEventTrigger>
     </Interaction.Behaviors>
@@ -69,7 +73,7 @@ For convenience, specialized behaviors are provided for common controls like `Bu
 </Button>
 ```
 
-Picker behaviors inherit `CanExecuteCommand`, which observes `Command.CanExecute(CommandParameter)`.
+Picker behaviors inherit `CanExecuteCommand`, which observes command availability.
 Bind the associated control's enabled state to it when you want command availability to drive the control:
 
 ```xml
@@ -78,7 +82,8 @@ Bind the associated control's enabled state to it when you want command availabi
     <Interaction.Behaviors>
         <ButtonOpenFilePickerBehavior x:Name="OpenFilePicker"
                                       Title="Select a file"
-                                      Command="{Binding OpenFilesCommand}" />
+                                      Command="{Binding OpenFilesCommand}"
+                                      CanExecuteCommandParameter="OpenFiles" />
     </Interaction.Behaviors>
 </Button>
 ```
@@ -90,6 +95,7 @@ Use `UseCommandCanExecuteForIsEnabled` when the behavior should create that bind
     <Interaction.Behaviors>
         <ButtonOpenFilePickerBehavior Title="Select a file"
                                       Command="{Binding OpenFilesCommand}"
+                                      CanExecuteCommandParameter="OpenFiles"
                                       UseCommandCanExecuteForIsEnabled="True" />
     </Interaction.Behaviors>
 </Button>
@@ -119,5 +125,6 @@ Common properties available on these actions and behaviors include:
 *   **`AllowMultiple`**: (Open File only) Whether to allow selecting multiple files.
 *   **`FileTypeFilter`**: A collection of file types to filter by.
 *   **`SuggestedStartLocation`**: The initial location for the picker.
-*   **`CanExecuteCommand`**: (Actions and behaviors) Whether the configured command can execute with the current command parameter.
+*   **`CanExecuteCommand`**: (Actions and behaviors) Whether the configured command can execute with the current can-execute parameter.
+*   **`CanExecuteCommandParameter`**: (Actions and behaviors) Optional parameter used only for `Command.CanExecute`. Use this when command execution should still receive the picker result.
 *   **`UseCommandCanExecuteForIsEnabled`**: (Actions and behaviors) Whether the associated control should automatically follow `CanExecuteCommand` through `IsEnabled`.

--- a/docfx/articles/interactivity/command-can-execute-observer.md
+++ b/docfx/articles/interactivity/command-can-execute-observer.md
@@ -1,0 +1,98 @@
+# CommandCanExecuteObserver
+
+`CommandCanExecuteObserver` is a public helper for command-backed behaviors that need to expose a bindable command availability state.
+
+It observes `ICommand.CanExecute(parameter)`, listens to `CanExecuteChanged`, and reports the current value through a callback. If the command is `null`, it reports `true`.
+
+The observer uses a weak event target for `CanExecuteChanged`, so a long-lived command cannot keep the observer or owning behavior alive if cleanup is missed. You should still call `Stop()` or `Dispose()` when the behavior is detached so the command subscription is removed immediately.
+
+## Behavior lifecycle
+
+Use one observer per command state property:
+
+* Call `Start(command, parameter)` when the behavior is attached.
+* Call `Update(command, parameter)` when the command or command parameter changes.
+* Call `Stop()` or `Dispose()` when the behavior is detached.
+
+## Custom behavior example
+
+```csharp
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+public sealed class MyCommandBehavior : StyledElementBehavior<Control>
+{
+    private readonly CommandCanExecuteObserver _canExecuteObserver;
+    private bool _canExecuteCommand = true;
+
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<MyCommandBehavior, ICommand?>(nameof(Command));
+
+    public static readonly StyledProperty<object?> CommandParameterProperty =
+        AvaloniaProperty.Register<MyCommandBehavior, object?>(nameof(CommandParameter));
+
+    public static readonly DirectProperty<MyCommandBehavior, bool> CanExecuteCommandProperty =
+        AvaloniaProperty.RegisterDirect<MyCommandBehavior, bool>(
+            nameof(CanExecuteCommand),
+            behavior => behavior.CanExecuteCommand);
+
+    public MyCommandBehavior()
+    {
+        _canExecuteObserver = new CommandCanExecuteObserver(value => CanExecuteCommand = value);
+    }
+
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    public bool CanExecuteCommand
+    {
+        get => _canExecuteCommand;
+        private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
+    }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        _canExecuteObserver.Start(Command, CommandParameter);
+    }
+
+    protected override void OnDetaching()
+    {
+        _canExecuteObserver.Stop();
+        base.OnDetaching();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
+        {
+            _canExecuteObserver.Update(Command, CommandParameter);
+        }
+    }
+}
+```
+
+Bind the associated control to the exposed state:
+
+```xml
+<Button Content="Run"
+        IsEnabled="{Binding #CommandBehavior.CanExecuteCommand}">
+    <Interaction.Behaviors>
+        <local:MyCommandBehavior x:Name="CommandBehavior"
+                                 Command="{Binding RunCommand}" />
+    </Interaction.Behaviors>
+</Button>
+```

--- a/docfx/articles/interactivity/command-can-execute-observer.md
+++ b/docfx/articles/interactivity/command-can-execute-observer.md
@@ -3,6 +3,7 @@
 `CommandCanExecuteObserver` is a public helper for command-backed behaviors that need to expose a bindable command availability state.
 
 It observes `ICommand.CanExecute(parameter)`, listens to `CanExecuteChanged`, and reports the current value through a callback. If the command is `null`, it reports `true`.
+When the command parameter is not available until execution time, use the overloads that accept `isParameterKnown: false`; the observer reports `true` without calling `CanExecute` until a real parameter is supplied.
 
 The observer uses a weak event target for `CanExecuteChanged`, so a long-lived command cannot keep the observer or owning behavior alive if cleanup is missed. You should still call `Stop()` or `Dispose()` when the behavior is detached so the command subscription is removed immediately.
 
@@ -13,6 +14,8 @@ Use one observer per command state property:
 * Call `Start(command, parameter)` when the behavior is attached.
 * Call `Update(command, parameter)` when the command or command parameter changes.
 * Call `Stop()` or `Dispose()` when the behavior is detached.
+
+Use `Start(command, parameter, isParameterKnown: false)` and `Update(command, parameter, isParameterKnown: false)` for event-driven behaviors where the command will later execute with event args, picker results, or other values that do not exist at attach time. This prevents commands that reject `null` from being probed with a placeholder parameter.
 
 ## Custom behavior example
 

--- a/docfx/articles/interactivity/invoke-command-action-base.md
+++ b/docfx/articles/interactivity/invoke-command-action-base.md
@@ -8,6 +8,7 @@
 
 *   **`Command`**: The `ICommand` to execute.
 *   **`CanExecuteCommand`**: A read-only value that observes `Command.CanExecute(CommandParameter)`.
+*   **`UseCommandCanExecuteForIsEnabled`**: When `true`, the control associated with the hosting trigger has `IsEnabled` follow `CanExecuteCommand`.
 *   **`CommandParameter`**: An optional parameter to pass to the command's `Execute` method.
 *   **`InputConverter`**: An optional `IValueConverter` to convert the parameter before passing it to the command.
 *   **`InputConverterParameter`**: An optional parameter to pass to the `InputConverter`.
@@ -40,6 +41,19 @@ Use `CanExecuteCommand` when an action is hosted by a trigger and the associated
         <ClickEventTrigger>
             <OpenFilePickerAction x:Name="OpenAction"
                                   Command="{Binding OpenFilesCommand}" />
+        </ClickEventTrigger>
+    </Interaction.Behaviors>
+</Border>
+```
+
+Set `UseCommandCanExecuteForIsEnabled` on the action when it should create that binding for the trigger's associated control:
+
+```xml
+<Border>
+    <Interaction.Behaviors>
+        <ClickEventTrigger>
+            <OpenFilePickerAction Command="{Binding OpenFilesCommand}"
+                                  UseCommandCanExecuteForIsEnabled="True" />
         </ClickEventTrigger>
     </Interaction.Behaviors>
 </Border>

--- a/docfx/articles/interactivity/invoke-command-action-base.md
+++ b/docfx/articles/interactivity/invoke-command-action-base.md
@@ -2,9 +2,12 @@
 
 `InvokeCommandActionBase` is an abstract base class for actions that invoke an `ICommand`. It provides a standard set of properties for binding commands and command parameters, making it easier to create actions that interact with ViewModels.
 
+`CanExecuteCommand` is implemented with the public `CommandCanExecuteObserver` helper, which custom actions can also use through this base class.
+
 ## Properties
 
 *   **`Command`**: The `ICommand` to execute.
+*   **`CanExecuteCommand`**: A read-only value that observes `Command.CanExecute(CommandParameter)`.
 *   **`CommandParameter`**: An optional parameter to pass to the command's `Execute` method.
 *   **`InputConverter`**: An optional `IValueConverter` to convert the parameter before passing it to the command.
 *   **`InputConverterParameter`**: An optional parameter to pass to the `InputConverter`.
@@ -27,4 +30,17 @@ public class MyCommandAction : InvokeCommandActionBase
         return null;
     }
 }
+```
+
+Use `CanExecuteCommand` when an action is hosted by a trigger and the associated control should reflect command availability:
+
+```xml
+<Border IsEnabled="{Binding #OpenAction.CanExecuteCommand}">
+    <Interaction.Behaviors>
+        <ClickEventTrigger>
+            <OpenFilePickerAction x:Name="OpenAction"
+                                  Command="{Binding OpenFilesCommand}" />
+        </ClickEventTrigger>
+    </Interaction.Behaviors>
+</Border>
 ```

--- a/docfx/articles/interactivity/invoke-command-action-base.md
+++ b/docfx/articles/interactivity/invoke-command-action-base.md
@@ -7,13 +7,16 @@
 ## Properties
 
 *   **`Command`**: The `ICommand` to execute.
-*   **`CanExecuteCommand`**: A read-only value that observes `Command.CanExecute(CommandParameter)`.
+*   **`CanExecuteCommand`**: A read-only value that observes command availability.
+*   **`CanExecuteCommandParameter`**: An optional parameter used only for `Command.CanExecute`.
 *   **`UseCommandCanExecuteForIsEnabled`**: When `true`, the control associated with the hosting trigger has `IsEnabled` follow `CanExecuteCommand`.
 *   **`CommandParameter`**: An optional parameter to pass to the command's `Execute` method.
 *   **`InputConverter`**: An optional `IValueConverter` to convert the parameter before passing it to the command.
 *   **`InputConverterParameter`**: An optional parameter to pass to the `InputConverter`.
 *   **`InputConverterLanguage`**: An optional language string to pass to the `InputConverter`.
 *   **`PassEventArgsToCommand`**: A boolean property. If `true`, the event arguments (or the parameter passed to `Execute`) are passed to the command. If `false` (default), `CommandParameter` is used if set; otherwise, the parameter passed to `Execute` is used.
+
+`CanExecuteCommand` uses `CanExecuteCommandParameter` when it is set. Otherwise it uses `CommandParameter` when that is set. If neither value is set and the action will execute with event args, converted input, picker results, or another runtime parameter, `CanExecuteCommand` stays `true` instead of probing `CanExecute(null)`.
 
 ## Usage
 
@@ -40,7 +43,8 @@ Use `CanExecuteCommand` when an action is hosted by a trigger and the associated
     <Interaction.Behaviors>
         <ClickEventTrigger>
             <OpenFilePickerAction x:Name="OpenAction"
-                                  Command="{Binding OpenFilesCommand}" />
+                                  Command="{Binding OpenFilesCommand}"
+                                  CanExecuteCommandParameter="OpenFiles" />
         </ClickEventTrigger>
     </Interaction.Behaviors>
 </Border>
@@ -53,6 +57,7 @@ Set `UseCommandCanExecuteForIsEnabled` on the action when it should create that 
     <Interaction.Behaviors>
         <ClickEventTrigger>
             <OpenFilePickerAction Command="{Binding OpenFilesCommand}"
+                                  CanExecuteCommandParameter="OpenFiles"
                                   UseCommandCanExecuteForIsEnabled="True" />
         </ClickEventTrigger>
     </Interaction.Behaviors>

--- a/docfx/articles/interactivity/invoke-command-behavior-base.md
+++ b/docfx/articles/interactivity/invoke-command-behavior-base.md
@@ -8,6 +8,7 @@
 
 *   **`Command`**: The `ICommand` to execute.
 *   **`CanExecuteCommand`**: A read-only value that observes `Command.CanExecute(CommandParameter)`.
+*   **`UseCommandCanExecuteForIsEnabled`**: When `true`, the associated control's `IsEnabled` property follows `CanExecuteCommand`.
 *   **`CommandParameter`**: An optional parameter to pass to the command's `Execute` method.
 *   **`InputConverter`**: An optional `IValueConverter` to convert the parameter before passing it to the command.
 *   **`InputConverterParameter`**: An optional parameter to pass to the `InputConverter`.
@@ -33,6 +34,18 @@ Use `CanExecuteCommand` when a behavior is attached to a control that does not h
         <FilesDropBehavior x:Name="DropBehavior"
                            Command="{Binding DropFilesCommand}"
                            CommandParameter="{Binding CurrentFolder}" />
+    </Interaction.Behaviors>
+</Border>
+```
+
+Set `UseCommandCanExecuteForIsEnabled` when the behavior should create that binding for the associated control:
+
+```xml
+<Border>
+    <Interaction.Behaviors>
+        <FilesDropBehavior Command="{Binding DropFilesCommand}"
+                           CommandParameter="{Binding CurrentFolder}"
+                           UseCommandCanExecuteForIsEnabled="True" />
     </Interaction.Behaviors>
 </Border>
 ```

--- a/docfx/articles/interactivity/invoke-command-behavior-base.md
+++ b/docfx/articles/interactivity/invoke-command-behavior-base.md
@@ -7,13 +7,16 @@
 ## Properties
 
 *   **`Command`**: The `ICommand` to execute.
-*   **`CanExecuteCommand`**: A read-only value that observes `Command.CanExecute(CommandParameter)`.
+*   **`CanExecuteCommand`**: A read-only value that observes command availability.
+*   **`CanExecuteCommandParameter`**: An optional parameter used only for `Command.CanExecute`.
 *   **`UseCommandCanExecuteForIsEnabled`**: When `true`, the associated control's `IsEnabled` property follows `CanExecuteCommand`.
 *   **`CommandParameter`**: An optional parameter to pass to the command's `Execute` method.
 *   **`InputConverter`**: An optional `IValueConverter` to convert the parameter before passing it to the command.
 *   **`InputConverterParameter`**: An optional parameter to pass to the `InputConverter`.
 *   **`InputConverterLanguage`**: An optional language string to pass to the `InputConverter`.
 *   **`PassEventArgsToCommand`**: A boolean property. If `true`, the event arguments are passed to the command.
+
+`CanExecuteCommand` uses `CanExecuteCommandParameter` when it is set. Otherwise it uses `CommandParameter` when that is set. If neither value is set and the behavior will execute with event args, converted input, picker results, or another runtime parameter, `CanExecuteCommand` stays `true` instead of probing `CanExecute(null)`.
 
 ## Usage
 
@@ -33,6 +36,7 @@ Use `CanExecuteCommand` when a behavior is attached to a control that does not h
     <Interaction.Behaviors>
         <FilesDropBehavior x:Name="DropBehavior"
                            Command="{Binding DropFilesCommand}"
+                           CanExecuteCommandParameter="{Binding CurrentFolder}"
                            CommandParameter="{Binding CurrentFolder}" />
     </Interaction.Behaviors>
 </Border>
@@ -44,6 +48,7 @@ Set `UseCommandCanExecuteForIsEnabled` when the behavior should create that bind
 <Border>
     <Interaction.Behaviors>
         <FilesDropBehavior Command="{Binding DropFilesCommand}"
+                           CanExecuteCommandParameter="{Binding CurrentFolder}"
                            CommandParameter="{Binding CurrentFolder}"
                            UseCommandCanExecuteForIsEnabled="True" />
     </Interaction.Behaviors>

--- a/docfx/articles/interactivity/invoke-command-behavior-base.md
+++ b/docfx/articles/interactivity/invoke-command-behavior-base.md
@@ -2,9 +2,12 @@
 
 `InvokeCommandBehaviorBase` is a base class for behaviors that invoke an `ICommand`. It is similar to `InvokeCommandActionBase` but designed for behaviors rather than actions.
 
+`CanExecuteCommand` is implemented with the public `CommandCanExecuteObserver` helper, which custom behaviors can also use to expose their own bindable command availability state.
+
 ## Properties
 
 *   **`Command`**: The `ICommand` to execute.
+*   **`CanExecuteCommand`**: A read-only value that observes `Command.CanExecute(CommandParameter)`.
 *   **`CommandParameter`**: An optional parameter to pass to the command's `Execute` method.
 *   **`InputConverter`**: An optional `IValueConverter` to convert the parameter before passing it to the command.
 *   **`InputConverterParameter`**: An optional parameter to pass to the `InputConverter`.
@@ -20,4 +23,16 @@ public class MyCommandBehavior : InvokeCommandBehaviorBase
 {
     // ... implementation ...
 }
+```
+
+Use `CanExecuteCommand` when a behavior is attached to a control that does not have its own command source state:
+
+```xml
+<Border IsEnabled="{Binding #DropBehavior.CanExecuteCommand}">
+    <Interaction.Behaviors>
+        <FilesDropBehavior x:Name="DropBehavior"
+                           Command="{Binding DropFilesCommand}"
+                           CommandParameter="{Binding CurrentFolder}" />
+    </Interaction.Behaviors>
+</Border>
 ```

--- a/docfx/articles/interactivity/toc.yml
+++ b/docfx/articles/interactivity/toc.yml
@@ -24,6 +24,8 @@
   href: interactive-behavior-base.md
 - name: InvokeCommandBehaviorBase
   href: invoke-command-behavior-base.md
+- name: CommandCanExecuteObserver
+  href: command-can-execute-observer.md
 - name: EventTriggerBase
   href: event-trigger-base.md
 - name: InteractiveTriggerBase

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -106,6 +106,9 @@ public partial class MainWindowViewModel : ViewModelBase
         ];
 
         FileItems = new ObservableCollection<Uri>();
+        CanUseButtonPickerCommands = true;
+        CanUseMenuPickerCommands = true;
+        CanUsePanelPickerActionCommand = true;
 
         EmitNextCommand = ReactiveCommand.Create(EmitNext);
         EmitErrorCommand = ReactiveCommand.Create(EmitError);
@@ -144,6 +147,12 @@ public partial class MainWindowViewModel : ViewModelBase
         OpenFilesCommand = ReactiveCommand.Create<IEnumerable<IStorageItem>>(OpenFiles);
         SaveFileCommand = ReactiveCommand.Create<Uri>(SaveFile);
         OpenFoldersCommand = ReactiveCommand.Create<IEnumerable<IStorageFolder>>(OpenFolders);
+        var canUseButtonPickerCommands = this.WhenAnyValue(x => x.CanUseButtonPickerCommands);
+        var canUseMenuPickerCommands = this.WhenAnyValue(x => x.CanUseMenuPickerCommands);
+        var canUsePanelPickerActionCommand = this.WhenAnyValue(x => x.CanUsePanelPickerActionCommand);
+        ButtonPickerCanExecuteCommand = ReactiveCommand.Create<object?>(HandlePickerCanExecuteResult, canUseButtonPickerCommands);
+        MenuPickerCanExecuteCommand = ReactiveCommand.Create<object?>(HandlePickerCanExecuteResult, canUseMenuPickerCommands);
+        PanelPickerActionCanExecuteCommand = ReactiveCommand.Create<object?>(HandlePickerCanExecuteResult, canUsePanelPickerActionCommand);
 
         GetClipboardTextCommand = ReactiveCommand.Create<string?>(GetClipboardText);
         GetClipboardDataCommand = ReactiveCommand.Create<object?>(GetClipboardData);
@@ -289,6 +298,15 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [Reactive]
     public partial IStorageFolder? DocumentsFolder { get; set; }
+
+    [Reactive]
+    public partial bool CanUseButtonPickerCommands { get; set; }
+
+    [Reactive]
+    public partial bool CanUseMenuPickerCommands { get; set; }
+
+    [Reactive]
+    public partial bool CanUsePanelPickerActionCommand { get; set; }
 
     private string _uploadFilePath = string.Empty;
     public string UploadFilePath
@@ -447,6 +465,12 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public ICommand OpenFoldersCommand { get; set; }
 
+    public ICommand ButtonPickerCanExecuteCommand { get; }
+
+    public ICommand MenuPickerCanExecuteCommand { get; }
+
+    public ICommand PanelPickerActionCanExecuteCommand { get; }
+
     public ICommand GetClipboardTextCommand { get; set; }
 
     public ICommand GetClipboardDataCommand { get; set; }
@@ -522,6 +546,25 @@ public partial class MainWindowViewModel : ViewModelBase
             {
                 DocumentsFolder = folder;
             }
+        }
+    }
+
+    private void HandlePickerCanExecuteResult(object? result)
+    {
+        switch (result)
+        {
+            case IEnumerable<IStorageFolder> folders:
+                OpenFolders(folders);
+                break;
+            case IEnumerable<IStorageItem> items:
+                OpenFiles(items);
+                break;
+            case Uri uri:
+                SaveFile(uri);
+                break;
+            case IStorageItem { Path: { } path }:
+                FileItems?.Add(path);
+                break;
         }
     }
 

--- a/samples/BehaviorsTestApplication/Views/MainView.axaml
+++ b/samples/BehaviorsTestApplication/Views/MainView.axaml
@@ -363,6 +363,9 @@
       <TabItem Header="Storage Provider">
         <pages:StorageProviderView />
       </TabItem>
+      <TabItem Header="Picker CanExecuteCommand">
+        <pages:PickerCanExecuteCommandView />
+      </TabItem>
       <TabItem Header="Clipboard">
         <pages:ClipboardView />
       </TabItem>

--- a/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml
@@ -1,0 +1,164 @@
+﻿<UserControl x:Class="BehaviorsTestApplication.Views.Pages.PickerCanExecuteCommandView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BehaviorsTestApplication.ViewModels"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d" d:DesignWidth="780" d:DesignHeight="520">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <Grid Margin="8" RowDefinitions="Auto,Auto,Auto,Auto,Auto,*">
+    <StackPanel Grid.Row="0"
+                Orientation="Horizontal"
+                Spacing="16"
+                Margin="0,0,0,8">
+      <CheckBox Content="Button picker commands"
+                IsChecked="{Binding CanUseButtonPickerCommands, Mode=TwoWay}" />
+      <CheckBox Content="Menu picker commands"
+                IsChecked="{Binding CanUseMenuPickerCommands, Mode=TwoWay}" />
+      <CheckBox Content="Panel picker action command"
+                IsChecked="{Binding CanUsePanelPickerActionCommand, Mode=TwoWay}" />
+    </StackPanel>
+
+    <Menu Grid.Row="1" Margin="0,0,0,8">
+      <MenuItem Header="File">
+        <MenuItem Header="Open files"
+                  IsEnabled="{Binding #MenuOpenFilePicker.CanExecuteCommand}">
+          <Interaction.Behaviors>
+            <MenuItemOpenFilePickerBehavior x:Name="MenuOpenFilePicker"
+                                            Command="{Binding MenuPickerCanExecuteCommand}"
+                                            Title="Open Files"
+                                            SuggestedFileName="MyFile"
+                                            AllowMultiple="True"
+                                            FileTypeFilter="Text Files|*.txt|Markdown Files|*.md|All Files|*.*" />
+          </Interaction.Behaviors>
+        </MenuItem>
+        <MenuItem Header="Open folders"
+                  IsEnabled="{Binding #MenuOpenFolderPicker.CanExecuteCommand}">
+          <Interaction.Behaviors>
+            <MenuItemOpenFolderPickerBehavior x:Name="MenuOpenFolderPicker"
+                                              Command="{Binding MenuPickerCanExecuteCommand}"
+                                              Title="Open Folders"
+                                              AllowMultiple="True"
+                                              StorageProvider="{Binding $parent[TopLevel].StorageProvider}" />
+          </Interaction.Behaviors>
+        </MenuItem>
+        <MenuItem Header="Save file"
+                  IsEnabled="{Binding #MenuSaveFilePicker.CanExecuteCommand}">
+          <Interaction.Behaviors>
+            <MenuItemSaveFilePickerBehavior x:Name="MenuSaveFilePicker"
+                                            Command="{Binding MenuPickerCanExecuteCommand}"
+                                            InputConverter="{x:Static StorageItemToPathConverter.Instance}"
+                                            Title="Save File"
+                                            SuggestedFileName="MyFile"
+                                            DefaultExtension="txt"
+                                            FileTypeChoices="Text Files (*.txt)|*.txt|Markdown Files (*.md)|*.md|All Files (*.*)|*.*" />
+          </Interaction.Behaviors>
+        </MenuItem>
+      </MenuItem>
+    </Menu>
+
+    <Grid Grid.Row="2"
+          Margin="0,0,0,10"
+          ColumnDefinitions="*,8,*,8,*">
+      <TextBlock Grid.Column="0"
+                 Text="{Binding #MenuOpenFilePicker.CanExecuteCommand, StringFormat='Menu open files: {0}'}" />
+      <TextBlock Grid.Column="2"
+                 Text="{Binding #MenuOpenFolderPicker.CanExecuteCommand, StringFormat='Menu open folders: {0}'}" />
+      <TextBlock Grid.Column="4"
+                 Text="{Binding #MenuSaveFilePicker.CanExecuteCommand, StringFormat='Menu save file: {0}'}" />
+    </Grid>
+
+    <Grid Grid.Row="3"
+          ColumnDefinitions="*,8,*,8,*"
+          RowDefinitions="Auto,Auto">
+      <Button Grid.Row="0"
+              Grid.Column="0"
+              Content="Open files"
+              IsEnabled="{Binding #ButtonOpenFilePicker.CanExecuteCommand}">
+        <Interaction.Behaviors>
+          <ButtonOpenFilePickerBehavior x:Name="ButtonOpenFilePicker"
+                                        Command="{Binding ButtonPickerCanExecuteCommand}"
+                                        Title="Open Files"
+                                        SuggestedFileName="MyFile"
+                                        AllowMultiple="True"
+                                        FileTypeFilter="Text Files|*.txt|Markdown Files|*.md|All Files|*.*" />
+        </Interaction.Behaviors>
+      </Button>
+      <Button Grid.Row="0"
+              Grid.Column="2"
+              Content="Open folders"
+              IsEnabled="{Binding #ButtonOpenFolderPicker.CanExecuteCommand}">
+        <Interaction.Behaviors>
+          <ButtonOpenFolderPickerBehavior x:Name="ButtonOpenFolderPicker"
+                                          Command="{Binding ButtonPickerCanExecuteCommand}"
+                                          Title="Open Folders"
+                                          AllowMultiple="True"
+                                          SuggestedStartLocationPath="{Binding DocumentsFolderPath}" />
+        </Interaction.Behaviors>
+      </Button>
+      <Button Grid.Row="0"
+              Grid.Column="4"
+              Content="Save file"
+              IsEnabled="{Binding #ButtonSaveFilePicker.CanExecuteCommand}">
+        <Interaction.Behaviors>
+          <ButtonSaveFilePickerBehavior x:Name="ButtonSaveFilePicker"
+                                        Command="{Binding ButtonPickerCanExecuteCommand}"
+                                        InputConverter="{x:Static StorageItemToPathConverter.Instance}"
+                                        Title="Save File"
+                                        SuggestedFileName="MyFile"
+                                        DefaultExtension="txt"
+                                        FileTypeChoices="Text Files (*.txt)|*.txt|Markdown Files (*.md)|*.md|All Files (*.*)|*.*" />
+        </Interaction.Behaviors>
+      </Button>
+
+      <TextBlock Grid.Row="1"
+                 Grid.Column="0"
+                 Margin="0,4,0,0"
+                 Text="{Binding #ButtonOpenFilePicker.CanExecuteCommand, StringFormat='Button open files: {0}'}" />
+      <TextBlock Grid.Row="1"
+                 Grid.Column="2"
+                 Margin="0,4,0,0"
+                 Text="{Binding #ButtonOpenFolderPicker.CanExecuteCommand, StringFormat='Button open folders: {0}'}" />
+      <TextBlock Grid.Row="1"
+                 Grid.Column="4"
+                 Margin="0,4,0,0"
+                 Text="{Binding #ButtonSaveFilePicker.CanExecuteCommand, StringFormat='Button save file: {0}'}" />
+    </Grid>
+
+    <Grid Grid.Row="4"
+          Margin="0,12,0,0"
+          ColumnDefinitions="2*,8,*">
+      <Border Grid.Column="0"
+              Height="64"
+              Background="LightGreen"
+              CornerRadius="4"
+              Focusable="True"
+              IsEnabled="{Binding #PanelOpenFilePickerAction.CanExecuteCommand}">
+        <Interaction.Behaviors>
+          <ClickEventTrigger>
+            <OpenFilePickerAction x:Name="PanelOpenFilePickerAction"
+                                  Command="{Binding PanelPickerActionCanExecuteCommand}"
+                                  Title="Open Files from Panel Click"
+                                  SuggestedFileName="PanelSample"
+                                  AllowMultiple="True"
+                                  FileTypeFilter="Text Files|*.txt|Markdown Files|*.md|All Files|*.*" />
+          </ClickEventTrigger>
+        </Interaction.Behaviors>
+        <TextBlock HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Open files from panel click" />
+      </Border>
+
+      <TextBlock Grid.Column="2"
+                 VerticalAlignment="Center"
+                 Text="{Binding #PanelOpenFilePickerAction.CanExecuteCommand, StringFormat='Panel action open files: {0}'}" />
+    </Grid>
+
+    <ListBox Grid.Row="5"
+             Margin="0,12,0,0"
+             ItemsSource="{Binding FileItems}" />
+  </Grid>
+</UserControl>

--- a/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml
@@ -28,6 +28,7 @@
           <Interaction.Behaviors>
             <MenuItemOpenFilePickerBehavior x:Name="MenuOpenFilePicker"
                                             Command="{Binding MenuPickerCanExecuteCommand}"
+                                            CanExecuteCommandParameter="MenuOpenFiles"
                                             UseCommandCanExecuteForIsEnabled="True"
                                             Title="Open Files"
                                             SuggestedFileName="MyFile"
@@ -39,6 +40,7 @@
           <Interaction.Behaviors>
             <MenuItemOpenFolderPickerBehavior x:Name="MenuOpenFolderPicker"
                                               Command="{Binding MenuPickerCanExecuteCommand}"
+                                              CanExecuteCommandParameter="MenuOpenFolders"
                                               UseCommandCanExecuteForIsEnabled="True"
                                               Title="Open Folders"
                                               AllowMultiple="True"
@@ -49,6 +51,7 @@
           <Interaction.Behaviors>
             <MenuItemSaveFilePickerBehavior x:Name="MenuSaveFilePicker"
                                             Command="{Binding MenuPickerCanExecuteCommand}"
+                                            CanExecuteCommandParameter="MenuSaveFile"
                                             UseCommandCanExecuteForIsEnabled="True"
                                             InputConverter="{x:Static StorageItemToPathConverter.Instance}"
                                             Title="Save File"
@@ -80,6 +83,7 @@
         <Interaction.Behaviors>
           <ButtonOpenFilePickerBehavior x:Name="ButtonOpenFilePicker"
                                         Command="{Binding ButtonPickerCanExecuteCommand}"
+                                        CanExecuteCommandParameter="ButtonOpenFiles"
                                         UseCommandCanExecuteForIsEnabled="True"
                                         Title="Open Files"
                                         SuggestedFileName="MyFile"
@@ -93,6 +97,7 @@
         <Interaction.Behaviors>
           <ButtonOpenFolderPickerBehavior x:Name="ButtonOpenFolderPicker"
                                           Command="{Binding ButtonPickerCanExecuteCommand}"
+                                          CanExecuteCommandParameter="ButtonOpenFolders"
                                           UseCommandCanExecuteForIsEnabled="True"
                                           Title="Open Folders"
                                           AllowMultiple="True"
@@ -105,6 +110,7 @@
         <Interaction.Behaviors>
           <ButtonSaveFilePickerBehavior x:Name="ButtonSaveFilePicker"
                                         Command="{Binding ButtonPickerCanExecuteCommand}"
+                                        CanExecuteCommandParameter="ButtonSaveFile"
                                         UseCommandCanExecuteForIsEnabled="True"
                                         InputConverter="{x:Static StorageItemToPathConverter.Instance}"
                                         Title="Save File"
@@ -140,6 +146,7 @@
           <ClickEventTrigger>
             <OpenFilePickerAction x:Name="PanelOpenFilePickerAction"
                                   Command="{Binding PanelPickerActionCanExecuteCommand}"
+                                  CanExecuteCommandParameter="PanelOpenFiles"
                                   UseCommandCanExecuteForIsEnabled="True"
                                   Title="Open Files from Panel Click"
                                   SuggestedFileName="PanelSample"

--- a/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml
@@ -24,32 +24,32 @@
 
     <Menu Grid.Row="1" Margin="0,0,0,8">
       <MenuItem Header="File">
-        <MenuItem Header="Open files"
-                  IsEnabled="{Binding #MenuOpenFilePicker.CanExecuteCommand}">
+        <MenuItem Header="Open files">
           <Interaction.Behaviors>
             <MenuItemOpenFilePickerBehavior x:Name="MenuOpenFilePicker"
                                             Command="{Binding MenuPickerCanExecuteCommand}"
+                                            UseCommandCanExecuteForIsEnabled="True"
                                             Title="Open Files"
                                             SuggestedFileName="MyFile"
                                             AllowMultiple="True"
                                             FileTypeFilter="Text Files|*.txt|Markdown Files|*.md|All Files|*.*" />
           </Interaction.Behaviors>
         </MenuItem>
-        <MenuItem Header="Open folders"
-                  IsEnabled="{Binding #MenuOpenFolderPicker.CanExecuteCommand}">
+        <MenuItem Header="Open folders">
           <Interaction.Behaviors>
             <MenuItemOpenFolderPickerBehavior x:Name="MenuOpenFolderPicker"
                                               Command="{Binding MenuPickerCanExecuteCommand}"
+                                              UseCommandCanExecuteForIsEnabled="True"
                                               Title="Open Folders"
                                               AllowMultiple="True"
                                               StorageProvider="{Binding $parent[TopLevel].StorageProvider}" />
           </Interaction.Behaviors>
         </MenuItem>
-        <MenuItem Header="Save file"
-                  IsEnabled="{Binding #MenuSaveFilePicker.CanExecuteCommand}">
+        <MenuItem Header="Save file">
           <Interaction.Behaviors>
             <MenuItemSaveFilePickerBehavior x:Name="MenuSaveFilePicker"
                                             Command="{Binding MenuPickerCanExecuteCommand}"
+                                            UseCommandCanExecuteForIsEnabled="True"
                                             InputConverter="{x:Static StorageItemToPathConverter.Instance}"
                                             Title="Save File"
                                             SuggestedFileName="MyFile"
@@ -76,11 +76,11 @@
           RowDefinitions="Auto,Auto">
       <Button Grid.Row="0"
               Grid.Column="0"
-              Content="Open files"
-              IsEnabled="{Binding #ButtonOpenFilePicker.CanExecuteCommand}">
+              Content="Open files">
         <Interaction.Behaviors>
           <ButtonOpenFilePickerBehavior x:Name="ButtonOpenFilePicker"
                                         Command="{Binding ButtonPickerCanExecuteCommand}"
+                                        UseCommandCanExecuteForIsEnabled="True"
                                         Title="Open Files"
                                         SuggestedFileName="MyFile"
                                         AllowMultiple="True"
@@ -89,11 +89,11 @@
       </Button>
       <Button Grid.Row="0"
               Grid.Column="2"
-              Content="Open folders"
-              IsEnabled="{Binding #ButtonOpenFolderPicker.CanExecuteCommand}">
+              Content="Open folders">
         <Interaction.Behaviors>
           <ButtonOpenFolderPickerBehavior x:Name="ButtonOpenFolderPicker"
                                           Command="{Binding ButtonPickerCanExecuteCommand}"
+                                          UseCommandCanExecuteForIsEnabled="True"
                                           Title="Open Folders"
                                           AllowMultiple="True"
                                           SuggestedStartLocationPath="{Binding DocumentsFolderPath}" />
@@ -101,11 +101,11 @@
       </Button>
       <Button Grid.Row="0"
               Grid.Column="4"
-              Content="Save file"
-              IsEnabled="{Binding #ButtonSaveFilePicker.CanExecuteCommand}">
+              Content="Save file">
         <Interaction.Behaviors>
           <ButtonSaveFilePickerBehavior x:Name="ButtonSaveFilePicker"
                                         Command="{Binding ButtonPickerCanExecuteCommand}"
+                                        UseCommandCanExecuteForIsEnabled="True"
                                         InputConverter="{x:Static StorageItemToPathConverter.Instance}"
                                         Title="Save File"
                                         SuggestedFileName="MyFile"
@@ -135,12 +135,12 @@
               Height="64"
               Background="LightGreen"
               CornerRadius="4"
-              Focusable="True"
-              IsEnabled="{Binding #PanelOpenFilePickerAction.CanExecuteCommand}">
+              Focusable="True">
         <Interaction.Behaviors>
           <ClickEventTrigger>
             <OpenFilePickerAction x:Name="PanelOpenFilePickerAction"
                                   Command="{Binding PanelPickerActionCanExecuteCommand}"
+                                  UseCommandCanExecuteForIsEnabled="True"
                                   Title="Open Files from Panel Click"
                                   SuggestedFileName="PanelSample"
                                   AllowMultiple="True"

--- a/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml.cs
+++ b/samples/BehaviorsTestApplication/Views/Pages/PickerCanExecuteCommandView.axaml.cs
@@ -1,0 +1,17 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BehaviorsTestApplication.Views.Pages;
+
+public partial class PickerCanExecuteCommandView : UserControl
+{
+    public PickerCanExecuteCommandView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Xaml.Behaviors.Interactions.Custom/ExecuteCommand/Core/ExecuteCommandBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/ExecuteCommand/Core/ExecuteCommandBehaviorBase.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
@@ -13,6 +14,9 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// </summary>
 public abstract class ExecuteCommandBehaviorBase : AttachedToVisualTreeBehavior<Control>
 {
+    private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
+    private bool _canExecuteCommand = true;
+
     /// <summary>
     /// 
     /// </summary>
@@ -24,6 +28,12 @@ public abstract class ExecuteCommandBehaviorBase : AttachedToVisualTreeBehavior<
     /// </summary>
     public static readonly StyledProperty<ICommand?> CommandProperty =
         AvaloniaProperty.Register<ExecuteCommandBehaviorBase, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CanExecuteCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<ExecuteCommandBehaviorBase, bool> CanExecuteCommandProperty =
+        AvaloniaProperty.RegisterDirect<ExecuteCommandBehaviorBase, bool>(nameof(CanExecuteCommand), behavior => behavior.CanExecuteCommand);
 
     /// <summary>
     /// 
@@ -50,6 +60,14 @@ public abstract class ExecuteCommandBehaviorBase : AttachedToVisualTreeBehavior<
         AvaloniaProperty.Register<ExecuteCommandBehaviorBase, Control?>(nameof(SourceControl));
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ExecuteCommandBehaviorBase"/> class.
+    /// </summary>
+    protected ExecuteCommandBehaviorBase()
+    {
+        _commandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteCommand);
+    }
+
+    /// <summary>
     /// 
     /// </summary>
     public TopLevel? TopLevel
@@ -65,6 +83,15 @@ public abstract class ExecuteCommandBehaviorBase : AttachedToVisualTreeBehavior<
     {
         get => GetValue(CommandProperty);
         set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Command"/> can execute with the current <see cref="CommandParameter"/>.
+    /// </summary>
+    public bool CanExecuteCommand
+    {
+        get => _canExecuteCommand;
+        private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
     }
 
     /// <summary>
@@ -105,6 +132,32 @@ public abstract class ExecuteCommandBehaviorBase : AttachedToVisualTreeBehavior<
         set => SetValue(SourceControlProperty, value);
     }
 
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        _commandCanExecuteObserver.Start(Command, CommandParameter);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        _commandCanExecuteObserver.Stop();
+
+        base.OnDetaching();
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
+        {
+            _commandCanExecuteObserver.Update(Command, CommandParameter);
+        }
+    }
 
     /// <summary>
     /// Executes the associated command.
@@ -139,5 +192,10 @@ public abstract class ExecuteCommandBehaviorBase : AttachedToVisualTreeBehavior<
 
         Command.Execute(CommandParameter);
         return true;
+    }
+
+    private void SetCanExecuteCommand(bool value)
+    {
+        CanExecuteCommand = value;
     }
 }

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DragDropCommandsBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DragDropCommandsBehavior.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using Avalonia.Input;
+using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.DragAndDrop;
 
@@ -8,6 +9,15 @@ namespace Avalonia.Xaml.Interactions.DragAndDrop;
 /// </summary>
 public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
 {
+    private readonly CommandCanExecuteObserver _dragEnterCommandCanExecuteObserver;
+    private readonly CommandCanExecuteObserver _dragOverCommandCanExecuteObserver;
+    private readonly CommandCanExecuteObserver _dragLeaveCommandCanExecuteObserver;
+    private readonly CommandCanExecuteObserver _dropCommandCanExecuteObserver;
+    private bool _canExecuteDragEnterCommand = true;
+    private bool _canExecuteDragOverCommand = true;
+    private bool _canExecuteDragLeaveCommand = true;
+    private bool _canExecuteDropCommand = true;
+
     /// <summary>
     /// Identifies the <see cref="DragEnterCommand"/> avalonia property.
     /// </summary>
@@ -31,6 +41,49 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     /// </summary>
     public static readonly StyledProperty<ICommand?> DropCommandProperty =
         AvaloniaProperty.Register<DragDropCommandsBehavior, ICommand?>(nameof(DropCommand));
+
+    /// <summary>
+    /// Identifies the <see cref="CanExecuteDragEnterCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<DragDropCommandsBehavior, bool> CanExecuteDragEnterCommandProperty =
+        AvaloniaProperty.RegisterDirect<DragDropCommandsBehavior, bool>(
+            nameof(CanExecuteDragEnterCommand),
+            behavior => behavior.CanExecuteDragEnterCommand);
+
+    /// <summary>
+    /// Identifies the <see cref="CanExecuteDragOverCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<DragDropCommandsBehavior, bool> CanExecuteDragOverCommandProperty =
+        AvaloniaProperty.RegisterDirect<DragDropCommandsBehavior, bool>(
+            nameof(CanExecuteDragOverCommand),
+            behavior => behavior.CanExecuteDragOverCommand);
+
+    /// <summary>
+    /// Identifies the <see cref="CanExecuteDragLeaveCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<DragDropCommandsBehavior, bool> CanExecuteDragLeaveCommandProperty =
+        AvaloniaProperty.RegisterDirect<DragDropCommandsBehavior, bool>(
+            nameof(CanExecuteDragLeaveCommand),
+            behavior => behavior.CanExecuteDragLeaveCommand);
+
+    /// <summary>
+    /// Identifies the <see cref="CanExecuteDropCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<DragDropCommandsBehavior, bool> CanExecuteDropCommandProperty =
+        AvaloniaProperty.RegisterDirect<DragDropCommandsBehavior, bool>(
+            nameof(CanExecuteDropCommand),
+            behavior => behavior.CanExecuteDropCommand);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DragDropCommandsBehavior"/> class.
+    /// </summary>
+    public DragDropCommandsBehavior()
+    {
+        _dragEnterCommandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteDragEnterCommand);
+        _dragOverCommandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteDragOverCommand);
+        _dragLeaveCommandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteDragLeaveCommand);
+        _dropCommandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteDropCommand);
+    }
 
     /// <summary>
     /// Gets or sets the command invoked on drag enter.
@@ -69,9 +122,90 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     }
 
     /// <summary>
+    /// Gets a value indicating whether <see cref="DragEnterCommand"/> can execute without an event-specific parameter.
+    /// </summary>
+    public bool CanExecuteDragEnterCommand
+    {
+        get => _canExecuteDragEnterCommand;
+        private set => SetAndRaise(CanExecuteDragEnterCommandProperty, ref _canExecuteDragEnterCommand, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="DragOverCommand"/> can execute without an event-specific parameter.
+    /// </summary>
+    public bool CanExecuteDragOverCommand
+    {
+        get => _canExecuteDragOverCommand;
+        private set => SetAndRaise(CanExecuteDragOverCommandProperty, ref _canExecuteDragOverCommand, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="DragLeaveCommand"/> can execute without an event-specific parameter.
+    /// </summary>
+    public bool CanExecuteDragLeaveCommand
+    {
+        get => _canExecuteDragLeaveCommand;
+        private set => SetAndRaise(CanExecuteDragLeaveCommandProperty, ref _canExecuteDragLeaveCommand, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="DropCommand"/> can execute without an event-specific parameter.
+    /// </summary>
+    public bool CanExecuteDropCommand
+    {
+        get => _canExecuteDropCommand;
+        private set => SetAndRaise(CanExecuteDropCommandProperty, ref _canExecuteDropCommand, value);
+    }
+
+    /// <summary>
     /// Specifies whether the event args should be passed to the command.
     /// </summary>
     public bool PassEventArgsToCommand { get; set; } = true;
+
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        _dragEnterCommandCanExecuteObserver.Start(DragEnterCommand, null);
+        _dragOverCommandCanExecuteObserver.Start(DragOverCommand, null);
+        _dragLeaveCommandCanExecuteObserver.Start(DragLeaveCommand, null);
+        _dropCommandCanExecuteObserver.Start(DropCommand, null);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        _dragEnterCommandCanExecuteObserver.Stop();
+        _dragOverCommandCanExecuteObserver.Stop();
+        _dragLeaveCommandCanExecuteObserver.Stop();
+        _dropCommandCanExecuteObserver.Stop();
+
+        base.OnDetaching();
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == DragEnterCommandProperty)
+        {
+            _dragEnterCommandCanExecuteObserver.Update(DragEnterCommand, null);
+        }
+        else if (change.Property == DragOverCommandProperty)
+        {
+            _dragOverCommandCanExecuteObserver.Update(DragOverCommand, null);
+        }
+        else if (change.Property == DragLeaveCommandProperty)
+        {
+            _dragLeaveCommandCanExecuteObserver.Update(DragLeaveCommand, null);
+        }
+        else if (change.Property == DropCommandProperty)
+        {
+            _dropCommandCanExecuteObserver.Update(DropCommand, null);
+        }
+    }
 
     private void ExecuteCommand(ICommand? command, DragEventArgs e)
     {
@@ -99,4 +233,24 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
 
     /// <inheritdoc />
     protected override void OnDrop(object? sender, DragEventArgs e) => ExecuteCommand(DropCommand, e);
+
+    private void SetCanExecuteDragEnterCommand(bool value)
+    {
+        CanExecuteDragEnterCommand = value;
+    }
+
+    private void SetCanExecuteDragOverCommand(bool value)
+    {
+        CanExecuteDragOverCommand = value;
+    }
+
+    private void SetCanExecuteDragLeaveCommand(bool value)
+    {
+        CanExecuteDragLeaveCommand = value;
+    }
+
+    private void SetCanExecuteDropCommand(bool value)
+    {
+        CanExecuteDropCommand = value;
+    }
 }

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/DragDropCommandsBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/DragDropCommandsBehavior.cs
@@ -17,6 +17,7 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     private bool _canExecuteDragOverCommand = true;
     private bool _canExecuteDragLeaveCommand = true;
     private bool _canExecuteDropCommand = true;
+    private bool _passEventArgsToCommand = true;
 
     /// <summary>
     /// Identifies the <see cref="DragEnterCommand"/> avalonia property.
@@ -41,6 +42,12 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     /// </summary>
     public static readonly StyledProperty<ICommand?> DropCommandProperty =
         AvaloniaProperty.Register<DragDropCommandsBehavior, ICommand?>(nameof(DropCommand));
+
+    /// <summary>
+    /// Identifies the <see cref="CanExecuteCommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CanExecuteCommandParameterProperty =
+        AvaloniaProperty.Register<DragDropCommandsBehavior, object?>(nameof(CanExecuteCommandParameter));
 
     /// <summary>
     /// Identifies the <see cref="CanExecuteDragEnterCommand"/> avalonia property.
@@ -122,7 +129,17 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     }
 
     /// <summary>
-    /// Gets a value indicating whether <see cref="DragEnterCommand"/> can execute without an event-specific parameter.
+    /// Gets or sets the parameter used to evaluate the drag-and-drop commands before event-specific parameters are available.
+    /// This property does not change the parameter passed to command execution.
+    /// </summary>
+    public object? CanExecuteCommandParameter
+    {
+        get => GetValue(CanExecuteCommandParameterProperty);
+        set => SetValue(CanExecuteCommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="DragEnterCommand"/> can execute with the current can-execute parameter.
     /// </summary>
     public bool CanExecuteDragEnterCommand
     {
@@ -131,7 +148,7 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     }
 
     /// <summary>
-    /// Gets a value indicating whether <see cref="DragOverCommand"/> can execute without an event-specific parameter.
+    /// Gets a value indicating whether <see cref="DragOverCommand"/> can execute with the current can-execute parameter.
     /// </summary>
     public bool CanExecuteDragOverCommand
     {
@@ -140,7 +157,7 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     }
 
     /// <summary>
-    /// Gets a value indicating whether <see cref="DragLeaveCommand"/> can execute without an event-specific parameter.
+    /// Gets a value indicating whether <see cref="DragLeaveCommand"/> can execute with the current can-execute parameter.
     /// </summary>
     public bool CanExecuteDragLeaveCommand
     {
@@ -149,7 +166,7 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     }
 
     /// <summary>
-    /// Gets a value indicating whether <see cref="DropCommand"/> can execute without an event-specific parameter.
+    /// Gets a value indicating whether <see cref="DropCommand"/> can execute with the current can-execute parameter.
     /// </summary>
     public bool CanExecuteDropCommand
     {
@@ -160,17 +177,27 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
     /// <summary>
     /// Specifies whether the event args should be passed to the command.
     /// </summary>
-    public bool PassEventArgsToCommand { get; set; } = true;
+    public bool PassEventArgsToCommand
+    {
+        get => _passEventArgsToCommand;
+        set
+        {
+            if (_passEventArgsToCommand == value)
+            {
+                return;
+            }
+
+            _passEventArgsToCommand = value;
+            UpdateCanExecuteObservers();
+        }
+    }
 
     /// <inheritdoc />
     protected override void OnAttached()
     {
         base.OnAttached();
 
-        _dragEnterCommandCanExecuteObserver.Start(DragEnterCommand, null);
-        _dragOverCommandCanExecuteObserver.Start(DragOverCommand, null);
-        _dragLeaveCommandCanExecuteObserver.Start(DragLeaveCommand, null);
-        _dropCommandCanExecuteObserver.Start(DropCommand, null);
+        StartCanExecuteObservers();
     }
 
     /// <inheritdoc />
@@ -191,19 +218,35 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
 
         if (change.Property == DragEnterCommandProperty)
         {
-            _dragEnterCommandCanExecuteObserver.Update(DragEnterCommand, null);
+            _dragEnterCommandCanExecuteObserver.Update(
+                DragEnterCommand,
+                ResolveCanExecuteParameter(),
+                IsCanExecuteParameterKnown());
         }
         else if (change.Property == DragOverCommandProperty)
         {
-            _dragOverCommandCanExecuteObserver.Update(DragOverCommand, null);
+            _dragOverCommandCanExecuteObserver.Update(
+                DragOverCommand,
+                ResolveCanExecuteParameter(),
+                IsCanExecuteParameterKnown());
         }
         else if (change.Property == DragLeaveCommandProperty)
         {
-            _dragLeaveCommandCanExecuteObserver.Update(DragLeaveCommand, null);
+            _dragLeaveCommandCanExecuteObserver.Update(
+                DragLeaveCommand,
+                ResolveCanExecuteParameter(),
+                IsCanExecuteParameterKnown());
         }
         else if (change.Property == DropCommandProperty)
         {
-            _dropCommandCanExecuteObserver.Update(DropCommand, null);
+            _dropCommandCanExecuteObserver.Update(
+                DropCommand,
+                ResolveCanExecuteParameter(),
+                IsCanExecuteParameterKnown());
+        }
+        else if (change.Property == CanExecuteCommandParameterProperty)
+        {
+            UpdateCanExecuteObservers();
         }
     }
 
@@ -233,6 +276,38 @@ public sealed class DragDropCommandsBehavior : DragAndDropEventsBehavior
 
     /// <inheritdoc />
     protected override void OnDrop(object? sender, DragEventArgs e) => ExecuteCommand(DropCommand, e);
+
+    private void StartCanExecuteObservers()
+    {
+        var parameter = ResolveCanExecuteParameter();
+        var isParameterKnown = IsCanExecuteParameterKnown();
+
+        _dragEnterCommandCanExecuteObserver.Start(DragEnterCommand, parameter, isParameterKnown);
+        _dragOverCommandCanExecuteObserver.Start(DragOverCommand, parameter, isParameterKnown);
+        _dragLeaveCommandCanExecuteObserver.Start(DragLeaveCommand, parameter, isParameterKnown);
+        _dropCommandCanExecuteObserver.Start(DropCommand, parameter, isParameterKnown);
+    }
+
+    private void UpdateCanExecuteObservers()
+    {
+        var parameter = ResolveCanExecuteParameter();
+        var isParameterKnown = IsCanExecuteParameterKnown();
+
+        _dragEnterCommandCanExecuteObserver.Update(DragEnterCommand, parameter, isParameterKnown);
+        _dragOverCommandCanExecuteObserver.Update(DragOverCommand, parameter, isParameterKnown);
+        _dragLeaveCommandCanExecuteObserver.Update(DragLeaveCommand, parameter, isParameterKnown);
+        _dropCommandCanExecuteObserver.Update(DropCommand, parameter, isParameterKnown);
+    }
+
+    private object? ResolveCanExecuteParameter()
+    {
+        return IsSet(CanExecuteCommandParameterProperty) ? CanExecuteCommandParameter : null;
+    }
+
+    private bool IsCanExecuteParameterKnown()
+    {
+        return IsSet(CanExecuteCommandParameterProperty) || !PassEventArgsToCommand;
+    }
 
     private void SetCanExecuteDragEnterCommand(bool value)
     {

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerActionBase.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerActionBase.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
@@ -16,6 +18,8 @@ namespace Avalonia.Xaml.Interactions.Core;
 /// </summary>
 public abstract class PickerActionBase : InvokeCommandActionBase
 {
+    private readonly List<Task> _activePickerOperations = [];
+
     /// <summary>
     /// Identifies the <seealso cref="StorageProvider"/> avalonia property.
     /// </summary>
@@ -142,6 +146,52 @@ public abstract class PickerActionBase : InvokeCommandActionBase
             SuggestedStartLocationPath,
             CreateSuggestedStartLocationDirectory,
             provider);
+    }
+
+    /// <summary>
+    /// Keeps an asynchronous picker operation rooted until it completes.
+    /// </summary>
+    /// <param name="operation">The picker operation to track.</param>
+    /// <returns>The tracked operation.</returns>
+    protected Task TrackPickerOperation(Task operation)
+    {
+        lock (_activePickerOperations)
+        {
+            _activePickerOperations.Add(operation);
+        }
+
+        _ = RemoveCompletedPickerOperationAsync(operation);
+        return operation;
+    }
+
+    internal int ActivePickerOperationCount
+    {
+        get
+        {
+            lock (_activePickerOperations)
+            {
+                return _activePickerOperations.Count;
+            }
+        }
+    }
+
+    private async Task RemoveCompletedPickerOperationAsync(Task operation)
+    {
+        try
+        {
+            await operation.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The caller receives the original task; this continuation only owns lifetime cleanup.
+        }
+        finally
+        {
+            lock (_activePickerOperations)
+            {
+                _activePickerOperations.Remove(operation);
+            }
+        }
     }
 
     private static IStorageProvider? ResolveFromObject(object? target)

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerActionBase.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/Core/PickerActionBase.cs
@@ -8,6 +8,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Avalonia.Xaml.Interactivity;
 
@@ -162,6 +163,18 @@ public abstract class PickerActionBase : InvokeCommandActionBase
 
         _ = RemoveCompletedPickerOperationAsync(operation);
         return operation;
+    }
+
+    /// <summary>
+    /// Runs and tracks an asynchronous picker operation on the UI thread.
+    /// </summary>
+    /// <param name="operation">The picker operation to run.</param>
+    /// <returns>The tracked dispatcher operation.</returns>
+    protected Task TrackDispatchedPickerOperation(Func<Task> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        return TrackPickerOperation(Dispatcher.UIThread.InvokeAsync(operation));
     }
 
     internal int ActivePickerOperationCount

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFilePickerAction.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFilePickerAction.cs
@@ -70,7 +70,7 @@ public class OpenFilePickerAction : PickerActionBase
             return false;
         }
 
-        return TrackPickerOperation(OpenFilePickerAsync(visual));
+        return TrackDispatchedPickerOperation(() => OpenFilePickerAsync(visual));
     }
 
     private async Task OpenFilePickerAsync(Visual visual)

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFilePickerAction.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFilePickerAction.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Platform.Storage;
-using Avalonia.Threading;
 
 namespace Avalonia.Xaml.Interactions.Core;
 
@@ -63,17 +62,15 @@ public class OpenFilePickerAction : PickerActionBase
     /// </summary>
     /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Avalonia.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
     /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-    /// <returns>True if the command is successfully executed; else false.</returns>
+    /// <returns>The started picker task; otherwise false when the sender is not a visual.</returns>
     public override object Execute(object? sender, object? parameter)
     {
         if (sender is not Visual visual)
         {
             return false;
         }
-        
-        Dispatcher.UIThread.InvokeAsync(async () => await OpenFilePickerAsync(visual));
 
-        return true; 
+        return TrackPickerOperation(OpenFilePickerAsync(visual));
     }
 
     private async Task OpenFilePickerAsync(Visual visual)

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFolderPickerAction.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFolderPickerAction.cs
@@ -55,7 +55,7 @@ public class OpenFolderPickerAction : PickerActionBase
             return false;
         }
 
-        return TrackPickerOperation(OpenFolderPickerAsync(visual));
+        return TrackDispatchedPickerOperation(() => OpenFolderPickerAsync(visual));
     }
 
     private async Task OpenFolderPickerAsync(Visual visual)

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFolderPickerAction.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/OpenFolderPickerAction.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Platform.Storage;
-using Avalonia.Threading;
 
 namespace Avalonia.Xaml.Interactions.Core;
 
@@ -48,7 +47,7 @@ public class OpenFolderPickerAction : PickerActionBase
     /// </summary>
     /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Avalonia.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
     /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-    /// <returns>True if the command is successfully executed; else false.</returns>
+    /// <returns>The started picker task; otherwise false when the sender is not a visual.</returns>
     public override object Execute(object? sender, object? parameter)
     {
         if (sender is not Visual visual)
@@ -56,9 +55,7 @@ public class OpenFolderPickerAction : PickerActionBase
             return false;
         }
 
-        Dispatcher.UIThread.InvokeAsync(async () => await OpenFolderPickerAsync(visual));
-
-        return true; 
+        return TrackPickerOperation(OpenFolderPickerAsync(visual));
     }
 
     private async Task OpenFolderPickerAsync(Visual visual)

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/SaveFilePickerAction.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/SaveFilePickerAction.cs
@@ -85,7 +85,7 @@ public class SaveFilePickerAction : PickerActionBase
             return false;
         }
 
-        return TrackPickerOperation(SaveFilePickerAsync(visual));
+        return TrackDispatchedPickerOperation(() => SaveFilePickerAsync(visual));
     }
 
     private async Task SaveFilePickerAsync(Visual visual)

--- a/src/Xaml.Behaviors.Interactions/StorageProvider/SaveFilePickerAction.cs
+++ b/src/Xaml.Behaviors.Interactions/StorageProvider/SaveFilePickerAction.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Platform.Storage;
-using Avalonia.Threading;
 
 namespace Avalonia.Xaml.Interactions.Core;
 
@@ -78,17 +77,15 @@ public class SaveFilePickerAction : PickerActionBase
     /// </summary>
     /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Avalonia.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
     /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-    /// <returns>True if the command is successfully executed; else false.</returns>
+    /// <returns>The started picker task; otherwise false when the sender is not a visual.</returns>
     public override object Execute(object? sender, object? parameter)
     {
         if (sender is not Visual visual)
         {
             return false;
         }
-        
-        Dispatcher.UIThread.InvokeAsync(async () => await SaveFilePickerAsync(visual));
 
-        return true; 
+        return TrackPickerOperation(SaveFilePickerAsync(visual));
     }
 
     private async Task SaveFilePickerAsync(Visual visual)

--- a/src/Xaml.Behaviors.Interactivity/Actions/InvokeCommandActionBase.cs
+++ b/src/Xaml.Behaviors.Interactivity/Actions/InvokeCommandActionBase.cs
@@ -16,6 +16,7 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
     private readonly CommandCanExecuteIsEnabledBinder _commandCanExecuteIsEnabledBinder;
     private bool _canExecuteCommand = true;
+    private bool _passEventArgsToCommand;
 
     /// <summary>
     /// Identifies the <seealso cref="Command"/> avalonia property.
@@ -28,6 +29,12 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     /// </summary>
     public static readonly DirectProperty<InvokeCommandActionBase, bool> CanExecuteCommandProperty =
         AvaloniaProperty.RegisterDirect<InvokeCommandActionBase, bool>(nameof(CanExecuteCommand), action => action.CanExecuteCommand);
+
+    /// <summary>
+    /// Identifies the <seealso cref="CanExecuteCommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CanExecuteCommandParameterProperty =
+        AvaloniaProperty.Register<InvokeCommandActionBase, object?>(nameof(CanExecuteCommandParameter));
 
     /// <summary>
     /// Identifies the <seealso cref="UseCommandCanExecuteForIsEnabled"/> avalonia property.
@@ -79,12 +86,23 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     }
 
     /// <summary>
-    /// Gets a value indicating whether <see cref="Command"/> can execute with the current <see cref="CommandParameter"/>.
+    /// Gets a value indicating whether <see cref="Command"/> can execute with the current can-execute parameter.
     /// </summary>
     public bool CanExecuteCommand
     {
         get => _canExecuteCommand;
         private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter that is passed to <see cref="ICommand.CanExecute(object)"/>.
+    /// When this property is not set, <see cref="CommandParameter"/> is used if it is set.
+    /// This property does not change the parameter passed to <see cref="ICommand.Execute(object)"/>.
+    /// </summary>
+    public object? CanExecuteCommandParameter
+    {
+        get => GetValue(CanExecuteCommandParameterProperty);
+        set => SetValue(CanExecuteCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -143,11 +161,24 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     /// <summary>
     /// Specifies whether the EventArgs of the event that triggered this action should be passed to the Command as a parameter.
     /// </summary>
-    public bool PassEventArgsToCommand { get; set; }
+    public bool PassEventArgsToCommand
+    {
+        get => _passEventArgsToCommand;
+        set
+        {
+            if (_passEventArgsToCommand == value)
+            {
+                return;
+            }
+
+            _passEventArgsToCommand = value;
+            _commandCanExecuteObserver.Update(Command, ResolveCanExecuteParameter(), IsCanExecuteParameterKnown());
+        }
+    }
 
     void IActionLogicalTreeLifecycle.AttachedToActionLogicalTree()
     {
-        _commandCanExecuteObserver.Start(Command, CommandParameter);
+        _commandCanExecuteObserver.Start(Command, ResolveCanExecuteParameter(), IsCanExecuteParameterKnown());
         UpdateCommandCanExecuteIsEnabledBinding();
     }
 
@@ -162,9 +193,12 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
+        if (change.Property == CommandProperty ||
+            change.Property == CommandParameterProperty ||
+            change.Property == CanExecuteCommandParameterProperty ||
+            change.Property == InputConverterProperty)
         {
-            _commandCanExecuteObserver.Update(Command, CommandParameter);
+            _commandCanExecuteObserver.Update(Command, ResolveCanExecuteParameter(), IsCanExecuteParameterKnown());
         }
         else if (change.Property == UseCommandCanExecuteForIsEnabledProperty)
         {
@@ -205,6 +239,23 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
         }
 
         return resolvedParameter;
+    }
+
+    private object? ResolveCanExecuteParameter()
+    {
+        if (IsSet(CanExecuteCommandParameterProperty))
+        {
+            return CanExecuteCommandParameter;
+        }
+
+        return IsSet(CommandParameterProperty) ? CommandParameter : null;
+    }
+
+    private bool IsCanExecuteParameterKnown()
+    {
+        return IsSet(CanExecuteCommandParameterProperty) ||
+               IsSet(CommandParameterProperty) ||
+               (InputConverter is null && !PassEventArgsToCommand);
     }
 
     private void SetCanExecuteCommand(bool value)

--- a/src/Xaml.Behaviors.Interactivity/Actions/InvokeCommandActionBase.cs
+++ b/src/Xaml.Behaviors.Interactivity/Actions/InvokeCommandActionBase.cs
@@ -8,13 +8,22 @@ namespace Avalonia.Xaml.Interactivity;
 /// <summary>
 /// Command action base class.
 /// </summary>
-public abstract class InvokeCommandActionBase : StyledElementAction
+public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogicalTreeLifecycle
 {
+    private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
+    private bool _canExecuteCommand = true;
+
     /// <summary>
     /// Identifies the <seealso cref="Command"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<ICommand?> CommandProperty =
         AvaloniaProperty.Register<InvokeCommandActionBase, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CanExecuteCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<InvokeCommandActionBase, bool> CanExecuteCommandProperty =
+        AvaloniaProperty.RegisterDirect<InvokeCommandActionBase, bool>(nameof(CanExecuteCommand), action => action.CanExecuteCommand);
 
     /// <summary>
     /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
@@ -42,12 +51,29 @@ public abstract class InvokeCommandActionBase : StyledElementAction
         AvaloniaProperty.Register<InvokeCommandActionBase, string?>(nameof(InputConverterLanguage), string.Empty);
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="InvokeCommandActionBase"/> class.
+    /// </summary>
+    protected InvokeCommandActionBase()
+    {
+        _commandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteCommand);
+    }
+
+    /// <summary>
     /// Gets or sets the command this action should invoke. This is an avalonia property.
     /// </summary>
     public ICommand? Command
     {
         get => GetValue(CommandProperty);
         set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Command"/> can execute with the current <see cref="CommandParameter"/>.
+    /// </summary>
+    public bool CanExecuteCommand
+    {
+        get => _canExecuteCommand;
+        private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
     }
   
     /// <summary>
@@ -98,6 +124,27 @@ public abstract class InvokeCommandActionBase : StyledElementAction
     /// </summary>
     public bool PassEventArgsToCommand { get; set; }
 
+    void IActionLogicalTreeLifecycle.AttachedToActionLogicalTree()
+    {
+        _commandCanExecuteObserver.Start(Command, CommandParameter);
+    }
+
+    void IActionLogicalTreeLifecycle.DetachedFromActionLogicalTree()
+    {
+        _commandCanExecuteObserver.Stop();
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
+        {
+            _commandCanExecuteObserver.Update(Command, CommandParameter);
+        }
+    }
+
     /// <summary>
     /// Resolves the command parameter that will be passed to the
     /// associated <see cref="System.Windows.Input.ICommand"/>.
@@ -131,5 +178,10 @@ public abstract class InvokeCommandActionBase : StyledElementAction
         }
 
         return resolvedParameter;
+    }
+
+    private void SetCanExecuteCommand(bool value)
+    {
+        CanExecuteCommand = value;
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/Actions/InvokeCommandActionBase.cs
+++ b/src/Xaml.Behaviors.Interactivity/Actions/InvokeCommandActionBase.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Windows.Input;
 using Avalonia.Data.Converters;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Avalonia.Reactive;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -11,6 +14,7 @@ namespace Avalonia.Xaml.Interactivity;
 public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogicalTreeLifecycle
 {
     private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
+    private readonly CommandCanExecuteIsEnabledBinder _commandCanExecuteIsEnabledBinder;
     private bool _canExecuteCommand = true;
 
     /// <summary>
@@ -24,6 +28,12 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     /// </summary>
     public static readonly DirectProperty<InvokeCommandActionBase, bool> CanExecuteCommandProperty =
         AvaloniaProperty.RegisterDirect<InvokeCommandActionBase, bool>(nameof(CanExecuteCommand), action => action.CanExecuteCommand);
+
+    /// <summary>
+    /// Identifies the <seealso cref="UseCommandCanExecuteForIsEnabled"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> UseCommandCanExecuteForIsEnabledProperty =
+        AvaloniaProperty.Register<InvokeCommandActionBase, bool>(nameof(UseCommandCanExecuteForIsEnabled));
 
     /// <summary>
     /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
@@ -56,6 +66,7 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     protected InvokeCommandActionBase()
     {
         _commandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteCommand);
+        _commandCanExecuteIsEnabledBinder = new CommandCanExecuteIsEnabledBinder();
     }
 
     /// <summary>
@@ -74,6 +85,16 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     {
         get => _canExecuteCommand;
         private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the control associated with the hosting trigger should have its
+    /// <see cref="InputElement.IsEnabled"/> property follow <see cref="CanExecuteCommand"/>.
+    /// </summary>
+    public bool UseCommandCanExecuteForIsEnabled
+    {
+        get => GetValue(UseCommandCanExecuteForIsEnabledProperty);
+        set => SetValue(UseCommandCanExecuteForIsEnabledProperty, value);
     }
   
     /// <summary>
@@ -127,10 +148,12 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     void IActionLogicalTreeLifecycle.AttachedToActionLogicalTree()
     {
         _commandCanExecuteObserver.Start(Command, CommandParameter);
+        UpdateCommandCanExecuteIsEnabledBinding();
     }
 
     void IActionLogicalTreeLifecycle.DetachedFromActionLogicalTree()
     {
+        _commandCanExecuteIsEnabledBinder.Stop();
         _commandCanExecuteObserver.Stop();
     }
 
@@ -142,6 +165,10 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
         if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
         {
             _commandCanExecuteObserver.Update(Command, CommandParameter);
+        }
+        else if (change.Property == UseCommandCanExecuteForIsEnabledProperty)
+        {
+            UpdateCommandCanExecuteIsEnabledBinding();
         }
     }
 
@@ -183,5 +210,31 @@ public abstract class InvokeCommandActionBase : StyledElementAction, IActionLogi
     private void SetCanExecuteCommand(bool value)
     {
         CanExecuteCommand = value;
+    }
+
+    private void UpdateCommandCanExecuteIsEnabledBinding()
+    {
+        _commandCanExecuteIsEnabledBinder.Update(
+            ResolveCommandCanExecuteIsEnabledTarget(),
+            UseCommandCanExecuteForIsEnabled,
+            AvaloniaObjectExtensions.GetObservable(this, CanExecuteCommandProperty));
+    }
+
+    private InputElement? ResolveCommandCanExecuteIsEnabledTarget()
+    {
+        foreach (var logical in this.GetSelfAndLogicalAncestors())
+        {
+            if (logical is IBehavior { AssociatedObject: InputElement associatedInputElement })
+            {
+                return associatedInputElement;
+            }
+
+            if (logical is InputElement inputElement)
+            {
+                return inputElement;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/Behaviors/InvokeCommandBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactivity/Behaviors/InvokeCommandBehaviorBase.cs
@@ -3,6 +3,7 @@
 using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
+using Avalonia.Reactive;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -12,6 +13,7 @@ namespace Avalonia.Xaml.Interactivity;
 public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
 {
     private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
+    private readonly CommandCanExecuteIsEnabledBinder _commandCanExecuteIsEnabledBinder;
     private bool _canExecuteCommand = true;
 
     /// <summary>
@@ -25,6 +27,12 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     /// </summary>
     public static readonly DirectProperty<InvokeCommandBehaviorBase, bool> CanExecuteCommandProperty =
         AvaloniaProperty.RegisterDirect<InvokeCommandBehaviorBase, bool>(nameof(CanExecuteCommand), behavior => behavior.CanExecuteCommand);
+
+    /// <summary>
+    /// Identifies the <seealso cref="UseCommandCanExecuteForIsEnabled"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> UseCommandCanExecuteForIsEnabledProperty =
+        AvaloniaProperty.Register<InvokeCommandBehaviorBase, bool>(nameof(UseCommandCanExecuteForIsEnabled));
 
     /// <summary>
     /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
@@ -57,6 +65,7 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     protected InvokeCommandBehaviorBase()
     {
         _commandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteCommand);
+        _commandCanExecuteIsEnabledBinder = new CommandCanExecuteIsEnabledBinder();
     }
 
     /// <summary>
@@ -75,6 +84,16 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     {
         get => _canExecuteCommand;
         private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the associated control's
+    /// <see cref="Avalonia.Input.InputElement.IsEnabled"/> property should follow <see cref="CanExecuteCommand"/>.
+    /// </summary>
+    public bool UseCommandCanExecuteForIsEnabled
+    {
+        get => GetValue(UseCommandCanExecuteForIsEnabledProperty);
+        set => SetValue(UseCommandCanExecuteForIsEnabledProperty, value);
     }
   
     /// <summary>
@@ -131,11 +150,13 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
         base.OnAttached();
 
         _commandCanExecuteObserver.Start(Command, CommandParameter);
+        UpdateCommandCanExecuteIsEnabledBinding();
     }
 
     /// <inheritdoc />
     protected override void OnDetaching()
     {
+        _commandCanExecuteIsEnabledBinder.Stop();
         _commandCanExecuteObserver.Stop();
 
         base.OnDetaching();
@@ -149,6 +170,10 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
         if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
         {
             _commandCanExecuteObserver.Update(Command, CommandParameter);
+        }
+        else if (change.Property == UseCommandCanExecuteForIsEnabledProperty)
+        {
+            UpdateCommandCanExecuteIsEnabledBinding();
         }
     }
 
@@ -190,5 +215,13 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     private void SetCanExecuteCommand(bool value)
     {
         CanExecuteCommand = value;
+    }
+
+    private void UpdateCommandCanExecuteIsEnabledBinding()
+    {
+        _commandCanExecuteIsEnabledBinder.Update(
+            AssociatedObject,
+            UseCommandCanExecuteForIsEnabled,
+            AvaloniaObjectExtensions.GetObservable(this, CanExecuteCommandProperty));
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/Behaviors/InvokeCommandBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactivity/Behaviors/InvokeCommandBehaviorBase.cs
@@ -15,6 +15,7 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
     private readonly CommandCanExecuteIsEnabledBinder _commandCanExecuteIsEnabledBinder;
     private bool _canExecuteCommand = true;
+    private bool _passEventArgsToCommand;
 
     /// <summary>
     /// Identifies the <seealso cref="Command"/> avalonia property.
@@ -27,6 +28,12 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     /// </summary>
     public static readonly DirectProperty<InvokeCommandBehaviorBase, bool> CanExecuteCommandProperty =
         AvaloniaProperty.RegisterDirect<InvokeCommandBehaviorBase, bool>(nameof(CanExecuteCommand), behavior => behavior.CanExecuteCommand);
+
+    /// <summary>
+    /// Identifies the <seealso cref="CanExecuteCommandParameter"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<object?> CanExecuteCommandParameterProperty =
+        AvaloniaProperty.Register<InvokeCommandBehaviorBase, object?>(nameof(CanExecuteCommandParameter));
 
     /// <summary>
     /// Identifies the <seealso cref="UseCommandCanExecuteForIsEnabled"/> avalonia property.
@@ -78,12 +85,23 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     }
 
     /// <summary>
-    /// Gets a value indicating whether <see cref="Command"/> can execute with the current <see cref="CommandParameter"/>.
+    /// Gets a value indicating whether <see cref="Command"/> can execute with the current can-execute parameter.
     /// </summary>
     public bool CanExecuteCommand
     {
         get => _canExecuteCommand;
         private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter that is passed to <see cref="ICommand.CanExecute(object)"/>.
+    /// When this property is not set, <see cref="CommandParameter"/> is used if it is set.
+    /// This property does not change the parameter passed to <see cref="ICommand.Execute(object)"/>.
+    /// </summary>
+    public object? CanExecuteCommandParameter
+    {
+        get => GetValue(CanExecuteCommandParameterProperty);
+        set => SetValue(CanExecuteCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -142,14 +160,27 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     /// <summary>
     /// Specifies whether the EventArgs of the event that triggered this action should be passed to the Command as a parameter.
     /// </summary>
-    public bool PassEventArgsToCommand { get; set; }
+    public bool PassEventArgsToCommand
+    {
+        get => _passEventArgsToCommand;
+        set
+        {
+            if (_passEventArgsToCommand == value)
+            {
+                return;
+            }
+
+            _passEventArgsToCommand = value;
+            _commandCanExecuteObserver.Update(Command, ResolveCanExecuteParameter(), IsCanExecuteParameterKnown());
+        }
+    }
 
     /// <inheritdoc />
     protected override void OnAttached()
     {
         base.OnAttached();
 
-        _commandCanExecuteObserver.Start(Command, CommandParameter);
+        _commandCanExecuteObserver.Start(Command, ResolveCanExecuteParameter(), IsCanExecuteParameterKnown());
         UpdateCommandCanExecuteIsEnabledBinding();
     }
 
@@ -167,9 +198,12 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
+        if (change.Property == CommandProperty ||
+            change.Property == CommandParameterProperty ||
+            change.Property == CanExecuteCommandParameterProperty ||
+            change.Property == InputConverterProperty)
         {
-            _commandCanExecuteObserver.Update(Command, CommandParameter);
+            _commandCanExecuteObserver.Update(Command, ResolveCanExecuteParameter(), IsCanExecuteParameterKnown());
         }
         else if (change.Property == UseCommandCanExecuteForIsEnabledProperty)
         {
@@ -210,6 +244,23 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
         }
 
         return resolvedParameter;
+    }
+
+    private object? ResolveCanExecuteParameter()
+    {
+        if (IsSet(CanExecuteCommandParameterProperty))
+        {
+            return CanExecuteCommandParameter;
+        }
+
+        return IsSet(CommandParameterProperty) ? CommandParameter : null;
+    }
+
+    private bool IsCanExecuteParameterKnown()
+    {
+        return IsSet(CanExecuteCommandParameterProperty) ||
+               IsSet(CommandParameterProperty) ||
+               (InputConverter is null && !PassEventArgsToCommand);
     }
 
     private void SetCanExecuteCommand(bool value)

--- a/src/Xaml.Behaviors.Interactivity/Behaviors/InvokeCommandBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactivity/Behaviors/InvokeCommandBehaviorBase.cs
@@ -11,11 +11,20 @@ namespace Avalonia.Xaml.Interactivity;
 /// </summary>
 public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
 {
+    private readonly CommandCanExecuteObserver _commandCanExecuteObserver;
+    private bool _canExecuteCommand = true;
+
     /// <summary>
     /// Identifies the <seealso cref="Command"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<ICommand?> CommandProperty =
         AvaloniaProperty.Register<InvokeCommandBehaviorBase, ICommand?>(nameof(Command));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CanExecuteCommand"/> avalonia property.
+    /// </summary>
+    public static readonly DirectProperty<InvokeCommandBehaviorBase, bool> CanExecuteCommandProperty =
+        AvaloniaProperty.RegisterDirect<InvokeCommandBehaviorBase, bool>(nameof(CanExecuteCommand), behavior => behavior.CanExecuteCommand);
 
     /// <summary>
     /// Identifies the <seealso cref="CommandParameter"/> avalonia property.
@@ -43,12 +52,29 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
         AvaloniaProperty.Register<InvokeCommandBehaviorBase, string?>(nameof(InputConverterLanguage), string.Empty);
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="InvokeCommandBehaviorBase"/> class.
+    /// </summary>
+    protected InvokeCommandBehaviorBase()
+    {
+        _commandCanExecuteObserver = new CommandCanExecuteObserver(SetCanExecuteCommand);
+    }
+
+    /// <summary>
     /// Gets or sets the command this action should invoke. This is an avalonia property.
     /// </summary>
     public ICommand? Command
     {
         get => GetValue(CommandProperty);
         set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Command"/> can execute with the current <see cref="CommandParameter"/>.
+    /// </summary>
+    public bool CanExecuteCommand
+    {
+        get => _canExecuteCommand;
+        private set => SetAndRaise(CanExecuteCommandProperty, ref _canExecuteCommand, value);
     }
   
     /// <summary>
@@ -99,6 +125,33 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
     /// </summary>
     public bool PassEventArgsToCommand { get; set; }
 
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        _commandCanExecuteObserver.Start(Command, CommandParameter);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        _commandCanExecuteObserver.Stop();
+
+        base.OnDetaching();
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == CommandProperty || change.Property == CommandParameterProperty)
+        {
+            _commandCanExecuteObserver.Update(Command, CommandParameter);
+        }
+    }
+
     /// <summary>
     /// Resolves the command parameter that will be supplied to the
     /// <see cref="System.Windows.Input.ICommand"/> implementation.
@@ -132,5 +185,10 @@ public abstract class InvokeCommandBehaviorBase : StyledElementBehavior<Control>
         }
 
         return resolvedParameter;
+    }
+
+    private void SetCanExecuteCommand(bool value)
+    {
+        CanExecuteCommand = value;
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteIsEnabledBinder.cs
+++ b/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteIsEnabledBinder.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Avalonia.Input;
+
+namespace Avalonia.Xaml.Interactivity;
+
+internal sealed class CommandCanExecuteIsEnabledBinder : IDisposable
+{
+    private InputElement? _target;
+    private IDisposable? _subscription;
+
+    public void Update(InputElement? target, bool enabled, IObservable<bool> canExecute)
+    {
+        if (!enabled || target is null)
+        {
+            Stop();
+            return;
+        }
+
+        if (ReferenceEquals(_target, target) && _subscription is not null)
+        {
+            return;
+        }
+
+        Stop();
+
+        _target = target;
+        _subscription = target.Bind(InputElement.IsEnabledProperty, canExecute);
+    }
+
+    public void Stop()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        _target = null;
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+}

--- a/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteIsEnabledBinder.cs
+++ b/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteIsEnabledBinder.cs
@@ -1,14 +1,21 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Reactive;
 
 namespace Avalonia.Xaml.Interactivity;
 
 internal sealed class CommandCanExecuteIsEnabledBinder : IDisposable
 {
+    private static readonly AttachedProperty<CommandCanExecuteIsEnabledOverlayState?> OverlayStateProperty =
+        AvaloniaProperty.RegisterAttached<CommandCanExecuteIsEnabledBinder, InputElement, CommandCanExecuteIsEnabledOverlayState?>(
+            "CommandCanExecuteIsEnabledOverlayState");
+
     private InputElement? _target;
-    private IDisposable? _subscription;
+    private IDisposable? _canExecuteSubscription;
+    private bool _isBlocking;
 
     public void Update(InputElement? target, bool enabled, IObservable<bool> canExecute)
     {
@@ -18,7 +25,7 @@ internal sealed class CommandCanExecuteIsEnabledBinder : IDisposable
             return;
         }
 
-        if (ReferenceEquals(_target, target) && _subscription is not null)
+        if (ReferenceEquals(_target, target) && _canExecuteSubscription is not null)
         {
             return;
         }
@@ -26,18 +33,88 @@ internal sealed class CommandCanExecuteIsEnabledBinder : IDisposable
         Stop();
 
         _target = target;
-        _subscription = target.Bind(InputElement.IsEnabledProperty, canExecute);
+        _canExecuteSubscription = canExecute.Subscribe(new AnonymousObserver<bool>(UpdateCanExecute));
     }
 
     public void Stop()
     {
-        _subscription?.Dispose();
-        _subscription = null;
+        _canExecuteSubscription?.Dispose();
+        _canExecuteSubscription = null;
+
+        if (_isBlocking && _target is not null)
+        {
+            RemoveDisabledOverlay(_target);
+        }
+
+        _isBlocking = false;
         _target = null;
     }
 
     public void Dispose()
     {
         Stop();
+    }
+
+    private void UpdateCanExecute(bool canExecute)
+    {
+        if (_target is not { } target)
+        {
+            return;
+        }
+
+        if (canExecute)
+        {
+            if (_isBlocking)
+            {
+                RemoveDisabledOverlay(target);
+                _isBlocking = false;
+            }
+        }
+        else if (!_isBlocking)
+        {
+            AddDisabledOverlay(target);
+            _isBlocking = true;
+        }
+    }
+
+    private static void AddDisabledOverlay(InputElement target)
+    {
+        var state = target.GetValue(OverlayStateProperty);
+        if (state is null)
+        {
+            state = new CommandCanExecuteIsEnabledOverlayState();
+            target.SetValue(OverlayStateProperty, state);
+        }
+
+        state.BlockCount++;
+        if (state.BlockCount == 1)
+        {
+            state.DisabledOverlay = target.SetValue(InputElement.IsEnabledProperty, false, BindingPriority.Animation);
+        }
+    }
+
+    private static void RemoveDisabledOverlay(InputElement target)
+    {
+        var state = target.GetValue(OverlayStateProperty);
+        if (state is null)
+        {
+            return;
+        }
+
+        state.BlockCount--;
+        if (state.BlockCount > 0)
+        {
+            return;
+        }
+
+        state.DisabledOverlay?.Dispose();
+        target.ClearValue(OverlayStateProperty);
+    }
+
+    private sealed class CommandCanExecuteIsEnabledOverlayState
+    {
+        public int BlockCount { get; set; }
+
+        public IDisposable? DisabledOverlay { get; set; }
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteObserver.cs
+++ b/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteObserver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
 using System.Windows.Input;
+using Avalonia.Threading;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -13,6 +14,7 @@ namespace Avalonia.Xaml.Interactivity;
 /// Avalonia direct property. Call <see cref="Start(ICommand?, object?)"/> when the behavior is attached,
 /// <see cref="Update(ICommand?, object?)"/> when the command or command parameter changes, and <see cref="Stop"/>
 /// when the behavior is detached.
+/// The callback supplied to the constructor is invoked on <see cref="Dispatcher.UIThread"/>.
 /// The command event subscription uses a weak reference to this observer so a long-lived command does not
 /// keep the observer or owning behavior alive if cleanup is missed.
 /// </remarks>
@@ -175,6 +177,22 @@ public sealed class CommandCanExecuteObserver : IDisposable
 
     private void UpdateCanExecute()
     {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(UpdateCanExecuteCore);
+            return;
+        }
+
+        UpdateCanExecuteCore();
+    }
+
+    private void UpdateCanExecuteCore()
+    {
+        if (!_isObserving)
+        {
+            return;
+        }
+
         if (_command is null || !_isParameterKnown)
         {
             _setCanExecute(true);

--- a/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteObserver.cs
+++ b/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteObserver.cs
@@ -10,8 +10,9 @@ namespace Avalonia.Xaml.Interactivity;
 /// </summary>
 /// <remarks>
 /// Use this helper from custom command-backed behaviors to expose a bindable command state, such as an
-/// Avalonia direct property. Call <see cref="Start"/> when the behavior is attached, <see cref="Update"/>
-/// when the command or command parameter changes, and <see cref="Stop"/> when the behavior is detached.
+/// Avalonia direct property. Call <see cref="Start(ICommand?, object?)"/> when the behavior is attached,
+/// <see cref="Update(ICommand?, object?)"/> when the command or command parameter changes, and <see cref="Stop"/>
+/// when the behavior is detached.
 /// The command event subscription uses a weak reference to this observer so a long-lived command does not
 /// keep the observer or owning behavior alive if cleanup is missed.
 /// </remarks>
@@ -22,6 +23,7 @@ public sealed class CommandCanExecuteObserver : IDisposable
     private readonly EventHandler _canExecuteChangedHandler;
     private ICommand? _command;
     private object? _parameter;
+    private bool _isParameterKnown = true;
     private bool _isObserving;
 
     /// <summary>
@@ -45,15 +47,35 @@ public sealed class CommandCanExecuteObserver : IDisposable
     /// <param name="parameter">The command parameter supplied to <see cref="ICommand.CanExecute"/>.</param>
     public void Start(ICommand? command, object? parameter)
     {
+        Start(command, parameter, true);
+    }
+
+    /// <summary>
+    /// Starts observing the specified command and reports its initial execution state.
+    /// </summary>
+    /// <param name="command">The command to observe, or <c>null</c> to report that execution is allowed.</param>
+    /// <param name="parameter">The command parameter supplied to <see cref="ICommand.CanExecute"/>.</param>
+    /// <param name="isParameterKnown">
+    /// <c>true</c> when <paramref name="parameter"/> is the actual parameter to evaluate; <c>false</c> when the
+    /// parameter will only be available at execution time.
+    /// </param>
+    /// <remarks>
+    /// When <paramref name="isParameterKnown"/> is <c>false</c>, the observer reports <c>true</c> without calling
+    /// <see cref="ICommand.CanExecute"/>. This avoids probing commands with placeholder values such as <c>null</c>
+    /// when event arguments or picker results will provide the real parameter later.
+    /// </remarks>
+    public void Start(ICommand? command, object? parameter, bool isParameterKnown)
+    {
         if (_isObserving)
         {
-            Update(command, parameter);
+            Update(command, parameter, isParameterKnown);
             return;
         }
 
         _isObserving = true;
         _command = command;
         _parameter = parameter;
+        _isParameterKnown = isParameterKnown;
 
         if (command is not null)
         {
@@ -70,9 +92,26 @@ public sealed class CommandCanExecuteObserver : IDisposable
     /// <param name="command">The command to observe, or <c>null</c> to report that execution is allowed.</param>
     /// <param name="parameter">The command parameter supplied to <see cref="ICommand.CanExecute"/>.</param>
     /// <remarks>
-    /// This method has no effect until <see cref="Start"/> has been called.
+    /// This method has no effect until <see cref="Start(ICommand?, object?)"/> has been called.
     /// </remarks>
     public void Update(ICommand? command, object? parameter)
+    {
+        Update(command, parameter, true);
+    }
+
+    /// <summary>
+    /// Updates the observed command and command parameter.
+    /// </summary>
+    /// <param name="command">The command to observe, or <c>null</c> to report that execution is allowed.</param>
+    /// <param name="parameter">The command parameter supplied to <see cref="ICommand.CanExecute"/>.</param>
+    /// <param name="isParameterKnown">
+    /// <c>true</c> when <paramref name="parameter"/> is the actual parameter to evaluate; <c>false</c> when the
+    /// parameter will only be available at execution time.
+    /// </param>
+    /// <remarks>
+    /// This method has no effect until <see cref="Start(ICommand?, object?)"/> has been called.
+    /// </remarks>
+    public void Update(ICommand? command, object? parameter, bool isParameterKnown)
     {
         if (!_isObserving)
         {
@@ -100,6 +139,7 @@ public sealed class CommandCanExecuteObserver : IDisposable
         }
 
         _parameter = parameter;
+        _isParameterKnown = isParameterKnown;
         UpdateCanExecute();
     }
 
@@ -120,6 +160,7 @@ public sealed class CommandCanExecuteObserver : IDisposable
 
         _command = null;
         _parameter = null;
+        _isParameterKnown = true;
         _isObserving = false;
         _weakCanExecuteChangedHandler.SetCommand(null);
     }
@@ -134,7 +175,13 @@ public sealed class CommandCanExecuteObserver : IDisposable
 
     private void UpdateCanExecute()
     {
-        _setCanExecute(_command?.CanExecute(_parameter) ?? true);
+        if (_command is null || !_isParameterKnown)
+        {
+            _setCanExecute(true);
+            return;
+        }
+
+        _setCanExecute(_command.CanExecute(_parameter));
     }
 
     private sealed class WeakCanExecuteChangedHandler

--- a/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteObserver.cs
+++ b/src/Xaml.Behaviors.Interactivity/Helpers/CommandCanExecuteObserver.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Windows.Input;
+
+namespace Avalonia.Xaml.Interactivity;
+
+/// <summary>
+/// Observes an <see cref="ICommand"/> and reports whether it can execute with a specified parameter.
+/// </summary>
+/// <remarks>
+/// Use this helper from custom command-backed behaviors to expose a bindable command state, such as an
+/// Avalonia direct property. Call <see cref="Start"/> when the behavior is attached, <see cref="Update"/>
+/// when the command or command parameter changes, and <see cref="Stop"/> when the behavior is detached.
+/// The command event subscription uses a weak reference to this observer so a long-lived command does not
+/// keep the observer or owning behavior alive if cleanup is missed.
+/// </remarks>
+public sealed class CommandCanExecuteObserver : IDisposable
+{
+    private readonly Action<bool> _setCanExecute;
+    private readonly WeakCanExecuteChangedHandler _weakCanExecuteChangedHandler;
+    private readonly EventHandler _canExecuteChangedHandler;
+    private ICommand? _command;
+    private object? _parameter;
+    private bool _isObserving;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandCanExecuteObserver"/> class.
+    /// </summary>
+    /// <param name="setCanExecute">The callback that receives the current command execution state.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="setCanExecute"/> is <c>null</c>.</exception>
+    public CommandCanExecuteObserver(Action<bool> setCanExecute)
+    {
+        ArgumentNullException.ThrowIfNull(setCanExecute);
+
+        _setCanExecute = setCanExecute;
+        _weakCanExecuteChangedHandler = new WeakCanExecuteChangedHandler(this);
+        _canExecuteChangedHandler = _weakCanExecuteChangedHandler.OnCanExecuteChanged;
+    }
+
+    /// <summary>
+    /// Starts observing the specified command and reports its initial execution state.
+    /// </summary>
+    /// <param name="command">The command to observe, or <c>null</c> to report that execution is allowed.</param>
+    /// <param name="parameter">The command parameter supplied to <see cref="ICommand.CanExecute"/>.</param>
+    public void Start(ICommand? command, object? parameter)
+    {
+        if (_isObserving)
+        {
+            Update(command, parameter);
+            return;
+        }
+
+        _isObserving = true;
+        _command = command;
+        _parameter = parameter;
+
+        if (command is not null)
+        {
+            _weakCanExecuteChangedHandler.SetCommand(command);
+            command.CanExecuteChanged += _canExecuteChangedHandler;
+        }
+
+        UpdateCanExecute();
+    }
+
+    /// <summary>
+    /// Updates the observed command and command parameter.
+    /// </summary>
+    /// <param name="command">The command to observe, or <c>null</c> to report that execution is allowed.</param>
+    /// <param name="parameter">The command parameter supplied to <see cref="ICommand.CanExecute"/>.</param>
+    /// <remarks>
+    /// This method has no effect until <see cref="Start"/> has been called.
+    /// </remarks>
+    public void Update(ICommand? command, object? parameter)
+    {
+        if (!_isObserving)
+        {
+            return;
+        }
+
+        if (!ReferenceEquals(_command, command))
+        {
+            if (_command is not null)
+            {
+                _command.CanExecuteChanged -= _canExecuteChangedHandler;
+            }
+
+            _command = command;
+
+            if (command is not null)
+            {
+                _weakCanExecuteChangedHandler.SetCommand(command);
+                command.CanExecuteChanged += _canExecuteChangedHandler;
+            }
+            else
+            {
+                _weakCanExecuteChangedHandler.SetCommand(null);
+            }
+        }
+
+        _parameter = parameter;
+        UpdateCanExecute();
+    }
+
+    /// <summary>
+    /// Stops observing the current command and clears the stored command parameter.
+    /// </summary>
+    public void Stop()
+    {
+        if (!_isObserving)
+        {
+            return;
+        }
+
+        if (_command is not null)
+        {
+            _command.CanExecuteChanged -= _canExecuteChangedHandler;
+        }
+
+        _command = null;
+        _parameter = null;
+        _isObserving = false;
+        _weakCanExecuteChangedHandler.SetCommand(null);
+    }
+
+    /// <summary>
+    /// Stops observing the current command.
+    /// </summary>
+    public void Dispose()
+    {
+        Stop();
+    }
+
+    private void UpdateCanExecute()
+    {
+        _setCanExecute(_command?.CanExecute(_parameter) ?? true);
+    }
+
+    private sealed class WeakCanExecuteChangedHandler
+    {
+        private readonly WeakReference<CommandCanExecuteObserver> _observer;
+        private WeakReference<ICommand>? _command;
+
+        public WeakCanExecuteChangedHandler(CommandCanExecuteObserver observer)
+        {
+            _observer = new WeakReference<CommandCanExecuteObserver>(observer);
+        }
+
+        public void SetCommand(ICommand? command)
+        {
+            _command = command is null ? null : new WeakReference<ICommand>(command);
+        }
+
+        public void OnCanExecuteChanged(object? sender, EventArgs e)
+        {
+            if (_observer.TryGetTarget(out var observer))
+            {
+                observer.UpdateCanExecute();
+                return;
+            }
+
+            ICommand? command = sender as ICommand;
+            if (command is null)
+            {
+                if (_command is null || !_command.TryGetTarget(out command))
+                {
+                    return;
+                }
+            }
+
+            command.CanExecuteChanged -= OnCanExecuteChanged;
+            _command = null;
+        }
+    }
+}

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementAction.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementAction.cs
@@ -51,10 +51,20 @@ public abstract class StyledElementAction : StyledElement, IAction
         {
             TemplatedParentHelper.SetTemplatedParent(this, templatedParent);
         }
+
+        if (this is IActionLogicalTreeLifecycle lifecycle)
+        {
+            lifecycle.AttachedToActionLogicalTree();
+        }
     }
 
     internal void DetachActionFromLogicalTree(StyledElement parent)
     {
+        if (this is IActionLogicalTreeLifecycle lifecycle)
+        {
+            lifecycle.DetachedFromActionLogicalTree();
+        }
+
 #if false
         Dispatcher.UIThread.Post(() =>
         {
@@ -67,4 +77,11 @@ public abstract class StyledElementAction : StyledElement, IAction
         });
 #endif
     }
+}
+
+internal interface IActionLogicalTreeLifecycle
+{
+    void AttachedToActionLogicalTree();
+
+    void DetachedFromActionLogicalTree();
 }

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementAction.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementAction.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia.Controls;
-using Avalonia.Threading;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -65,17 +64,12 @@ public abstract class StyledElementAction : StyledElement, IAction
             lifecycle.DetachedFromActionLogicalTree();
         }
 
-#if false
-        Dispatcher.UIThread.Post(() =>
-        {
-            ((ISetLogicalParent)this).SetParent(null);
+        ((ISetLogicalParent)this).SetParent(null);
 
-            if (parent is { TemplatedParent: not null })
-            {
-                TemplatedParentHelper.SetTemplatedParent(this, null);
-            }
-        });
-#endif
+        if (TemplatedParent is not null || parent.TemplatedParent is not null)
+        {
+            TemplatedParentHelper.SetTemplatedParent(this, null);
+        }
     }
 }
 

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Reactive;
-using Avalonia.Threading;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -80,6 +79,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
     public void Detach()
     {
         OnDetaching();
+
+        if (Parent is not null || TemplatedParent is not null)
+        {
+            DetachBehaviorFromLogicalTree();
+        }
+
         _dataContextDisposable?.Dispose();
         AssociatedObject = null;
     }
@@ -288,17 +293,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     internal virtual void DetachBehaviorFromLogicalTree()
     {
-#if false
-        Dispatcher.UIThread.Post(() =>
-        {
-            ((ISetLogicalParent)this).SetParent(null);
+        ((ISetLogicalParent)this).SetParent(null);
 
-            if (AssociatedObject is StyledElement { TemplatedParent: not null } or TopLevel)
-            {
-                TemplatedParentHelper.SetTemplatedParent(this, null);
-            }
-        });
-#endif
+        if (TemplatedParent is not null)
+        {
+            TemplatedParentHelper.SetTemplatedParent(this, null);
+        }
     }
 
     private IDisposable? SynchronizeDataContext(AvaloniaObject associatedObject)

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ActionLogicalTreeLifetimeTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ActionLogicalTreeLifetimeTests.cs
@@ -1,0 +1,450 @@
+using System;
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Xaml.Interactions.Core;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class ActionLogicalTreeLifetimeTests
+{
+    [AvaloniaFact]
+    public void TriggerAction_DetachesAndReattachesAcrossAssociatedControlLogicalTreeLifetime()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var action = CreateCommandAction(command);
+
+        trigger.Actions!.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.Same(trigger, action.Parent);
+        Assert.Same(target, trigger.Parent);
+
+        window.Content = null;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(action.Parent);
+        Assert.Null(trigger.Parent);
+
+        window.Content = target;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.Same(trigger, action.Parent);
+        Assert.Same(target, trigger.Parent);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void TriggerAction_DetachesWhenWindowCloses()
+    {
+        var command = new ObservableCommand();
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var action = CreateCommandAction(command);
+
+        trigger.Actions!.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(action.Parent);
+        Assert.Null(trigger.Parent);
+    }
+
+    [AvaloniaFact]
+    public void BehaviorCollectionRemove_DetachesTriggerActionLogicalTree()
+    {
+        var command = new ObservableCommand();
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var action = CreateCommandAction(command);
+
+        trigger.Actions!.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+
+        Interaction.GetBehaviors(target).Remove(trigger);
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(action.Parent);
+        Assert.Null(trigger.Parent);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void TriggerActionsReplacement_DetachesOldActionLogicalTreeAndAttachesNewAction()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var firstAction = CreateCommandAction(firstCommand);
+        var secondAction = CreateCommandAction(secondCommand);
+
+        trigger.Actions!.Add(firstAction);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.Same(trigger, firstAction.Parent);
+
+        trigger.Actions = new ActionCollection { secondAction };
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Null(firstAction.Parent);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.Same(trigger, secondAction.Parent);
+
+        window.Close();
+    }
+
+    [AvaloniaTheory]
+    [InlineData(NestedActionContainerKind.AsyncActionGroup)]
+    [InlineData(NestedActionContainerKind.DebounceAction)]
+    [InlineData(NestedActionContainerKind.ThrottleAction)]
+    [InlineData(NestedActionContainerKind.ConditionalActionTrueBranch)]
+    [InlineData(NestedActionContainerKind.ConditionalActionFalseBranch)]
+    [InlineData(NestedActionContainerKind.SwitchCaseDefaultActions)]
+    [InlineData(NestedActionContainerKind.SwitchCaseCaseActions)]
+    public void NestedActionContainers_DetachChildActionLogicalTreeWhenTriggerIsRemoved(NestedActionContainerKind kind)
+    {
+        var command = new ObservableCommand();
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var container = CreateNestedActionContainer(kind);
+        var childAction = CreateCommandAction(command);
+
+        AddChildAction(container, kind, childAction);
+        trigger.Actions!.Add(container);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.Same(ResolveExpectedChildParent(container, kind), childAction.Parent);
+
+        Interaction.GetBehaviors(target).Remove(trigger);
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(container.Parent);
+        Assert.Null(childAction.Parent);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void NestedActionContainerActionsReplacement_DetachesOldChildActionAndAttachesNewChildAction()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var group = new AsyncActionGroup();
+        var firstAction = CreateCommandAction(firstCommand);
+        var secondAction = CreateCommandAction(secondCommand);
+
+        group.Actions!.Add(firstAction);
+        trigger.Actions!.Add(group);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.Same(group, firstAction.Parent);
+
+        group.Actions = new ActionCollection { secondAction };
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Null(firstAction.Parent);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.Same(group, secondAction.Parent);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void NestedActionBindings_ClearWhenContainerLogicalTreeDetaches()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var indicator = new Border();
+        var trigger = new ClickEventTrigger();
+        var group = new AsyncActionGroup();
+        var action = CreateCommandAction(command);
+
+        indicator.Bind(InputElement.IsEnabledProperty, action.GetObservable(InvokeCommandActionBase.CanExecuteCommandProperty));
+        group.Actions!.Add(action);
+        trigger.Actions!.Add(group);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = new StackPanel
+        {
+            Children =
+            {
+                target,
+                indicator
+            }
+        };
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.False(indicator.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(indicator.IsEnabled);
+
+        Interaction.GetBehaviors(target).Remove(trigger);
+
+        Assert.Equal(0, command.SubscriptionCount);
+
+        command.CanExecuteResult = false;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(action.CanExecuteCommand);
+        Assert.True(indicator.IsEnabled);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabledBinding_ClearsWhenTriggerLogicalTreeDetaches()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var window = CreateWindow();
+        var target = CreateTarget();
+        var trigger = new ClickEventTrigger();
+        var action = CreateCommandAction(command);
+        action.UseCommandCanExecuteForIsEnabled = true;
+
+        trigger.Actions!.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.False(target.IsEnabled);
+
+        Interaction.GetBehaviors(target).Remove(trigger);
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.True(target.IsEnabled);
+
+        command.CanExecuteResult = false;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(target.IsEnabled);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PopupHostedTriggerAction_DetachesWhenPopupCloses()
+    {
+        var command = new ObservableCommand();
+        var window = CreateWindow();
+        var placementTarget = new Button
+        {
+            Content = "Host",
+            Width = 120,
+            Height = 32
+        };
+        var popupTarget = CreateTarget();
+        var popup = new Popup
+        {
+            PlacementTarget = placementTarget,
+            Child = popupTarget
+        };
+        var trigger = new ClickEventTrigger();
+        var action = CreateCommandAction(command);
+
+        trigger.Actions!.Add(action);
+        Interaction.GetBehaviors(popupTarget).Add(trigger);
+
+        window.Content = new Grid
+        {
+            Children =
+            {
+                placementTarget,
+                popup
+            }
+        };
+        window.Show();
+
+        popup.IsOpen = true;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.Same(trigger, action.Parent);
+
+        popup.IsOpen = false;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(action.Parent);
+        Assert.Null(trigger.Parent);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void TopLevelHostedTrigger_DetachesActionLogicalTreeWhenBehaviorIsRemoved()
+    {
+        var command = new ObservableCommand();
+        var window = CreateWindow();
+        var trigger = new ClickEventTrigger();
+        var action = CreateCommandAction(command);
+
+        trigger.Actions!.Add(action);
+        Interaction.GetBehaviors(window).Add(trigger);
+
+        Assert.Equal(1, command.SubscriptionCount);
+        Assert.Same(window, trigger.Parent);
+        Assert.Same(window, action.Parent);
+
+        Interaction.GetBehaviors(window).Remove(trigger);
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(trigger.Parent);
+        Assert.Null(action.Parent);
+    }
+
+    private static Window CreateWindow()
+    {
+        return new Window
+        {
+            Width = 320,
+            Height = 200
+        };
+    }
+
+    private static Border CreateTarget()
+    {
+        return new Border
+        {
+            Width = 160,
+            Height = 60,
+            Focusable = true
+        };
+    }
+
+    private static InvokeCommandAction CreateCommandAction(ObservableCommand command)
+    {
+        return new InvokeCommandAction
+        {
+            Command = command,
+            CanExecuteCommandParameter = "probe"
+        };
+    }
+
+    private static StyledElementAction CreateNestedActionContainer(NestedActionContainerKind kind)
+    {
+        return kind switch
+        {
+            NestedActionContainerKind.AsyncActionGroup => new AsyncActionGroup(),
+            NestedActionContainerKind.DebounceAction => new DebounceAction(),
+            NestedActionContainerKind.ThrottleAction => new ThrottleAction(),
+            NestedActionContainerKind.ConditionalActionTrueBranch => new ConditionalAction(),
+            NestedActionContainerKind.ConditionalActionFalseBranch => new ConditionalAction(),
+            NestedActionContainerKind.SwitchCaseDefaultActions => new SwitchCaseAction(),
+            NestedActionContainerKind.SwitchCaseCaseActions => new SwitchCaseAction(),
+            _ => throw new InvalidEnumArgumentException(nameof(kind), (int)kind, typeof(NestedActionContainerKind))
+        };
+    }
+
+    private static void AddChildAction(StyledElementAction container, NestedActionContainerKind kind, StyledElementAction child)
+    {
+        switch (container)
+        {
+            case AsyncActionGroup group:
+                group.Actions!.Add(child);
+                break;
+            case DebounceAction debounceAction:
+                debounceAction.Actions!.Add(child);
+                break;
+            case ThrottleAction throttleAction:
+                throttleAction.Actions!.Add(child);
+                break;
+            case ConditionalAction conditionalAction when kind == NestedActionContainerKind.ConditionalActionTrueBranch:
+                conditionalAction.Actions!.Add(child);
+                break;
+            case ConditionalAction conditionalAction:
+                conditionalAction.ElseActions!.Add(child);
+                break;
+            case SwitchCaseAction switchCaseAction when kind == NestedActionContainerKind.SwitchCaseDefaultActions:
+                switchCaseAction.DefaultActions!.Add(child);
+                break;
+            case SwitchCaseAction switchCaseAction:
+                var caseItem = new Case
+                {
+                    Value = "case"
+                };
+                caseItem.Actions!.Add(child);
+                switchCaseAction.Cases!.Add(caseItem);
+                break;
+            default:
+                throw new ArgumentException("Unsupported nested action container.", nameof(container));
+        }
+    }
+
+    private static StyledElement ResolveExpectedChildParent(StyledElementAction container, NestedActionContainerKind kind)
+    {
+        if (container is SwitchCaseAction switchCaseAction && kind == NestedActionContainerKind.SwitchCaseCaseActions)
+        {
+            return switchCaseAction.Cases![0];
+        }
+
+        return container;
+    }
+
+    public enum NestedActionContainerKind
+    {
+        AsyncActionGroup,
+        DebounceAction,
+        ThrottleAction,
+        ConditionalActionTrueBranch,
+        ConditionalActionFalseBranch,
+        SwitchCaseDefaultActions,
+        SwitchCaseCaseActions
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ObservableCommand.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ObservableCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Windows.Input;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+internal sealed class ObservableCommand : ICommand
+{
+    private EventHandler? _canExecuteChanged;
+
+    public bool CanExecuteResult { get; set; } = true;
+
+    public Func<object?, bool>? CanExecuteCallback { get; set; }
+
+    public int SubscriptionCount { get; private set; }
+
+    public object? LastCanExecuteParameter { get; private set; }
+
+    public event EventHandler? CanExecuteChanged
+    {
+        add
+        {
+            _canExecuteChanged += value;
+            SubscriptionCount++;
+        }
+        remove
+        {
+            _canExecuteChanged -= value;
+            SubscriptionCount--;
+        }
+    }
+
+    public bool CanExecute(object? parameter)
+    {
+        LastCanExecuteParameter = parameter;
+        return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
+    }
+
+    public void Execute(object? parameter)
+    {
+    }
+
+    public void RaiseCanExecuteChanged()
+    {
+        _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ObservableCommand.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ObservableCommand.cs
@@ -15,6 +15,8 @@ internal sealed class ObservableCommand : ICommand
 
     public object? LastCanExecuteParameter { get; private set; }
 
+    public int CanExecuteCallCount { get; private set; }
+
     public event EventHandler? CanExecuteChanged
     {
         add
@@ -31,6 +33,7 @@ internal sealed class ObservableCommand : ICommand
 
     public bool CanExecute(object? parameter)
     {
+        CanExecuteCallCount++;
         LastCanExecuteParameter = parameter;
         return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
     }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerActionBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerActionBaseTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Avalonia.Xaml.Interactions.Core;
 using Xunit;
 
@@ -56,6 +57,28 @@ public class PickerActionBaseTests
     }
 
     [AvaloniaFact]
+    public async Task TrackDispatchedPickerOperation_RunsOperationOnUiThread()
+    {
+        var action = new TestPickerAction();
+        var operationWasOnUiThread = false;
+        Task? task = null;
+
+        await Task.Run(() =>
+        {
+            task = action.TrackDispatched(() =>
+            {
+                operationWasOnUiThread = Dispatcher.UIThread.CheckAccess();
+                return Task.CompletedTask;
+            });
+        });
+
+        await Assert.IsAssignableFrom<Task>(task);
+
+        Assert.True(operationWasOnUiThread);
+        await WaitForNoActiveOperations(action);
+    }
+
+    [AvaloniaFact]
     public async Task OpenFolderPickerAction_ReturnsTaskWhenSenderIsVisual()
     {
         var action = new OpenFolderPickerAction
@@ -103,6 +126,11 @@ public class PickerActionBaseTests
         public Task Track(Task task)
         {
             return TrackPickerOperation(task);
+        }
+
+        public Task TrackDispatched(Func<Task> operation)
+        {
+            return TrackDispatchedPickerOperation(operation);
         }
 
         public override object? Execute(object? sender, object? parameter)

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerActionBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerActionBaseTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactions.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class PickerActionBaseTests
+{
+    [AvaloniaFact]
+    public async Task TrackPickerOperation_KeepsOperationActiveUntilCompletion()
+    {
+        var action = new TestPickerAction();
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = action.Track(completion.Task);
+
+        Assert.Equal(1, action.ActivePickerOperationCount);
+
+        completion.SetResult();
+
+        await task;
+        await WaitForNoActiveOperations(action);
+    }
+
+    [AvaloniaFact]
+    public async Task TrackPickerOperation_RemovesOperationWhenProviderFails()
+    {
+        var action = new TestPickerAction();
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = action.Track(completion.Task);
+
+        Assert.Equal(1, action.ActivePickerOperationCount);
+
+        completion.SetException(new InvalidOperationException("Picker failed."));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => task);
+        await WaitForNoActiveOperations(action);
+    }
+
+    [AvaloniaFact]
+    public async Task OpenFilePickerAction_ReturnsTaskWhenSenderIsVisual()
+    {
+        var action = new OpenFilePickerAction
+        {
+            Command = new Command(_ => { })
+        };
+
+        var result = action.Execute(new Border(), null);
+
+        var task = Assert.IsAssignableFrom<Task>(result);
+        await task;
+    }
+
+    [AvaloniaFact]
+    public async Task OpenFolderPickerAction_ReturnsTaskWhenSenderIsVisual()
+    {
+        var action = new OpenFolderPickerAction
+        {
+            Command = new Command(_ => { })
+        };
+
+        var result = action.Execute(new Border(), null);
+
+        var task = Assert.IsAssignableFrom<Task>(result);
+        await task;
+    }
+
+    [AvaloniaFact]
+    public async Task SaveFilePickerAction_ReturnsTaskWhenSenderIsVisual()
+    {
+        var action = new SaveFilePickerAction
+        {
+            Command = new Command(_ => { })
+        };
+
+        var result = action.Execute(new Border(), null);
+
+        var task = Assert.IsAssignableFrom<Task>(result);
+        await task;
+    }
+
+    private static async Task WaitForNoActiveOperations(PickerActionBase action)
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            if (action.ActivePickerOperationCount == 0)
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(0, action.ActivePickerOperationCount);
+    }
+
+    private sealed class TestPickerAction : PickerActionBase
+    {
+        public Task Track(Task task)
+        {
+            return TrackPickerOperation(task);
+        }
+
+        public override object? Execute(object? sender, object? parameter)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerBehaviorBaseTests.cs
@@ -25,7 +25,8 @@ public class PickerBehaviorBaseTests
     {
         var behavior = new ButtonOpenFilePickerBehavior
         {
-            Command = new ObservableCommand { CanExecuteResult = false }
+            Command = new ObservableCommand { CanExecuteResult = false },
+            CanExecuteCommandParameter = "probe"
         };
         var button = new Button();
 
@@ -37,12 +38,42 @@ public class PickerBehaviorBaseTests
     }
 
     [AvaloniaFact]
+    public void CanExecuteCommand_DefersWhenPickerResultParameterIsUnavailable()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = _ => throw new System.InvalidOperationException("The picker result is not available yet.")
+        };
+        var behavior = new ButtonOpenFilePickerBehavior
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.True(button.IsEnabled);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.True(button.IsEnabled);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
     public void UseCommandCanExecuteForIsEnabled_UpdatesButtonPickerAssociatedObject()
     {
         var command = new ObservableCommand { CanExecuteResult = false };
         var behavior = new ButtonOpenFilePickerBehavior
         {
             Command = command,
+            CanExecuteCommandParameter = "probe",
             UseCommandCanExecuteForIsEnabled = true
         };
         var button = new Button();
@@ -66,6 +97,7 @@ public class PickerBehaviorBaseTests
         var behavior = new MenuItemSaveFilePickerBehavior
         {
             Command = command,
+            CanExecuteCommandParameter = "probe",
             UseCommandCanExecuteForIsEnabled = true
         };
         var menuItem = new MenuItem();
@@ -88,7 +120,8 @@ public class PickerBehaviorBaseTests
         var command = new ObservableCommand { CanExecuteResult = false };
         var behavior = new ButtonOpenFilePickerBehavior
         {
-            Command = command
+            Command = command,
+            CanExecuteCommandParameter = "probe"
         };
         var button = new Button();
 
@@ -135,7 +168,8 @@ public class PickerBehaviorBaseTests
         var secondCommand = new ObservableCommand { CanExecuteResult = true };
         var behavior = new ButtonSaveFilePickerBehavior
         {
-            Command = firstCommand
+            Command = firstCommand,
+            CanExecuteCommandParameter = "probe"
         };
         var button = new Button();
 

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerBehaviorBaseTests.cs
@@ -1,0 +1,111 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactions.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public class PickerBehaviorBaseTests
+{
+    [AvaloniaFact]
+    public void CanExecuteCommand_DefaultsToTrueWithoutCommand()
+    {
+        var behavior = new ButtonOpenFilePickerBehavior();
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UpdatesWhenAttached()
+    {
+        var behavior = new ButtonOpenFilePickerBehavior
+        {
+            Command = new ObservableCommand { CanExecuteResult = false }
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UpdatesWhenCommandRaisesCanExecuteChanged()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new ButtonOpenFilePickerBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesCurrentCommandParameter()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var behavior = new ButtonOpenFolderPickerBehavior
+        {
+            Command = command,
+            CommandParameter = "disabled"
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.CommandParameter = "enabled";
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_RewiresSubscriptionsWhenCommandChangesAndDetaches()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var behavior = new ButtonSaveFilePickerBehavior
+        {
+            Command = firstCommand
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.Command = secondCommand;
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+
+        Assert.Equal(0, secondCommand.SubscriptionCount);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/PickerBehaviorBaseTests.cs
@@ -37,6 +37,52 @@ public class PickerBehaviorBaseTests
     }
 
     [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_UpdatesButtonPickerAssociatedObject()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new ButtonOpenFilePickerBehavior
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.False(button.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(button.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_UpdatesMenuItemPickerAssociatedObject()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new MenuItemSaveFilePickerBehavior
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var menuItem = new MenuItem();
+
+        behavior.Attach(menuItem);
+
+        Assert.False(menuItem.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(menuItem.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
     public void CanExecuteCommand_UpdatesWhenCommandRaisesCanExecuteChanged()
     {
         var command = new ObservableCommand { CanExecuteResult = false };

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -138,6 +138,50 @@ public class ClickEventTriggerTests
     }
 
     [AvaloniaFact]
+    public void ClickEventTrigger_AsyncActionGroup_DetachesChildCommandObservers()
+    {
+        var command = new ObservableCommand();
+
+        var window = new Window
+        {
+            Width = 200,
+            Height = 120,
+        };
+
+        var target = new Border
+        {
+            Width = 160,
+            Height = 60,
+            Focusable = true,
+        };
+
+        var trigger = new ClickEventTrigger();
+        var group = new AsyncActionGroup();
+        var action = new InvokeCommandAction
+        {
+            Command = command,
+        };
+
+        group.Actions ??= [];
+        group.Actions.Add(action);
+
+        trigger.Actions ??= [];
+        trigger.Actions.Add(group);
+        Avalonia.Xaml.Interactivity.Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.Equal(1, command.SubscriptionCount);
+
+        Avalonia.Xaml.Interactivity.Interaction.GetBehaviors(target).Remove(trigger);
+
+        Assert.Equal(0, command.SubscriptionCount);
+        Assert.Null(group.Parent);
+        Assert.Null(action.Parent);
+    }
+
+    [AvaloniaFact]
     public async Task ClickEventTrigger_RoutingStrategies_PropertyChange_RewiresHandlers()
     {
         var nativeCommandCalls = 0;

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -118,6 +118,7 @@ public class ClickEventTriggerTests
         var action = new OpenFilePickerAction
         {
             Command = command,
+            CanExecuteCommandParameter = "probe",
             UseCommandCanExecuteForIsEnabled = true,
         };
 

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ClickEventTriggerTests.cs
@@ -97,6 +97,46 @@ public class ClickEventTriggerTests
     }
 
     [AvaloniaFact]
+    public void ClickEventTrigger_PickerAction_UseCommandCanExecuteForIsEnabled_DisablesAssociatedPanel()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+
+        var window = new Window
+        {
+            Width = 200,
+            Height = 120,
+        };
+
+        var target = new Border
+        {
+            Width = 160,
+            Height = 60,
+            Focusable = true,
+        };
+
+        var trigger = new ClickEventTrigger();
+        var action = new OpenFilePickerAction
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true,
+        };
+
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        Avalonia.Xaml.Interactivity.Interaction.GetBehaviors(target).Add(trigger);
+
+        window.Content = target;
+        window.Show();
+
+        Assert.False(target.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(target.IsEnabled);
+    }
+
+    [AvaloniaFact]
     public async Task ClickEventTrigger_RoutingStrategies_PropertyChange_RewiresHandlers()
     {
         var nativeCommandCalls = 0;

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ExecuteCommandBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ExecuteCommandBehaviorBaseTests.cs
@@ -1,0 +1,83 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class ExecuteCommandBehaviorBaseTests
+{
+    [AvaloniaFact]
+    public void CanExecuteCommand_UpdatesWhenCommandRaisesCanExecuteChanged()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new ExecuteCommandOnTappedBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesCurrentCommandParameter()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var behavior = new ExecuteCommandOnTappedBehavior
+        {
+            Command = command,
+            CommandParameter = "disabled"
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.CommandParameter = "enabled";
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_RewiresSubscriptionsWhenCommandChangesAndDetaches()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var behavior = new ExecuteCommandOnTappedBehavior
+        {
+            Command = firstCommand
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.Command = secondCommand;
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+
+        Assert.Equal(0, secondCommand.SubscriptionCount);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/DragDropCommandsBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/DragDropCommandsBehaviorTests.cs
@@ -1,0 +1,98 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactions.DragAndDrop;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
+
+public class DragDropCommandsBehaviorTests
+{
+    [AvaloniaFact]
+    public void CanExecuteCommandProperties_UpdateWhenCommandsRaiseCanExecuteChanged()
+    {
+        var dragEnterCommand = new ObservableCommand { CanExecuteResult = false };
+        var dragOverCommand = new ObservableCommand { CanExecuteResult = false };
+        var dragLeaveCommand = new ObservableCommand { CanExecuteResult = false };
+        var dropCommand = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new DragDropCommandsBehavior
+        {
+            DragEnterCommand = dragEnterCommand,
+            DragOverCommand = dragOverCommand,
+            DragLeaveCommand = dragLeaveCommand,
+            DropCommand = dropCommand
+        };
+        var border = new Border();
+
+        behavior.Attach(border);
+
+        Assert.False(behavior.CanExecuteDragEnterCommand);
+        Assert.False(behavior.CanExecuteDragOverCommand);
+        Assert.False(behavior.CanExecuteDragLeaveCommand);
+        Assert.False(behavior.CanExecuteDropCommand);
+
+        dragEnterCommand.CanExecuteResult = true;
+        dragOverCommand.CanExecuteResult = true;
+        dragLeaveCommand.CanExecuteResult = true;
+        dropCommand.CanExecuteResult = true;
+        dragEnterCommand.RaiseCanExecuteChanged();
+        dragOverCommand.RaiseCanExecuteChanged();
+        dragLeaveCommand.RaiseCanExecuteChanged();
+        dropCommand.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteDragEnterCommand);
+        Assert.True(behavior.CanExecuteDragOverCommand);
+        Assert.True(behavior.CanExecuteDragLeaveCommand);
+        Assert.True(behavior.CanExecuteDropCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommandProperties_RewireSubscriptionsWhenCommandsChangeAndDetach()
+    {
+        var firstDropCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondDropCommand = new ObservableCommand { CanExecuteResult = true };
+        var behavior = new DragDropCommandsBehavior
+        {
+            DropCommand = firstDropCommand
+        };
+        var border = new Border();
+
+        behavior.Attach(border);
+
+        Assert.Equal(1, firstDropCommand.SubscriptionCount);
+        Assert.False(behavior.CanExecuteDropCommand);
+
+        behavior.DropCommand = secondDropCommand;
+
+        Assert.Equal(0, firstDropCommand.SubscriptionCount);
+        Assert.Equal(1, secondDropCommand.SubscriptionCount);
+        Assert.True(behavior.CanExecuteDropCommand);
+
+        behavior.Detach();
+
+        Assert.Equal(0, secondDropCommand.SubscriptionCount);
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommandProperties_UseNullBeforeDragEventArgsAreAvailable()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => parameter is null
+        };
+        var behavior = new DragDropCommandsBehavior
+        {
+            DropCommand = command
+        };
+        var border = new Border();
+
+        behavior.Attach(border);
+
+        Assert.True(behavior.CanExecuteDropCommand);
+        Assert.Null(command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/DragDropCommandsBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/DragDropCommandsBehaviorTests.cs
@@ -20,7 +20,8 @@ public class DragDropCommandsBehaviorTests
             DragEnterCommand = dragEnterCommand,
             DragOverCommand = dragOverCommand,
             DragLeaveCommand = dragLeaveCommand,
-            DropCommand = dropCommand
+            DropCommand = dropCommand,
+            PassEventArgsToCommand = false
         };
         var border = new Border();
 
@@ -55,7 +56,8 @@ public class DragDropCommandsBehaviorTests
         var secondDropCommand = new ObservableCommand { CanExecuteResult = true };
         var behavior = new DragDropCommandsBehavior
         {
-            DropCommand = firstDropCommand
+            DropCommand = firstDropCommand,
+            PassEventArgsToCommand = false
         };
         var border = new Border();
 
@@ -76,11 +78,33 @@ public class DragDropCommandsBehaviorTests
     }
 
     [AvaloniaFact]
-    public void CanExecuteCommandProperties_UseNullBeforeDragEventArgsAreAvailable()
+    public void CanExecuteCommandProperties_UseNullWhenEventArgsAreNotPassed()
     {
         var command = new ObservableCommand
         {
             CanExecuteCallback = parameter => parameter is null
+        };
+        var behavior = new DragDropCommandsBehavior
+        {
+            DropCommand = command,
+            PassEventArgsToCommand = false
+        };
+        var border = new Border();
+
+        behavior.Attach(border);
+
+        Assert.True(behavior.CanExecuteDropCommand);
+        Assert.Null(command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommandProperties_DeferWhenDragEventArgsAreUnavailable()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = _ => throw new System.InvalidOperationException("The drag event args are not available yet.")
         };
         var behavior = new DragDropCommandsBehavior
         {
@@ -91,7 +115,60 @@ public class DragDropCommandsBehaviorTests
         behavior.Attach(border);
 
         Assert.True(behavior.CanExecuteDropCommand);
-        Assert.Null(command.LastCanExecuteParameter);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteDropCommand);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommandProperties_UseCanExecuteCommandParameterWhenEventArgsArePassed()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var behavior = new DragDropCommandsBehavior
+        {
+            DropCommand = command,
+            CanExecuteCommandParameter = "disabled"
+        };
+        var border = new Border();
+
+        behavior.Attach(border);
+        Assert.False(behavior.CanExecuteDropCommand);
+        Assert.Equal("disabled", command.LastCanExecuteParameter);
+
+        behavior.CanExecuteCommandParameter = "enabled";
+
+        Assert.True(behavior.CanExecuteDropCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void PassEventArgsToCommand_UpdatesCanExecuteParameterAvailability()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new DragDropCommandsBehavior
+        {
+            DropCommand = command
+        };
+        var border = new Border();
+
+        behavior.Attach(border);
+        Assert.True(behavior.CanExecuteDropCommand);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        behavior.PassEventArgsToCommand = false;
+
+        Assert.False(behavior.CanExecuteDropCommand);
+        Assert.Equal(1, command.CanExecuteCallCount);
 
         behavior.Detach();
     }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/CommandCanExecuteObserverTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/CommandCanExecuteObserverTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class CommandCanExecuteObserverTests
+{
+    [Fact]
+    public void Constructor_ThrowsForNullCallback()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CommandCanExecuteObserver(null!));
+    }
+
+    [Fact]
+    public void Start_ReportsTrueWhenCommandIsNull()
+    {
+        var canExecute = false;
+        var observer = new CommandCanExecuteObserver(value => canExecute = value);
+
+        observer.Start(null, null);
+
+        Assert.True(canExecute);
+    }
+
+    [Fact]
+    public void Update_UsesCurrentCommandParameter()
+    {
+        var canExecute = false;
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var observer = new CommandCanExecuteObserver(value => canExecute = value);
+
+        observer.Start(command, "disabled");
+        Assert.False(canExecute);
+
+        observer.Update(command, "enabled");
+
+        Assert.True(canExecute);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+    }
+
+    [Fact]
+    public void Update_RewiresCommandSubscriptions()
+    {
+        var canExecute = false;
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var observer = new CommandCanExecuteObserver(value => canExecute = value);
+
+        observer.Start(firstCommand, null);
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.False(canExecute);
+
+        observer.Update(secondCommand, null);
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.True(canExecute);
+    }
+
+    [Fact]
+    public void Dispose_RemovesCommandSubscription()
+    {
+        var command = new ObservableCommand();
+        var observer = new CommandCanExecuteObserver(_ => { });
+
+        observer.Start(command, null);
+        Assert.Equal(1, command.SubscriptionCount);
+
+        observer.Dispose();
+
+        Assert.Equal(0, command.SubscriptionCount);
+    }
+
+    [Fact]
+    public void CommandCanExecuteChangedSubscription_DoesNotRetainObserverOrCallbackTarget()
+    {
+        var command = new ObservableCommand();
+
+        var references = CreateAndReleaseObserver(command);
+
+        Assert.Equal(1, command.SubscriptionCount);
+        AssertCollected(references.Observer, references.CallbackTarget);
+
+        command.RaiseCanExecuteChangedWithNullSender();
+
+        Assert.Equal(0, command.SubscriptionCount);
+        GC.KeepAlive(command);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Observer, WeakReference CallbackTarget) CreateAndReleaseObserver(ObservableCommand command)
+    {
+        var callbackTarget = new CallbackTarget();
+        var observer = new CommandCanExecuteObserver(callbackTarget.SetCanExecute);
+
+        observer.Start(command, null);
+
+        return (new WeakReference(observer), new WeakReference(callbackTarget));
+    }
+
+    private static void AssertCollected(params WeakReference[] references)
+    {
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+            if (Array.TrueForAll(references, reference => !reference.IsAlive))
+            {
+                return;
+            }
+        }
+
+        Assert.All(references, reference => Assert.False(reference.IsAlive));
+    }
+
+    private sealed class CallbackTarget
+    {
+        public bool CanExecute { get; private set; }
+
+        public void SetCanExecute(bool value)
+        {
+            CanExecute = value;
+        }
+    }
+
+    private sealed class ObservableCommand : ICommand
+    {
+        private EventHandler? _canExecuteChanged;
+
+        public bool CanExecuteResult { get; set; } = true;
+
+        public Func<object?, bool>? CanExecuteCallback { get; set; }
+
+        public int SubscriptionCount { get; private set; }
+
+        public object? LastCanExecuteParameter { get; private set; }
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add
+            {
+                _canExecuteChanged += value;
+                SubscriptionCount++;
+            }
+            remove
+            {
+                _canExecuteChanged -= value;
+                SubscriptionCount--;
+            }
+        }
+
+        public bool CanExecute(object? parameter)
+        {
+            LastCanExecuteParameter = parameter;
+            return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
+        }
+
+        public void Execute(object? parameter)
+        {
+        }
+
+        public void RaiseCanExecuteChanged()
+        {
+            _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void RaiseCanExecuteChangedWithNullSender()
+        {
+            _canExecuteChanged?.Invoke(null, EventArgs.Empty);
+        }
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/CommandCanExecuteObserverTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/CommandCanExecuteObserverTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Input;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactivity.UnitTests;
@@ -126,6 +129,33 @@ public class CommandCanExecuteObserverTests
         observer.Dispose();
 
         Assert.Equal(0, command.SubscriptionCount);
+    }
+
+    [AvaloniaFact]
+    public async Task CanExecuteChanged_FromBackgroundThread_UpdatesCallbackOnUiThread()
+    {
+        var callbackCount = 0;
+        var canExecuteChangedCallbackUsedUiThread = false;
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var observer = new CommandCanExecuteObserver(_ =>
+        {
+            callbackCount++;
+            if (callbackCount == 2)
+            {
+                canExecuteChangedCallbackUsedUiThread = Dispatcher.UIThread.CheckAccess();
+            }
+        });
+
+        observer.Start(command, null);
+
+        command.CanExecuteResult = true;
+        await Task.Run(command.RaiseCanExecuteChanged);
+        await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+        Assert.Equal(2, callbackCount);
+        Assert.True(canExecuteChangedCallbackUsedUiThread);
+
+        observer.Dispose();
     }
 
     [Fact]

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/CommandCanExecuteObserverTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/CommandCanExecuteObserverTests.cs
@@ -44,6 +44,57 @@ public class CommandCanExecuteObserverTests
     }
 
     [Fact]
+    public void Start_WithUnknownParameter_ReportsTrueWithoutCallingCanExecute()
+    {
+        var canExecute = false;
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = _ => throw new InvalidOperationException("The parameter is not available yet.")
+        };
+        var observer = new CommandCanExecuteObserver(value => canExecute = value);
+
+        observer.Start(command, null, false);
+
+        Assert.True(canExecute);
+        Assert.Equal(0, command.CanExecuteCallCount);
+    }
+
+    [Fact]
+    public void CanExecuteChanged_WithUnknownParameter_DoesNotCallCanExecute()
+    {
+        var canExecute = false;
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = _ => throw new InvalidOperationException("The parameter is not available yet.")
+        };
+        var observer = new CommandCanExecuteObserver(value => canExecute = value);
+
+        observer.Start(command, null, false);
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(canExecute);
+        Assert.Equal(0, command.CanExecuteCallCount);
+    }
+
+    [Fact]
+    public void Update_FromUnknownToKnownParameter_ProbesCurrentParameter()
+    {
+        var canExecute = false;
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var observer = new CommandCanExecuteObserver(value => canExecute = value);
+
+        observer.Start(command, null, false);
+        observer.Update(command, "enabled", true);
+
+        Assert.True(canExecute);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+        Assert.Equal(1, command.CanExecuteCallCount);
+    }
+
+    [Fact]
     public void Update_RewiresCommandSubscriptions()
     {
         var canExecute = false;
@@ -143,6 +194,8 @@ public class CommandCanExecuteObserverTests
 
         public object? LastCanExecuteParameter { get; private set; }
 
+        public int CanExecuteCallCount { get; private set; }
+
         public event EventHandler? CanExecuteChanged
         {
             add
@@ -159,6 +212,7 @@ public class CommandCanExecuteObserverTests
 
         public bool CanExecute(object? parameter)
         {
+            CanExecuteCallCount++;
             LastCanExecuteParameter = parameter;
             return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
         }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class InvokeCommandActionBaseTests
+{
+    [AvaloniaFact]
+    public void CanExecuteCommand_DefaultsToTrueWithoutCommand()
+    {
+        var action = new TestInvokeCommandAction();
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.True(action.CanExecuteCommand);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UpdatesWhenCommandRaisesCanExecuteChanged()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+        Assert.False(action.CanExecuteCommand);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(action.CanExecuteCommand);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesCurrentCommandParameter()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command,
+            CommandParameter = "disabled"
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+        Assert.False(action.CanExecuteCommand);
+
+        action.CommandParameter = "enabled";
+
+        Assert.True(action.CanExecuteCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_RewiresSubscriptionsWhenCommandChangesAndDetaches()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var action = new TestInvokeCommandAction
+        {
+            Command = firstCommand
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.False(action.CanExecuteCommand);
+
+        action.Command = secondCommand;
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.True(action.CanExecuteCommand);
+
+        action.DetachActionFromLogicalTree(parent);
+
+        Assert.Equal(0, secondCommand.SubscriptionCount);
+    }
+
+    private sealed class TestInvokeCommandAction : InvokeCommandActionBase
+    {
+        public override object? Execute(object? sender, object? parameter)
+        {
+            return null;
+        }
+    }
+
+    private sealed class ObservableCommand : ICommand
+    {
+        private EventHandler? _canExecuteChanged;
+
+        public bool CanExecuteResult { get; set; } = true;
+
+        public Func<object?, bool>? CanExecuteCallback { get; set; }
+
+        public int SubscriptionCount { get; private set; }
+
+        public object? LastCanExecuteParameter { get; private set; }
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add
+            {
+                _canExecuteChanged += value;
+                SubscriptionCount++;
+            }
+            remove
+            {
+                _canExecuteChanged -= value;
+                SubscriptionCount--;
+            }
+        }
+
+        public bool CanExecute(object? parameter)
+        {
+            LastCanExecuteParameter = parameter;
+            return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
+        }
+
+        public void Execute(object? parameter)
+        {
+        }
+
+        public void RaiseCanExecuteChanged()
+        {
+            _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
@@ -43,6 +43,72 @@ public class InvokeCommandActionBaseTests
     }
 
     [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_DefaultFalse_DoesNotUpdateParentIsEnabled()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.False(action.CanExecuteCommand);
+        Assert.True(parent.IsEnabled);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_UpdatesParentIsEnabled()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.False(parent.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(parent.IsEnabled);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_PropertyChange_AttachesAndDetachesBinding()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.True(parent.IsEnabled);
+
+        action.UseCommandCanExecuteForIsEnabled = true;
+
+        Assert.False(parent.IsEnabled);
+
+        action.UseCommandCanExecuteForIsEnabled = false;
+
+        Assert.True(parent.IsEnabled);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
     public void CanExecuteCommand_UsesCurrentCommandParameter()
     {
         var command = new ObservableCommand

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
@@ -134,6 +134,86 @@ public class InvokeCommandActionBaseTests
     }
 
     [AvaloniaFact]
+    public void CanExecuteCommand_DefersWhenEventParameterIsUnavailable()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = _ => throw new InvalidOperationException("The event parameter is not available yet.")
+        };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command,
+            PassEventArgsToCommand = true,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.True(action.CanExecuteCommand);
+        Assert.True(parent.IsEnabled);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(action.CanExecuteCommand);
+        Assert.True(parent.IsEnabled);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesSeparateCanExecuteCommandParameter()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command,
+            PassEventArgsToCommand = true,
+            CanExecuteCommandParameter = "disabled"
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+        Assert.False(action.CanExecuteCommand);
+        Assert.Equal("disabled", command.LastCanExecuteParameter);
+
+        action.CanExecuteCommandParameter = "enabled";
+
+        Assert.True(action.CanExecuteCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+        Assert.Equal("event parameter", action.ResolveParameterForTest("event parameter"));
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void PassEventArgsToCommand_UpdatesCanExecuteParameterAvailability()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command
+        };
+        var parent = new Border();
+
+        action.AttachActionToLogicalTree(parent);
+        Assert.False(action.CanExecuteCommand);
+        Assert.Equal(1, command.CanExecuteCallCount);
+
+        action.PassEventArgsToCommand = true;
+
+        Assert.True(action.CanExecuteCommand);
+        Assert.Equal(1, command.CanExecuteCallCount);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
     public void CanExecuteCommand_RewiresSubscriptionsWhenCommandChangesAndDetaches()
     {
         var firstCommand = new ObservableCommand { CanExecuteResult = false };
@@ -162,6 +242,11 @@ public class InvokeCommandActionBaseTests
 
     private sealed class TestInvokeCommandAction : InvokeCommandActionBase
     {
+        public object? ResolveParameterForTest(object? parameter)
+        {
+            return ResolveParameter(parameter);
+        }
+
         public override object? Execute(object? sender, object? parameter)
         {
             return null;
@@ -180,6 +265,8 @@ public class InvokeCommandActionBaseTests
 
         public object? LastCanExecuteParameter { get; private set; }
 
+        public int CanExecuteCallCount { get; private set; }
+
         public event EventHandler? CanExecuteChanged
         {
             add
@@ -196,6 +283,7 @@ public class InvokeCommandActionBaseTests
 
         public bool CanExecute(object? parameter)
         {
+            CanExecuteCallCount++;
             LastCanExecuteParameter = parameter;
             return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
         }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandActionBaseTests.cs
@@ -84,6 +84,72 @@ public class InvokeCommandActionBaseTests
     }
 
     [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_PreservesExistingDisabledParentState()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var action = new TestInvokeCommandAction
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var parent = new Border
+        {
+            IsEnabled = false
+        };
+
+        action.AttachActionToLogicalTree(parent);
+
+        Assert.False(parent.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.False(parent.IsEnabled);
+
+        parent.IsEnabled = true;
+
+        Assert.True(parent.IsEnabled);
+
+        action.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_ComposesMultipleActionBlockers()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = false };
+        var firstAction = new TestInvokeCommandAction
+        {
+            Command = firstCommand,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var secondAction = new TestInvokeCommandAction
+        {
+            Command = secondCommand,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var parent = new Border();
+
+        firstAction.AttachActionToLogicalTree(parent);
+        secondAction.AttachActionToLogicalTree(parent);
+
+        Assert.False(parent.IsEnabled);
+
+        firstCommand.CanExecuteResult = true;
+        firstCommand.RaiseCanExecuteChanged();
+
+        Assert.False(parent.IsEnabled);
+
+        secondCommand.CanExecuteResult = true;
+        secondCommand.RaiseCanExecuteChanged();
+
+        Assert.True(parent.IsEnabled);
+
+        firstAction.DetachActionFromLogicalTree(parent);
+        secondAction.DetachActionFromLogicalTree(parent);
+    }
+
+    [AvaloniaFact]
     public void UseCommandCanExecuteForIsEnabled_PropertyChange_AttachesAndDetachesBinding()
     {
         var command = new ObservableCommand { CanExecuteResult = false };

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
@@ -155,6 +155,86 @@ public class InvokeCommandBehaviorBaseTests
     }
 
     [AvaloniaFact]
+    public void CanExecuteCommand_DefersWhenEventParameterIsUnavailable()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = _ => throw new InvalidOperationException("The event parameter is not available yet.")
+        };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command,
+            PassEventArgsToCommand = true,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.True(button.IsEnabled);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.True(button.IsEnabled);
+        Assert.Equal(0, command.CanExecuteCallCount);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesSeparateCanExecuteCommandParameter()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command,
+            PassEventArgsToCommand = true,
+            CanExecuteCommandParameter = "disabled"
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+        Assert.Equal("disabled", command.LastCanExecuteParameter);
+
+        behavior.CanExecuteCommandParameter = "enabled";
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+        Assert.Equal("event parameter", behavior.ResolveParameterForTest("event parameter"));
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void PassEventArgsToCommand_UpdatesCanExecuteParameterAvailability()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+        Assert.Equal(1, command.CanExecuteCallCount);
+
+        behavior.PassEventArgsToCommand = true;
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.Equal(1, command.CanExecuteCallCount);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
     public void CanExecuteCommand_RewiresSubscriptionsWhenCommandChangesAndDetaches()
     {
         var firstCommand = new ObservableCommand { CanExecuteResult = false };
@@ -181,7 +261,13 @@ public class InvokeCommandBehaviorBaseTests
         Assert.Equal(0, secondCommand.SubscriptionCount);
     }
 
-    private sealed class TestInvokeCommandBehavior : InvokeCommandBehaviorBase;
+    private sealed class TestInvokeCommandBehavior : InvokeCommandBehaviorBase
+    {
+        public object? ResolveParameterForTest(object? parameter)
+        {
+            return ResolveParameter(parameter);
+        }
+    }
 
     private sealed class ObservableCommand : ICommand
     {
@@ -194,6 +280,8 @@ public class InvokeCommandBehaviorBaseTests
         public int SubscriptionCount { get; private set; }
 
         public object? LastCanExecuteParameter { get; private set; }
+
+        public int CanExecuteCallCount { get; private set; }
 
         public event EventHandler? CanExecuteChanged
         {
@@ -211,6 +299,7 @@ public class InvokeCommandBehaviorBaseTests
 
         public bool CanExecute(object? parameter)
         {
+            CanExecuteCallCount++;
             LastCanExecuteParameter = parameter;
             return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
         }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class InvokeCommandBehaviorBaseTests
+{
+    [AvaloniaFact]
+    public void CanExecuteCommand_DefaultsToTrueWithoutCommand()
+    {
+        var behavior = new TestInvokeCommandBehavior();
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UpdatesWhenCommandRaisesCanExecuteChanged()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesCurrentCommandParameter()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => Equals(parameter, "enabled")
+        };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command,
+            CommandParameter = "disabled"
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.CommandParameter = "enabled";
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.Equal("enabled", command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_UsesNullWhenCommandParameterIsUnset()
+    {
+        var command = new ObservableCommand
+        {
+            CanExecuteCallback = parameter => parameter is null
+        };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.True(behavior.CanExecuteCommand);
+        Assert.Null(command.LastCanExecuteParameter);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void CanExecuteCommand_RewiresSubscriptionsWhenCommandChangesAndDetaches()
+    {
+        var firstCommand = new ObservableCommand { CanExecuteResult = false };
+        var secondCommand = new ObservableCommand { CanExecuteResult = true };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = firstCommand
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.Equal(1, firstCommand.SubscriptionCount);
+        Assert.False(behavior.CanExecuteCommand);
+
+        behavior.Command = secondCommand;
+
+        Assert.Equal(0, firstCommand.SubscriptionCount);
+        Assert.Equal(1, secondCommand.SubscriptionCount);
+        Assert.True(behavior.CanExecuteCommand);
+
+        behavior.Detach();
+
+        Assert.Equal(0, secondCommand.SubscriptionCount);
+    }
+
+    private sealed class TestInvokeCommandBehavior : InvokeCommandBehaviorBase;
+
+    private sealed class ObservableCommand : ICommand
+    {
+        private EventHandler? _canExecuteChanged;
+
+        public bool CanExecuteResult { get; set; } = true;
+
+        public Func<object?, bool>? CanExecuteCallback { get; set; }
+
+        public int SubscriptionCount { get; private set; }
+
+        public object? LastCanExecuteParameter { get; private set; }
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add
+            {
+                _canExecuteChanged += value;
+                SubscriptionCount++;
+            }
+            remove
+            {
+                _canExecuteChanged -= value;
+                SubscriptionCount--;
+            }
+        }
+
+        public bool CanExecute(object? parameter)
+        {
+            LastCanExecuteParameter = parameter;
+            return CanExecuteCallback?.Invoke(parameter) ?? CanExecuteResult;
+        }
+
+        public void Execute(object? parameter)
+        {
+        }
+
+        public void RaiseCanExecuteChanged()
+        {
+            _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
@@ -43,6 +43,72 @@ public class InvokeCommandBehaviorBaseTests
     }
 
     [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_DefaultFalse_DoesNotUpdateAssociatedObjectIsEnabled()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.False(behavior.CanExecuteCommand);
+        Assert.True(button.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_UpdatesAssociatedObjectIsEnabled()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.False(button.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(button.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_PropertyChange_AttachesAndDetachesBinding()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command
+        };
+        var button = new Button();
+
+        behavior.Attach(button);
+
+        Assert.True(button.IsEnabled);
+
+        behavior.UseCommandCanExecuteForIsEnabled = true;
+
+        Assert.False(button.IsEnabled);
+
+        behavior.UseCommandCanExecuteForIsEnabled = false;
+
+        Assert.True(button.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
     public void CanExecuteCommand_UsesCurrentCommandParameter()
     {
         var command = new ObservableCommand

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InvokeCommandBehaviorBaseTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactivity.UnitTests;
@@ -79,6 +80,83 @@ public class InvokeCommandBehaviorBaseTests
         command.RaiseCanExecuteChanged();
 
         Assert.True(button.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_PreservesExistingDisabledState()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var button = new Button
+        {
+            IsEnabled = false
+        };
+
+        behavior.Attach(button);
+
+        Assert.False(button.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.False(button.IsEnabled);
+
+        button.IsEnabled = true;
+
+        Assert.True(button.IsEnabled);
+
+        behavior.Detach();
+    }
+
+    [AvaloniaFact]
+    public void UseCommandCanExecuteForIsEnabled_ComposesWithExistingIsEnabledBinding()
+    {
+        var command = new ObservableCommand { CanExecuteResult = false };
+        var behavior = new TestInvokeCommandBehavior
+        {
+            Command = command,
+            UseCommandCanExecuteForIsEnabled = true
+        };
+        var isEnabled = new BooleanObservable(true);
+        var button = new Button();
+        button.Bind(InputElement.IsEnabledProperty, isEnabled);
+
+        behavior.Attach(button);
+
+        Assert.False(button.IsEnabled);
+
+        isEnabled.Value = false;
+
+        Assert.False(button.IsEnabled);
+
+        isEnabled.Value = true;
+
+        Assert.False(button.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(button.IsEnabled);
+
+        isEnabled.Value = false;
+
+        Assert.False(button.IsEnabled);
+
+        command.CanExecuteResult = false;
+        command.RaiseCanExecuteChanged();
+
+        Assert.False(button.IsEnabled);
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+
+        Assert.False(button.IsEnabled);
 
         behavior.Detach();
     }
@@ -311,6 +389,72 @@ public class InvokeCommandBehaviorBaseTests
         public void RaiseCanExecuteChanged()
         {
             _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private sealed class BooleanObservable : IObservable<bool>
+    {
+        private IObserver<bool>? _observer;
+        private bool _value;
+
+        public BooleanObservable(bool value)
+        {
+            _value = value;
+        }
+
+        public bool Value
+        {
+            get => _value;
+            set
+            {
+                if (_value == value)
+                {
+                    return;
+                }
+
+                _value = value;
+                _observer?.OnNext(value);
+            }
+        }
+
+        public IDisposable Subscribe(IObserver<bool> observer)
+        {
+            _observer = observer;
+            observer.OnNext(_value);
+
+            return new Subscription(this, observer);
+        }
+
+        private void Unsubscribe(IObserver<bool> observer)
+        {
+            if (ReferenceEquals(_observer, observer))
+            {
+                _observer = null;
+            }
+        }
+
+        private sealed class Subscription : IDisposable
+        {
+            private readonly BooleanObservable _owner;
+            private readonly IObserver<bool> _observer;
+            private bool _disposed;
+
+            public Subscription(BooleanObservable owner, IObserver<bool> observer)
+            {
+                _owner = owner;
+                _observer = observer;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _owner.Unsubscribe(_observer);
+            }
         }
     }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementActionTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementActionTests.cs
@@ -73,4 +73,19 @@ public class StyledElementActionTests
         Assert.Equal(parent, action.Parent);
         Assert.Equal(templatedParent, action.TemplatedParent);
     }
+
+    [AvaloniaFact]
+    public void DetachActionFromLogicalTree_ClearsParentAndTemplatedParent()
+    {
+        var action = new StubAction();
+        var parent = new Button();
+        var templatedParent = new ContentControl();
+        TemplatedParentHelper.SetTemplatedParent(parent, templatedParent);
+
+        action.AttachActionToLogicalTree(parent);
+        action.DetachActionFromLogicalTree(parent);
+
+        Assert.Null(action.Parent);
+        Assert.Null(action.TemplatedParent);
+    }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+public class StyledElementBehaviorTests
+{
+    [AvaloniaFact]
+    public void Detach_ClearsLogicalParentAndTemplatedParent()
+    {
+        var behavior = new TestStyledElementBehavior();
+        var button = new Button();
+        var templatedParent = new ContentControl();
+        var window = new Window
+        {
+            Content = button
+        };
+
+        TemplatedParentHelper.SetTemplatedParent(button, templatedParent);
+        Interaction.GetBehaviors(button).Add(behavior);
+        window.Show();
+
+        Assert.Equal(button, behavior.Parent);
+        Assert.Equal(templatedParent, behavior.TemplatedParent);
+
+        behavior.Detach();
+
+        Assert.Null(behavior.Parent);
+        Assert.Null(behavior.TemplatedParent);
+
+        window.Close();
+    }
+
+    private sealed class TestStyledElementBehavior : StyledElementBehavior;
+}


### PR DESCRIPTION
# Add command CanExecute observation for behaviors and pickers

## Summary

This PR adds reusable command `CanExecute` observation across command-oriented behaviors and picker workflows, exposes the observed state as bindable `CanExecuteCommand` properties, and adds sample/documentation coverage for the new pattern.

It also hardens picker action async lifetime handling and updates the Avalonia 12 package baseline to a patched runtime version after reproducing macOS native picker crashes against Avalonia 12.0.0.

## Changes

- Added public `CommandCanExecuteObserver` for reusable `ICommand.CanExecute` observation.
- Added `CanExecuteCommand` to `InvokeCommandBehaviorBase` and `InvokeCommandActionBase`.
- Added action logical-tree lifecycle hooks so actions can start and stop command observation when attached through triggers.
- Added `CanExecuteCommand` support to execute-command behavior bases and drag/drop command behavior surfaces.
- Added focused unit tests for command observation, weak event cleanup, command rewiring, command parameters, and detach behavior.
- Added a `Picker CanExecuteCommand` sample page that demonstrates:
  - all button picker behaviors,
  - all menu item picker behaviors,
  - a `ClickEventTrigger` attached to a normal panel that opens a picker action,
  - binding host control `IsEnabled` to the behavior/action `CanExecuteCommand`.
- Added picker behavior unit coverage and shared test command helpers.
- Added documentation for `CommandCanExecuteObserver`, command behavior/action `CanExecuteCommand`, drag/drop command state, execute-command behavior state, and picker storage-provider usage.
- Changed picker actions to return and track their async picker operations instead of starting an untracked nested dispatcher operation.
- Updated package baselines:
  - `Xaml.Behaviors` package version: `12.0.5`
  - Avalonia packages: `12.0.5`
  - Avalonia DataGrid: `12.0.1`

## Why

Picker behaviors attached to controls can execute commands, but the associated controls were not automatically disabled when the bound command could not execute. Rather than coupling picker behavior directly to button/menu item state, this exposes a bindable `CanExecuteCommand` property so users can opt into the control state they want:

```xml
<Button IsEnabled="{Binding #OpenFilePicker.CanExecuteCommand}">
  <Interaction.Behaviors>
    <ButtonOpenFilePickerBehavior x:Name="OpenFilePicker"
                                  Command="{Binding OpenCommand}" />
  </Interaction.Behaviors>
</Button>
```

The same pattern now works for picker actions hosted by non-button controls through `ClickEventTrigger`.

During sample validation, macOS file picker completion crashed inside Avalonia Native when using Avalonia 12.0.0. This matches upstream Avalonia issue #21150. The PR keeps the local picker action lifetime hardening and moves the package baseline to a patched Avalonia 12 release.

## Impact

- Existing behavior execution remains unchanged.
- Consumers can bind UI enabled/disabled state to `CanExecuteCommand`.
- Custom behavior authors can use the public `CommandCanExecuteObserver`.
- Picker actions are better behaved when composed inside async action groups because they now return their picker task.
- The sample application uses patched Avalonia native libraries for storage pickers.

## Validation

Ran:

- `dotnet restore AvaloniaBehaviors.slnx`
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --framework net10.0 --filter "PickerActionBaseTests|ClickEventTrigger_SaveFilePickerAction|StorageProvider"`
- `dotnet test tests/Xaml.Behaviors.Interactivity.UnitTests/Xaml.Behaviors.Interactivity.UnitTests.csproj --framework net10.0 --filter "CommandCanExecuteObserverTests|InvokeCommandActionBaseTests|InvokeCommandBehaviorBaseTests"`
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --framework net10.0`
- `dotnet build samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj --framework net10.0`
- `dotnet build src/Xaml.Behaviors.Interactivity/Xaml.Behaviors.Interactivity.csproj --framework net8.0`
- `dotnet build src/Xaml.Behaviors.Interactions/Xaml.Behaviors.Interactions.csproj --framework net8.0`
- `dotnet build src/Xaml.Behaviors.Interactions/Xaml.Behaviors.Interactions.csproj --framework net10.0`
- `dotnet build src/Xaml.Behaviors/Xaml.Behaviors.csproj --framework net10.0`
- `dotnet test AvaloniaBehaviors.slnx --framework net10.0`
- `dotnet msbuild src/Xaml.Behaviors/Xaml.Behaviors.csproj -getProperty:Version -getProperty:PackageVersion -getProperty:VersionPrefix`
- `git diff --check`

Known warnings are existing package vulnerability advisories from build/test dependencies.
