### PR TITLE
Invoke button commands through the native click flow

### DIFF
--- a/docfx/articles/interactions-custom/button/invoke-button-click-action.md
+++ b/docfx/articles/interactions-custom/button/invoke-button-click-action.md
@@ -1,6 +1,6 @@
 # InvokeButtonClickAction
 
-This action programmatically raises the `Click` event on a target `Button`. This is useful if you want to simulate a button click from another event or trigger.
+This action programmatically invokes a target `Button`. It follows Avalonia's normal button activation path, including the `Click` event, flyout handling, and command execution. Disabled buttons are not invoked.
 
 ### Properties
 *   `TargetButton`: The button to click. If not set, it attempts to use the `sender` if it is a button.
@@ -9,7 +9,9 @@ This action programmatically raises the `Click` event on a target `Button`. This
 
 ```xml
 <StackPanel>
-    <Button Name="SubmitButton" Content="Submit" Click="SubmitButton_Click" />
+    <Button Name="SubmitButton"
+            Content="Submit"
+            Command="{Binding SubmitCommand}" />
 
     <TextBox>
         <Interaction.Behaviors>
@@ -21,3 +23,5 @@ This action programmatically raises the `Click` event on a target `Button`. This
     </TextBox>
 </StackPanel>
 ```
+
+If a `Click` handler marks the event as handled, the button command is not executed, matching Avalonia's native button behavior.

--- a/src/Xaml.Behaviors.Interactions.Custom/Button/InvokeButtonClickAction.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Button/InvokeButtonClickAction.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia.Automation.Peers;
 using Avalonia.Controls;
-using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
-/// Raises <see cref="Button.ClickEvent"/> on the target button when executed.
+/// Invokes the target button when executed.
 /// </summary>
 public class InvokeButtonClickAction : StyledElementAction
 {
@@ -36,12 +36,13 @@ public class InvokeButtonClickAction : StyledElementAction
         }
 
         var button = TargetButton ?? sender as Button;
-        if (button is null)
+        if (button is null || !button.IsEffectivelyEnabled)
         {
             return false;
         }
 
-        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        var automationPeer = new ButtonAutomationPeer(button);
+        automationPeer.Invoke();
         return true;
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/InvokeButtonClickActionTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/InvokeButtonClickActionTests.cs
@@ -1,0 +1,77 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class InvokeButtonClickActionTests
+{
+    [AvaloniaFact]
+    public void Execute_Invokes_Button_Command_With_Parameter()
+    {
+        object? executedParameter = null;
+        var clickCount = 0;
+        var parameter = new object();
+        var button = new Button
+        {
+            Command = new Command(value => executedParameter = value),
+            CommandParameter = parameter
+        };
+        button.Click += (_, _) => clickCount++;
+        var window = new Window { Content = button };
+        var action = new InvokeButtonClickAction { TargetButton = button };
+
+        window.Show();
+
+        var result = action.Execute(sender: null, parameter: null);
+
+        Assert.True(Assert.IsType<bool>(result));
+        Assert.Equal(1, clickCount);
+        Assert.Same(parameter, executedParameter);
+    }
+
+    [AvaloniaFact]
+    public void Execute_Respects_Handled_Click_Event()
+    {
+        var commandCallCount = 0;
+        var button = new Button
+        {
+            Command = new Command(_ => commandCallCount++)
+        };
+        button.Click += (_, args) => args.Handled = true;
+        var window = new Window { Content = button };
+        var action = new InvokeButtonClickAction { TargetButton = button };
+
+        window.Show();
+
+        var result = action.Execute(sender: null, parameter: null);
+
+        Assert.True(Assert.IsType<bool>(result));
+        Assert.Equal(0, commandCallCount);
+    }
+
+    [AvaloniaFact]
+    public void Execute_Does_Not_Invoke_Disabled_Button()
+    {
+        var clickCount = 0;
+        var commandCallCount = 0;
+        var button = new Button
+        {
+            IsEnabled = false,
+            Command = new Command(_ => commandCallCount++)
+        };
+        button.Click += (_, _) => clickCount++;
+        var window = new Window { Content = button };
+        var action = new InvokeButtonClickAction { TargetButton = button };
+
+        window.Show();
+
+        var result = action.Execute(sender: null, parameter: null);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal(0, clickCount);
+        Assert.Equal(0, commandCallCount);
+    }
+}


### PR DESCRIPTION
## Summary

- invoke target buttons through Avalonia's native button activation path
- execute bound commands with their configured command parameters
- preserve handled `Click` event, disabled-state, `CanExecute`, and flyout semantics
- document the complete behavior and add focused headless tests

## Problem

`InvokeButtonClickAction` previously called `button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent))`. That only raised the routed event. It did not call `Button.OnClick()`, so Avalonia never reached the command execution portion of its button activation pipeline.

A button with `Command="{Binding ...}"` therefore appeared to receive a click event while its command was never invoked, which is the failure reported in #322.

## Root cause

Avalonia's `Button.OnClick()` performs more work than raising `ClickEvent`:

1. it verifies that the button is effectively enabled
2. it opens or closes the configured flyout
3. it raises the routed `Click` event
4. if the event was not handled, it evaluates and executes `Command` with `CommandParameter`

Raising the routed event directly bypassed steps 1, 2, and 4.

## Changes

- use `ButtonAutomationPeer.Invoke()` to enter Avalonia's supported button invocation path
- return `false` without invoking an effectively disabled target
- update the API summary and user documentation to describe full button invocation instead of event-only behavior
- replace the code-behind-oriented documentation example with an MVVM command example

## Tests

Added headless coverage proving that:

- the `Click` event is raised and the bound command receives the exact configured parameter
- a handled `Click` event suppresses command execution, matching Avalonia's native ordering
- disabled buttons do not raise `Click` or execute their command

## Validation

- confirmed the command regression test fails against the previous implementation
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --filter 'FullyQualifiedName~InvokeButtonClickActionTests' --no-restore`
  - 3 passed, 0 failed
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 92 passed, 0 failed, 2 pre-existing skipped drag tests
- `git diff --check`

Closes #322