### PR TITLE
Use bubble routing for inline edit double taps

### DIFF
--- a/docfx/articles/interactions-custom/control/inline-edit-behavior.md
+++ b/docfx/articles/interactions-custom/control/inline-edit-behavior.md
@@ -10,6 +10,8 @@ This behavior facilitates an "inline edit" pattern where a control switches betw
 *   `CancelKey`: The key to cancel changes and switch back (default: Escape).
 *   `EditOnAssociatedObjectDoubleTapped`: If true, double-tapping the container triggers edit mode.
 
+Double-tap activation follows Avalonia's bubble-routed `DoubleTapped` event, so taps on content inside the display control or associated container also begin editing.
+
 ### Example
 
 ```xml

--- a/src/Xaml.Behaviors.Interactions.Custom/Control/InlineEditBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Control/InlineEditBehavior.cs
@@ -172,7 +172,7 @@ public class InlineEditBehavior : StyledElementBehavior<Control>
 
     private void BeginEdit()
     {
-        if (EditControl is null || DisplayControl is null)
+        if (EditControl is null || DisplayControl is null || EditControl.IsVisible)
             return;
 
         DisplayControl.IsVisible = false;

--- a/src/Xaml.Behaviors.Interactions.Custom/Control/InlineEditBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Control/InlineEditBehavior.cs
@@ -109,13 +109,13 @@ public class InlineEditBehavior : StyledElementBehavior<Control>
     {
         if (DisplayControl is not null)
         {
-            DisplayControl.AddHandler(InputElement.DoubleTappedEvent, OnDisplayActivate, RoutingStrategies.Tunnel);
+            DisplayControl.AddHandler(InputElement.DoubleTappedEvent, OnDisplayActivate, RoutingStrategies.Bubble);
             DisplayControl.AddHandler(InputElement.KeyDownEvent, OnDisplayKeyDown, RoutingStrategies.Tunnel);
         }
 
         if (EditOnAssociatedObjectDoubleTapped && AssociatedObject is not null)
         {
-            AssociatedObject.AddHandler(InputElement.DoubleTappedEvent, OnAssociatedObjectActivate, RoutingStrategies.Tunnel);
+            AssociatedObject.AddHandler(InputElement.DoubleTappedEvent, OnAssociatedObjectActivate, RoutingStrategies.Bubble);
         }
 
         if (EditControl is not null)

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/InlineEditBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/InlineEditBehaviorTests.cs
@@ -1,0 +1,71 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class InlineEditBehaviorTests
+{
+    [AvaloniaFact]
+    public void DoubleTapped_DisplayControl_Begins_Edit()
+    {
+        var displayControl = new Border { Width = 100, Height = 30, Background = Brushes.Transparent };
+        var editControl = new TextBox { Width = 100, Height = 30 };
+        var host = new StackPanel
+        {
+            Children =
+            {
+                displayControl,
+                editControl
+            }
+        };
+        Interaction.GetBehaviors(host).Add(new InlineEditBehavior
+        {
+            DisplayControl = displayControl,
+            EditControl = editControl
+        });
+        var window = new Window { Content = host };
+
+        window.Show();
+        window.Click(displayControl);
+        window.Click(displayControl);
+
+        Assert.False(displayControl.IsVisible);
+        Assert.True(editControl.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void DoubleTapped_AssociatedObject_Begins_Edit()
+    {
+        var activationTarget = new Border { Width = 100, Height = 30, Background = Brushes.Transparent };
+        var displayControl = new Border { Width = 100, Height = 30, Background = Brushes.Transparent };
+        var editControl = new TextBox { Width = 100, Height = 30 };
+        var host = new StackPanel
+        {
+            Children =
+            {
+                activationTarget,
+                displayControl,
+                editControl
+            }
+        };
+        Interaction.GetBehaviors(host).Add(new InlineEditBehavior
+        {
+            DisplayControl = displayControl,
+            EditControl = editControl,
+            EditOnAssociatedObjectDoubleTapped = true
+        });
+        var window = new Window { Content = host };
+
+        window.Show();
+        window.Click(activationTarget);
+        window.Click(activationTarget);
+
+        Assert.False(displayControl.IsVisible);
+        Assert.True(editControl.IsVisible);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/InlineEditBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/InlineEditBehaviorTests.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Xaml.Interactions.Custom;
 using Avalonia.Xaml.Interactivity;
@@ -67,5 +69,48 @@ public class InlineEditBehaviorTests
 
         Assert.False(displayControl.IsVisible);
         Assert.True(editControl.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void DoubleTapped_EditControl_DoesNotRestartEdit()
+    {
+        var activationTarget = new Border { Width = 100, Height = 30, Background = Brushes.Transparent };
+        var displayControl = new Border { Width = 100, Height = 30, Background = Brushes.Transparent };
+        var editControl = new TextBox { Width = 100, Height = 30, Text = "one two" };
+        var host = new StackPanel
+        {
+            Children =
+            {
+                activationTarget,
+                displayControl,
+                editControl
+            }
+        };
+        Interaction.GetBehaviors(host).Add(new InlineEditBehavior
+        {
+            DisplayControl = displayControl,
+            EditControl = editControl,
+            EditOnAssociatedObjectDoubleTapped = true
+        });
+        var window = new Window { Content = host };
+
+        window.Show();
+        window.Click(activationTarget);
+        window.Click(activationTarget);
+
+        editControl.AddHandler(
+            InputElement.DoubleTappedEvent,
+            (_, _) =>
+            {
+                editControl.SelectionStart = 1;
+                editControl.SelectionEnd = 3;
+            },
+            RoutingStrategies.Bubble);
+
+        window.Click(editControl);
+        window.Click(editControl);
+
+        Assert.Equal(1, editControl.SelectionStart);
+        Assert.Equal(3, editControl.SelectionEnd);
     }
 }


### PR DESCRIPTION
## Summary

- subscribe `InlineEditBehavior` to `DoubleTappedEvent` with bubble routing
- restore double-tap activation for both the configured display control and associated object
- add headless regression coverage for both activation paths
- document that nested display content participates through routed bubbling

## Problem

`InlineEditBehavior` registered its two double-tap handlers with `RoutingStrategies.Tunnel`. Avalonia's `InputElement.DoubleTappedEvent` is bubble-routed, so those handlers were never reached. As a result, the sample `EditableItem` and consumer controls no longer entered edit mode on a double tap after `ShowOnDoubleTappedBehavior` was replaced.

## Root cause

The predecessor behavior and the library's typed `DoubleTappedEventTrigger` use the routed event's bubble strategy. `InlineEditBehavior` introduced a strategy mismatch by explicitly requesting the unsupported tunnel route for this event.

## Changes

- change the display-control handler from `RoutingStrategies.Tunnel` to `RoutingStrategies.Bubble`
- change the associated-object handler from `RoutingStrategies.Tunnel` to `RoutingStrategies.Bubble`
- retain the existing key, focus, visibility, and detach behavior unchanged
- document nested-content activation semantics

## Tests

Added headless tests proving that:

- double-tapping the configured `DisplayControl` hides it and shows the edit control
- double-tapping content inside the associated object does the same when `EditOnAssociatedObjectDoubleTapped` is enabled

Both tests fail against the previous tunnel-only implementation and pass with this change.

## Validation

- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --filter 'FullyQualifiedName~InlineEditBehaviorTests' --no-restore`
  - 2 passed, 0 failed
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 91 passed, 0 failed, 2 pre-existing skipped drag tests
- `git diff --check`

Closes #324