### PR TITLE
Make validation rule properties bindable

### DIFF
--- a/docfx/articles/interactions-custom/validation/property-validation-behavior.md
+++ b/docfx/articles/interactions-custom/validation/property-validation-behavior.md
@@ -15,6 +15,8 @@ Base behavior that validates a property value using a set of rules.
 
 This behavior is intended to be subclassed for specific controls and properties.
 
+Validation-rule configuration, including each rule's error message, is exposed through Avalonia styled properties and supports compiled bindings. The behavior observes rule property and collection changes and revalidates the associated property immediately.
+
 
 ## Properties
 

--- a/docfx/articles/interactions-custom/validation/range-validation-rule.md
+++ b/docfx/articles/interactions-custom/validation/range-validation-rule.md
@@ -15,3 +15,14 @@ Validation rule that checks whether a value is within a specified range.
 ```xml
 <RangeValidationRule Minimum="0" Maximum="100" ErrorMessage="Value must be between 0 and 100." />
 ```
+
+All rule configuration properties are Avalonia styled properties, so they can use compiled bindings. When a bound rule property changes, the associated validation behavior immediately validates its current value again.
+
+```xml
+<SliderValidationBehavior IsValid="{Binding IsValid, Mode=OneWayToSource}">
+  <RangeValidationRule x:TypeArguments="x:Double"
+                       Minimum="{Binding Minimum}"
+                       Maximum="{Binding Maximum}"
+                       ErrorMessage="{Binding RangeErrorMessage}" />
+</SliderValidationBehavior>
+```

--- a/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/MainWindowViewModel.cs
@@ -127,6 +127,8 @@ public partial class MainWindowViewModel : ViewModelBase
         ValidatedNumber = 0m;
         SelectedItem = null;
         ValidatedSlider = 0.0;
+        SliderValidationMinimum = 0.0;
+        SliderValidationMaximum = 100.0;
         ValidatedDate = DateTimeOffset.Now;
         ValidatedItem = null;
 
@@ -434,6 +436,10 @@ public partial class MainWindowViewModel : ViewModelBase
     [Reactive] public partial double ValidatedSlider { get; set; }
 
     [Reactive] public partial bool IsSliderValid { get; set; }
+
+    [Reactive] public partial double SliderValidationMinimum { get; set; }
+
+    [Reactive] public partial double SliderValidationMaximum { get; set; }
 
     [Reactive] public partial DateTimeOffset? ValidatedDate { get; set; }
 

--- a/samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml
+++ b/samples/BehaviorsTestApplication/Views/Pages/SliderValidationBehaviorView.axaml
@@ -18,13 +18,26 @@
             Value="{Binding ValidatedSlider}">
       <Interaction.Behaviors>
         <SliderValidationBehavior IsValid="{Binding IsSliderValid, Mode=OneWayToSource}">
-          <RangeValidationRule x:TypeArguments="x:Double" Minimum="0" Maximum="100" ErrorMessage="Range 0-100" />
+          <RangeValidationRule x:TypeArguments="x:Double"
+                               Minimum="{Binding SliderValidationMinimum}"
+                               Maximum="{Binding SliderValidationMaximum}"
+                               ErrorMessage="Value is outside the configured range." />
         </SliderValidationBehavior>
       </Interaction.Behaviors>
     </Slider>
     <CheckBox IsEnabled="False"
               Content="IsSliderValid "
               IsChecked="{Binding IsSliderValid}" />
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <Slider Width="90"
+              Minimum="0"
+              Maximum="200"
+              Value="{Binding SliderValidationMinimum}" />
+      <Slider Width="90"
+              Minimum="0"
+              Maximum="200"
+              Value="{Binding SliderValidationMaximum}" />
+    </StackPanel>
     <TextBlock Text="{Binding ValidatedSlider}" />
   </StackPanel>
 </UserControl>

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/PropertyValidationBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/PropertyValidationBehavior.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using Avalonia.Collections;
 using Avalonia.Controls;
