### PR TITLE
Document and test the runtime XAML namespace fallback

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaDataGridVersion)" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />

--- a/docfx/articles/interactivity/xmlns-definitions.md
+++ b/docfx/articles/interactivity/xmlns-definitions.md
@@ -57,3 +57,26 @@ The assembly contains an attribute like this:
 ```
 
 When the XAML compiler or loader encounters the `https://github.com/avaloniaui` namespace, it looks into all referenced assemblies that have this attribute and includes the specified CLR namespaces in the lookup scope.
+
+## Previewer and runtime XAML loader fallback
+
+Compiled application XAML discovers the package mappings automatically. Avalonia's previewer uses the runtime XAML compiler, whose namespace map is built from assemblies already loaded in the previewer process. If that map is initialized before the behavior assemblies are loaded, the previewer can report errors such as `Unable to resolve type Interaction` even though the project builds and runs correctly.
+
+For a view affected by this previewer-only loading order, declare the behavior assemblies explicitly and use the prefixes in that view:
+
+```xml
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Xaml.Behaviors.Interactivity"
+             xmlns:core="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Xaml.Behaviors.Interactions">
+    <Button>
+        <i:Interaction.Behaviors>
+            <core:EventTriggerBehavior EventName="Click">
+                <core:InvokeCommandAction Command="{Binding SaveCommand}" />
+            </core:EventTriggerBehavior>
+        </i:Interaction.Behaviors>
+    </Button>
+</UserControl>
+```
+
+Use the assembly that owns each focused package namespace. For example, custom interactions use `assembly=Xaml.Behaviors.Interactions.Custom`. This explicit form forces the runtime compiler to resolve the required assembly and can coexist with application-defined `XmlnsDefinition` attributes. It is a previewer/runtime-loading compatibility fallback; the shorter default-namespace form remains recommended for normal compiled XAML.

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/XmlnsDefinitionRuntimeXamlTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/XmlnsDefinitionRuntimeXamlTests.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics.CodeAnalysis;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class XmlnsDefinitionRuntimeXamlTests
+{
+    [AvaloniaFact]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "This test intentionally exercises Avalonia's runtime XAML compiler.")]
+    public void Runtime_Loader_Resolves_Explicit_Behavior_Assemblies_Alongside_Application_XmlnsDefinitions()
+    {
+        const string xaml = """
+            <features:PreviewFeatureControl
+                xmlns="https://github.com/avaloniaui"
+                xmlns:features="https://unit.test/features"
+                xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Xaml.Behaviors.Interactivity"
+                xmlns:core="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Xaml.Behaviors.Interactions">
+              <i:Interaction.Behaviors>
+                <core:EventTriggerBehavior EventName="Loaded" />
+              </i:Interaction.Behaviors>
+            </features:PreviewFeatureControl>
+            """;
+
+        var result = AvaloniaRuntimeXamlLoader.Load(
+            xaml,
+            typeof(XmlnsDefinitionRuntimeXamlTests).Assembly,
+            designMode: true);
+
+        Assert.IsType<PreviewFeatureControl>(result);
+    }
+}
+
+public sealed class PreviewFeatureControl : Border;

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
+using Avalonia.Metadata;
 using Xunit;
 
 [assembly: AssemblyTitle("Xaml.Behaviors.Interactions.UnitTests")]
+[assembly: XmlnsDefinition("https://unit.test/features", "Avalonia.Xaml.Interactions.UnitTests.Custom")]
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Avalonia.HarfBuzz" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Headless.XUnit" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- reproduce the previewer/runtime XAML namespace failure reported in #325
- document an explicit assembly-qualified namespace fallback
- prove that the fallback coexists with application-defined `XmlnsDefinition` mappings
- add focused runtime-compiler regression coverage

## Investigation result

The behavior packages already contain the expected assembly-level `XmlnsDefinition` attributes. Normal compiled XAML resolves `Interaction`, `EventTriggerBehavior`, and the other mapped types correctly.

The reported error is reproducible in Avalonia's runtime XAML compiler (the same path used by the previewer), including the `Unable to resolve type Interaction` and `ResolveContentPropertyTransformer` diagnostic cascade. The runtime compiler builds its XML namespace map from assemblies loaded when its static compiler context is initialized. If the behavior assemblies have not yet been loaded, their otherwise-correct attributes are absent from that cached map.

Application-defined `XmlnsDefinition` attributes are not themselves invalid; they expose the runtime-loader ordering because the application assembly is available while external behavior assemblies may not be.

## Why this PR uses a compatibility fallback

This initialization and assembly-discovery behavior lives in Avalonia's runtime XAML loader, outside the behavior package. Changing or duplicating package attributes cannot update a namespace map that the host created before loading those assemblies.

The reliable package-side guidance is to use assembly-qualified CLR namespaces in views affected by the previewer/runtime-loader path. Explicit assembly names make the compiler resolve the required behavior assemblies directly.

## Changes

- add a previewer/runtime-loader troubleshooting section to the XML namespace documentation
- show explicit mappings for:
  - `Avalonia.Xaml.Interactivity` in `Xaml.Behaviors.Interactivity`
  - `Avalonia.Xaml.Interactions.Core` in `Xaml.Behaviors.Interactions`
- clarify that focused packages such as custom interactions should use their owning assembly
- add a custom XML namespace mapping to the test application assembly
- add a runtime XAML loader test combining that application mapping with explicit behavior assembly mappings
- add the runtime loader package only to the test project

## Validation

- first confirmed that the same runtime test fails with the default namespace and produces the issue's exact resolution errors
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --filter 'FullyQualifiedName~XmlnsDefinitionRuntimeXamlTests' --no-restore`
  - 1 passed, 0 failed
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 90 passed, 0 failed, 2 pre-existing skipped drag tests
- `git diff --check`

Closes #325