### PR TITLE
Preserve pointer presses during drag detection

### DIFF
--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.LogicalTree;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.DragAndDrop;
@@ -154,16 +153,6 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
             if (e.Source is Control control
                 && AssociatedObject?.DataContext == control.DataContext)
             {
-                if ((e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Meta | KeyModifiers.Shift)) == 0
-                    && ((control as ISelectable
-                    ?? control.Parent as ISelectable
-                    ?? control.FindLogicalAncestorOfType<ISelectable>())
-                        ?.IsSelected
-                    ?? false))
-                {
-                    e.Handled = true; //avoid deselection on drag
-                }
-
                 _dragStartPoint = e.GetPosition(null);
                 _triggerEvent = e;
                 _lock = true;

--- a/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
+++ b/src/Xaml.Behaviors.Interactions.DragAndDrop/ContextDragBehaviorBase.cs
@@ -169,6 +169,9 @@ public abstract class ContextDragBehaviorBase : StyledElementBehavior<Control>
                 _lock = true;
                 _captured = true;
 
+                // Drag detection must not consume the initial press. Selection and
+                // interactive content still need to observe it before a drag starts.
+                e.Handled = false;
                 return;
             }
         }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragBehaviorTests.cs
@@ -10,6 +10,19 @@ namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
 public class ContextDragBehaviorTests
 {
     [AvaloniaFact]
+    public void PointerPressed_Is_Not_Handled_For_Selected_Item_Content()
+    {
+        var window = new ContextDragEscapeWindow();
+        var pointerPressed = false;
+        window.SelectedItemContent.PointerPressed += (_, _) => pointerPressed = true;
+
+        window.Show();
+        window.MouseDown(window.SelectedItemContent, new Point(5, 5), MouseButton.Left);
+
+        Assert.True(pointerPressed);
+    }
+
+    [AvaloniaFact]
     public void Escape_Cancels_Drag()
     {
         var window = new ContextDragEscapeWindow();

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragEscapeWindow.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragEscapeWindow.axaml
@@ -2,9 +2,19 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.DragAndDrop"
         x:Class="Avalonia.Xaml.Interactions.UnitTests.DragAndDrop.ContextDragEscapeWindow">
-  <Border x:Name="TargetBorder" Width="100" Height="100" Background="Gray">
-    <Interaction.Behaviors>
-      <local:TestContextDragBehavior x:Name="TestBehavior" HorizontalDragThreshold="0" VerticalDragThreshold="0" />
-    </Interaction.Behaviors>
-  </Border>
+  <StackPanel>
+    <Border x:Name="TargetBorder" Width="100" Height="100" Background="Gray">
+      <Interaction.Behaviors>
+        <local:TestContextDragBehavior x:Name="TestBehavior" HorizontalDragThreshold="0" VerticalDragThreshold="0" />
+      </Interaction.Behaviors>
+    </Border>
+    <ListBoxItem IsSelected="True">
+      <Interaction.Behaviors>
+        <local:TestContextDragBehavior />
+      </Interaction.Behaviors>
+      <Border x:Name="SelectedItemContent" Width="100" Height="30" Background="Transparent">
+        <TextBlock Text="Selected item content" />
+      </Border>
+    </ListBoxItem>
+  </StackPanel>
 </Window>


### PR DESCRIPTION
## Summary

- preserve the initial pointer press while `ContextDragBehaviorBase` records a potential drag
- allow selected item content to continue receiving routed pointer input
- add headless regression coverage for content inside a selected `ListBoxItem`

## Problem

`ContextDragBehaviorBase.AssociatedObject_PointerPressed` conditionally marked the routed press as handled for selected items. The method later reset `Handled`, but an early `return` introduced during a refactor bypassed that reset on the successful drag-candidate path.

As a result, controls and content inside selected `TreeView`, `TreeDataGrid`, and other selectable item containers could not observe the press. This prevented normal selection and interaction whenever the drag behavior was attached.

## Root cause

The drag behavior needs to retain the original `PointerPressedEventArgs` so a drag can begin after the movement threshold is crossed. Retaining that event does not require consuming it. The early return left `e.Handled = true`, stopping the routed event before descendant content could process it.

## Changes

- remove the obsolete selected-item branch that marked the initial press handled
- explicitly keep `e.Handled = false` on the valid drag-candidate path
- document why drag detection must not consume the initial press
- extend the existing drag test window with selected item content
- verify via a headless test that the content still receives `PointerPressed`

## Compatibility and impact

Drag initiation and cancellation behavior are unchanged. The fix only restores routed input propagation for the initial press, matching the behavior that existed before the regression and allowing selection and embedded controls to work normally.

## Validation

- confirmed the new regression test fails against the previous implementation
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --filter 'FullyQualifiedName~ContextDragBehaviorTests' --no-restore`
  - 2 passed, 0 failed
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 90 passed, 0 failed, 2 pre-existing skipped drag tests
- `git diff --check`

Closes #318