@@ -93,6 +94,40 @@ public class PropertyValidationBehavior<TControl, TValue> : DisposingBehavior<TC
             return DisposableAction.Empty;
         }
 
+        var associatedObject = AssociatedObject;
+        var rules = Rules;
+        var subscribedRules = new HashSet<AvaloniaObject>();
+
+        void RulePropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            Validate();
+        }
+
+        void AttachRule(IValidationRule<TValue> rule)
+        {
+            if (rule is AvaloniaObject avaloniaObject && subscribedRules.Add(avaloniaObject))
+            {
+                avaloniaObject.PropertyChanged += RulePropertyChanged;
+            }
+        }
+
+        void RulesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            foreach (var subscribedRule in subscribedRules)
+            {
+                subscribedRule.PropertyChanged -= RulePropertyChanged;
+            }
+
+            subscribedRules.Clear();
+
+            foreach (var rule in rules)
+            {
+                AttachRule(rule);
+            }
+
+            Validate();
+        }
+
         void Handler(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Property == property)
@@ -101,9 +136,26 @@ public class PropertyValidationBehavior<TControl, TValue> : DisposingBehavior<TC
             }
         }
 
-        AssociatedObject.PropertyChanged += Handler;
+        associatedObject.PropertyChanged += Handler;
+        rules.CollectionChanged += RulesCollectionChanged;
 
-        return DisposableAction.Create(() => AssociatedObject.PropertyChanged -= Handler);
+        foreach (var rule in rules)
+        {
+            AttachRule(rule);
+        }
+
+        return DisposableAction.Create(() =>
+        {
+            associatedObject.PropertyChanged -= Handler;
+            rules.CollectionChanged -= RulesCollectionChanged;
+
+            foreach (var subscribedRule in subscribedRules)
+            {
+                subscribedRule.PropertyChanged -= RulePropertyChanged;
+            }
+
+            subscribedRules.Clear();
+        });
     }
 
     /// <inheritdoc />

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/MaxValueValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/MaxValueValidationRule.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
@@ -8,15 +10,38 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// Validation rule that checks that a numeric value is less than or equal to a maximum value.
 /// </summary>
 /// <typeparam name="T">Type of value to validate.</typeparam>
-public class MaxValueValidationRule<T> : IValidationRule<T>
+[SuppressMessage("AvaloniaProperty", "AVP1002:AvaloniaProperty objects should not be owned by a generic type")]
+public class MaxValueValidationRule<T> : AvaloniaObject, IValidationRule<T>
 {
+    /// <summary>
+    /// Identifies the <see cref="MaxValue"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<T?> MaxValueProperty =
+        AvaloniaProperty.Register<MaxValueValidationRule<T>, T?>(nameof(MaxValue));
+
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<MaxValueValidationRule<T>, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is above maximum.");
+
     /// <summary>
     /// Gets or sets the maximum value.
     /// </summary>
-    public T? MaxValue { get; set; }
+    public T? MaxValue
+    {
+        get => GetValue(MaxValueProperty);
+        set => SetValue(MaxValueProperty, value);
+    }
 
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is above maximum.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(T? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/MinLengthValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/MinLengthValidationRule.cs
@@ -1,20 +1,43 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia;
+
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Validation rule that requires a string with a minimal length.
 /// </summary>
-public class MinLengthValidationRule : IValidationRule<string>
+public class MinLengthValidationRule : AvaloniaObject, IValidationRule<string>
 {
+    /// <summary>
+    /// Identifies the <see cref="Length"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<int> LengthProperty =
+        AvaloniaProperty.Register<MinLengthValidationRule, int>(nameof(Length));
+
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<MinLengthValidationRule, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is too short.");
+
     /// <summary>
     /// Gets or sets the minimal allowed length.
     /// </summary>
-    // ReSharper disable once UnusedAutoPropertyAccessor.Global
-    public int Length { get; set; }
+    public int Length
+    {
+        get => GetValue(LengthProperty);
+        set => SetValue(LengthProperty, value);
+    }
 
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is too short.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(string? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/MinValueValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/MinValueValidationRule.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
@@ -8,15 +10,38 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// Validation rule that checks that a numeric value is greater than or equal to a minimum value.
 /// </summary>
 /// <typeparam name="T">Type of value to validate.</typeparam>
-public class MinValueValidationRule<T> : IValidationRule<T>
+[SuppressMessage("AvaloniaProperty", "AVP1002:AvaloniaProperty objects should not be owned by a generic type")]
+public class MinValueValidationRule<T> : AvaloniaObject, IValidationRule<T>
 {
+    /// <summary>
+    /// Identifies the <see cref="MinValue"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<T?> MinValueProperty =
+        AvaloniaProperty.Register<MinValueValidationRule<T>, T?>(nameof(MinValue));
+
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<MinValueValidationRule<T>, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is below minimum.");
+
     /// <summary>
     /// Gets or sets the minimum value.
     /// </summary>
-    public T? MinValue { get; set; }
+    public T? MinValue
+    {
+        get => GetValue(MinValueProperty);
+        set => SetValue(MinValueProperty, value);
+    }
 
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is below minimum.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(T? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/NotNullValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/NotNullValidationRule.cs
@@ -1,15 +1,31 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
+
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Validation rule that requires a non-null value.
 /// </summary>
 /// <typeparam name="T">Type of value to validate.</typeparam>
-public class NotNullValidationRule<T> : IValidationRule<T>
+[SuppressMessage("AvaloniaProperty", "AVP1002:AvaloniaProperty objects should not be owned by a generic type")]
+public class NotNullValidationRule<T> : AvaloniaObject, IValidationRule<T>
 {
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<NotNullValidationRule<T>, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is required.");
+
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is required.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(T? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RangeValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RangeValidationRule.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
@@ -8,22 +10,53 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// Validation rule that checks whether a value is within a specified range.
 /// </summary>
 /// <typeparam name="T">Type of value to validate.</typeparam>
-public class RangeValidationRule<T> : IValidationRule<T>
+[SuppressMessage("AvaloniaProperty", "AVP1002:AvaloniaProperty objects should not be owned by a generic type")]
+public class RangeValidationRule<T> : AvaloniaObject, IValidationRule<T>
 {
+    /// <summary>
+    /// Identifies the <see cref="Minimum"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<T?> MinimumProperty =
+        AvaloniaProperty.Register<RangeValidationRule<T>, T?>(nameof(Minimum));
+
+    /// <summary>
+    /// Identifies the <see cref="Maximum"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<T?> MaximumProperty =
+        AvaloniaProperty.Register<RangeValidationRule<T>, T?>(nameof(Maximum));
+
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<RangeValidationRule<T>, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is out of range.");
+
     /// <summary>
     /// Gets or sets the minimum allowed value.
     /// </summary>
-    // ReSharper disable once UnusedAutoPropertyAccessor.Global
-    public T? Minimum { get; set; }
+    public T? Minimum
+    {
+        get => GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
+    }
 
     /// <summary>
     /// Gets or sets the maximum allowed value.
     /// </summary>
-    // ReSharper disable once UnusedAutoPropertyAccessor.Global
-    public T? Maximum { get; set; }
+    public T? Maximum
+    {
+        get => GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
+    }
 
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is out of range.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(T? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RegexValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RegexValidationRule.cs
@@ -1,21 +1,46 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Text.RegularExpressions;
+using Avalonia;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Validation rule that checks value against a regular expression pattern.
 /// </summary>
-public class RegexValidationRule : IValidationRule<string>
+public class RegexValidationRule : AvaloniaObject, IValidationRule<string>
 {
+    /// <summary>
+    /// Identifies the <see cref="Pattern"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string> PatternProperty =
+        AvaloniaProperty.Register<RegexValidationRule, string>(
+            nameof(Pattern),
+            defaultValue: string.Empty);
+
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<RegexValidationRule, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Invalid format.");
+
     /// <summary>
     /// Gets or sets the regex pattern.
     /// </summary>
-    public string Pattern { get; set; } = string.Empty;
+    public string Pattern
+    {
+        get => GetValue(PatternProperty);
+        set => SetValue(PatternProperty, value);
+    }
 
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Invalid format.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(string? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RequiredDateValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RequiredDateValidationRule.cs
@@ -1,16 +1,29 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using Avalonia;
 
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Validation rule that requires a non-null date value.
 /// </summary>
-public class RequiredDateValidationRule : IValidationRule<DateTimeOffset?>
+public class RequiredDateValidationRule : AvaloniaObject, IValidationRule<DateTimeOffset?>
 {
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<RequiredDateValidationRule, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Date is required.");
+
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Date is required.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(DateTimeOffset? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RequiredDecimalValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RequiredDecimalValidationRule.cs
@@ -1,14 +1,28 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia;
+
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Validation rule that requires a non-null decimal value.
 /// </summary>
-public class RequiredDecimalValidationRule : IValidationRule<decimal?>
+public class RequiredDecimalValidationRule : AvaloniaObject, IValidationRule<decimal?>
 {
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<RequiredDecimalValidationRule, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is required.");
+
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is required.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(decimal? value)

--- a/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RequiredTextValidationRule.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Validation/Rules/RequiredTextValidationRule.cs
@@ -1,14 +1,28 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia;
+
 namespace Avalonia.Xaml.Interactions.Custom;
 
 /// <summary>
 /// Validation rule that requires a non-empty string value.
 /// </summary>
-public class RequiredTextValidationRule : IValidationRule<string>
+public class RequiredTextValidationRule : AvaloniaObject, IValidationRule<string>
 {
+    /// <summary>
+    /// Identifies the <see cref="ErrorMessage"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<RequiredTextValidationRule, string?>(
+            nameof(ErrorMessage),
+            defaultValue: "Value is required.");
+
     /// <inheritdoc />
-    public string? ErrorMessage { get; set; } = "Value is required.";
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
 
     /// <inheritdoc />
     public bool Validate(string? value)

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/BindableValidationRule001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/BindableValidationRule001.axaml
@@ -1,0 +1,25 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.Custom"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Custom.BindableValidationRule001"
+        x:DataType="local:ValidationRuleBindingSource">
+  <Window.DataContext>
+    <local:ValidationRuleBindingSource Minimum="0"
+                                       Maximum="100"
+                                       ErrorMessage="Value must be within the current bounds." />
+  </Window.DataContext>
+
+  <Slider x:Name="TargetSlider"
+          Minimum="0"
+          Maximum="200"
+          Value="50">
+    <Interaction.Behaviors>
+      <SliderValidationBehavior>
+        <RangeValidationRule x:TypeArguments="x:Double"
+                             Minimum="{Binding Minimum}"
+                             Maximum="{Binding Maximum}"
+                             ErrorMessage="{Binding ErrorMessage}" />
+      </SliderValidationBehavior>
+    </Interaction.Behaviors>
+  </Slider>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/BindableValidationRule001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/BindableValidationRule001.axaml.cs
@@ -1,0 +1,41 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public partial class BindableValidationRule001 : Window
+{
+    public BindableValidationRule001()
+    {
+        InitializeComponent();
+    }
+}
+
+public class ValidationRuleBindingSource : AvaloniaObject
+{
+    public static readonly StyledProperty<double> MinimumProperty =
+        AvaloniaProperty.Register<ValidationRuleBindingSource, double>(nameof(Minimum));
+
+    public static readonly StyledProperty<double> MaximumProperty =
+        AvaloniaProperty.Register<ValidationRuleBindingSource, double>(nameof(Maximum));
+
+    public static readonly StyledProperty<string?> ErrorMessageProperty =
+        AvaloniaProperty.Register<ValidationRuleBindingSource, string?>(nameof(ErrorMessage));
+
+    public double Minimum
+    {
+        get => GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
+    }
+
+    public double Maximum
+    {
+        get => GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
+    }
+
+    public string? ErrorMessage
+    {
+        get => GetValue(ErrorMessageProperty);
+        set => SetValue(ErrorMessageProperty, value);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ValidationRuleTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ValidationRuleTests.cs
@@ -1,0 +1,123 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class ValidationRuleTests
+{
+    [AvaloniaFact]
+    public void BoundRangeChanges_RevalidateAssociatedProperty()
+    {
+        var window = new BindableValidationRule001();
+        var source = Assert.IsType<ValidationRuleBindingSource>(window.DataContext);
+        var behavior = Assert.IsType<SliderValidationBehavior>(
+            Assert.Single(Interaction.GetBehaviors(window.TargetSlider)));
+
+        window.Show();
+
+        Assert.True(behavior.IsValid);
+        Assert.Null(behavior.Error);
+
+        source.Maximum = 40;
+
+        Assert.False(behavior.IsValid);
+        Assert.Equal(source.ErrorMessage, behavior.Error);
+
+        source.ErrorMessage = "The configured maximum is too small.";
+
+        Assert.Equal(source.ErrorMessage, behavior.Error);
+    }
+
+    [AvaloniaFact]
+    public void RuleCollectionChanges_UpdateSubscriptionsAndValidation()
+    {
+        var window = new BindableValidationRule001();
+        var behavior = Assert.IsType<SliderValidationBehavior>(
+            Assert.Single(Interaction.GetBehaviors(window.TargetSlider)));
+
+        window.Show();
+
+        behavior.Rules.Clear();
+
+        Assert.True(behavior.IsValid);
+        Assert.Null(behavior.Error);
+
+        var rule = new MaxValueValidationRule<double>
+        {
+            MaxValue = 40,
+            ErrorMessage = "Maximum is 40."
+        };
+        behavior.Rules.Add(rule);
+
+        Assert.False(behavior.IsValid);
+        Assert.Equal(rule.ErrorMessage, behavior.Error);
+
+        rule.MaxValue = 100;
+
+        Assert.True(behavior.IsValid);
+        Assert.Null(behavior.Error);
+    }
+
+    [AvaloniaFact]
+    public void ValidationRules_ExposeConfigurationAsAvaloniaProperties()
+    {
+        var maxValueRule = new MaxValueValidationRule<int>();
+        Assert.Equal("Value is above maximum.", maxValueRule.ErrorMessage);
+        maxValueRule.SetValue(MaxValueValidationRule<int>.MaxValueProperty, 10);
+        maxValueRule.SetValue(MaxValueValidationRule<int>.ErrorMessageProperty, "max");
+        Assert.Equal(10, maxValueRule.MaxValue);
+        Assert.Equal("max", maxValueRule.ErrorMessage);
+
+        var minLengthRule = new MinLengthValidationRule();
+        Assert.Equal("Value is too short.", minLengthRule.ErrorMessage);
+        minLengthRule.SetValue(MinLengthValidationRule.LengthProperty, 3);
+        minLengthRule.SetValue(MinLengthValidationRule.ErrorMessageProperty, "length");
+        Assert.Equal(3, minLengthRule.Length);
+        Assert.Equal("length", minLengthRule.ErrorMessage);
+
+        var minValueRule = new MinValueValidationRule<int>();
+        Assert.Equal("Value is below minimum.", minValueRule.ErrorMessage);
+        minValueRule.SetValue(MinValueValidationRule<int>.MinValueProperty, 1);
+        minValueRule.SetValue(MinValueValidationRule<int>.ErrorMessageProperty, "min");
+        Assert.Equal(1, minValueRule.MinValue);
+        Assert.Equal("min", minValueRule.ErrorMessage);
+
+        var notNullRule = new NotNullValidationRule<string>();
+        Assert.Equal("Value is required.", notNullRule.ErrorMessage);
+        notNullRule.SetValue(NotNullValidationRule<string>.ErrorMessageProperty, "null");
+        Assert.Equal("null", notNullRule.ErrorMessage);
+
+        var rangeRule = new RangeValidationRule<int>();
+        Assert.Equal("Value is out of range.", rangeRule.ErrorMessage);
+        rangeRule.SetValue(RangeValidationRule<int>.MinimumProperty, 2);
+        rangeRule.SetValue(RangeValidationRule<int>.MaximumProperty, 8);
+        rangeRule.SetValue(RangeValidationRule<int>.ErrorMessageProperty, "range");
+        Assert.Equal(2, rangeRule.Minimum);
+        Assert.Equal(8, rangeRule.Maximum);
+        Assert.Equal("range", rangeRule.ErrorMessage);
+
+        var regexRule = new RegexValidationRule();
+        Assert.Equal("Invalid format.", regexRule.ErrorMessage);
+        regexRule.SetValue(RegexValidationRule.PatternProperty, "^[0-9]+$");
+        regexRule.SetValue(RegexValidationRule.ErrorMessageProperty, "regex");
+        Assert.Equal("^[0-9]+$", regexRule.Pattern);
+        Assert.Equal("regex", regexRule.ErrorMessage);
+
+        var requiredDateRule = new RequiredDateValidationRule();
+        Assert.Equal("Date is required.", requiredDateRule.ErrorMessage);
+        requiredDateRule.SetValue(RequiredDateValidationRule.ErrorMessageProperty, "date");
+        Assert.Equal("date", requiredDateRule.ErrorMessage);
+
+        var requiredDecimalRule = new RequiredDecimalValidationRule();
+        Assert.Equal("Value is required.", requiredDecimalRule.ErrorMessage);
+        requiredDecimalRule.SetValue(RequiredDecimalValidationRule.ErrorMessageProperty, "decimal");
+        Assert.Equal("decimal", requiredDecimalRule.ErrorMessage);
+
+        var requiredTextRule = new RequiredTextValidationRule();
+        Assert.Equal("Value is required.", requiredTextRule.ErrorMessage);
+        requiredTextRule.SetValue(RequiredTextValidationRule.ErrorMessageProperty, "text");
+        Assert.Equal("text", requiredTextRule.ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Summary

Makes every built-in validation rule an `AvaloniaObject` and exposes all rule configuration—including `ErrorMessage`—as documented `StyledProperty` values.

This enables compiled XAML such as:

```xml
<RangeValidationRule x:TypeArguments="x:Double"
                     Minimum="{Binding Minimum}"
                     Maximum="{Binding Maximum}"
                     ErrorMessage="{Binding RangeErrorMessage}" />
```

## Root cause

The validation rules were plain CLR objects with auto-properties. Avalonia bindings can only target Avalonia properties, so XAML could assign literals but could not bind rule limits, patterns, lengths, or messages.

There was a second lifecycle issue once those values became dynamic: `PropertyValidationBehavior` only revalidated when the associated control property changed. A bound rule property could therefore update successfully while `IsValid`, `Error`, and `DataValidationErrors` remained stale until the user edited the control again.

## Changes

- Derive all nine built-in validation rules from `AvaloniaObject`.
- Register styled properties for:
  - minimum/maximum/range values;
  - minimum length;
  - regex pattern;
  - every rule's error message.
- Preserve all existing default error messages and validation semantics.
- Have `PropertyValidationBehavior` observe:
  - Avalonia property changes on rules;
  - additions, removals, replacements, and resets in the rules collection.
- Revalidate the current associated value immediately after either kind of change.
- Dispose rule and collection subscriptions when the behavior detaches.
- Update the slider sample to demonstrate compiled bindings for dynamic range limits.
- Document bindable rule configuration and immediate revalidation.

## Tests

Added headless coverage that:

- loads the exact compiled-binding scenario from XAML;
- changes a bound maximum and verifies the current slider value becomes invalid without another slider edit;
- changes a bound error message and verifies the surfaced error updates immediately;
- verifies collection changes update subscriptions and validation;
- verifies every built-in rule exposes its configuration through Avalonia properties;
- verifies the pre-existing default error messages are unchanged.

Validation performed:

- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 92 passed, 2 existing drag tests skipped, 0 failed
- `dotnet build samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj --no-restore`
  - succeeded with 0 warnings and 0 errors

Closes #333