### PR TITLE
Allow DataTriggerBehavior to compare null values

### DIFF
--- a/docfx/articles/interactions/data-trigger-behavior.md
+++ b/docfx/articles/interactions/data-trigger-behavior.md
@@ -23,6 +23,16 @@
 </TextBlock>
 ```
 
+For equality comparisons, `null` is a valid bound value. An omitted `Binding` is not treated as a bound `null` value.
+
+```xml
+<DataTriggerBehavior Binding="{Binding SelectedItem}"
+                     ComparisonCondition="Equal"
+                     Value="{x:Null}">
+    <ChangePropertyAction PropertyName="Text" Value="No item selected" />
+</DataTriggerBehavior>
+```
+
 ## DataTrigger
 
 `DataTrigger` is a deprecated class that functions similarly to `DataTriggerBehavior` but inherits from `Trigger`. It is recommended to use `DataTriggerBehavior` instead.

--- a/docfx/articles/interactions/data-trigger-behavior.md
+++ b/docfx/articles/interactions/data-trigger-behavior.md
@@ -23,7 +23,7 @@
 </TextBlock>
 ```
 
-For equality comparisons, `null` is a valid bound value. An omitted `Binding` is not treated as a bound `null` value.
+For `Equal` and `NotEqual` comparisons, `null` is a valid bound value. Relational comparisons with `null` remain inactive, and an omitted `Binding` is not treated as a bound `null` value.
 
 ```xml
 <DataTriggerBehavior Binding="{Binding SelectedItem}"

--- a/src/Xaml.Behaviors.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions/Core/DataTriggerBehavior.cs
@@ -117,6 +117,13 @@ public class DataTriggerBehavior : StyledElementTrigger
             return;
         }
 
+        if (binding is null &&
+            ComparisonCondition is not ComparisonConditionType.Equal and
+            not ComparisonConditionType.NotEqual)
+        {
+            return;
+        }
+
         // Some value has changed--either the binding value, reference value, or the comparison condition. Re-evaluate the equation.
         if (ComparisonConditionTypeHelper.Compare(binding, ComparisonCondition, Value))
         {

--- a/src/Xaml.Behaviors.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions/Core/DataTriggerBehavior.cs
@@ -111,15 +111,16 @@ public class DataTriggerBehavior : StyledElementTrigger
             return;
         }
 
-        // NOTE: In UWP version binding null check is not present but Avalonia throws exception as Bindings are null when first initialized.
         var binding = Binding;
-        if (binding is not null)
+        if (!IsSet(BindingProperty) || Equals(binding, AvaloniaProperty.UnsetValue))
         {
-            // Some value has changed--either the binding value, reference value, or the comparison condition. Re-evaluate the equation.
-            if (ComparisonConditionTypeHelper.Compare(Binding, ComparisonCondition, Value))
-            {
-                Interaction.ExecuteActions(AssociatedObject, Actions, parameter);
-            }
+            return;
+        }
+
+        // Some value has changed--either the binding value, reference value, or the comparison condition. Re-evaluate the equation.
+        if (ComparisonConditionTypeHelper.Compare(binding, ComparisonCondition, Value))
+        {
+            Interaction.ExecuteActions(AssociatedObject, Actions, parameter);
         }
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior004.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior004.axaml
@@ -26,5 +26,15 @@
         </DataTriggerBehavior>
       </Interaction.Behaviors>
     </TextBlock>
+
+    <TextBlock x:Name="RelationalTextBlock" Text="Unchanged">
+      <Interaction.Behaviors>
+        <DataTriggerBehavior Binding="{Binding TestProperty}"
+                             ComparisonCondition="GreaterThan"
+                             Value="z">
+          <ChangePropertyAction PropertyName="Text" Value="Incorrectly executed" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </TextBlock>
   </StackPanel>
 </Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior004.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior004.axaml
@@ -1,0 +1,30 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.Core"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.DataTriggerBehavior004"
+        x:DataType="local:DataTriggerBehavior004BindingSource"
+        Title="DataTriggerBehavior004">
+  <Window.DataContext>
+    <local:DataTriggerBehavior004BindingSource TestProperty="Initial value" />
+  </Window.DataContext>
+
+  <StackPanel>
+    <TextBlock x:Name="TargetTextBlock" Text="Not empty">
+      <Interaction.Behaviors>
+        <DataTriggerBehavior Binding="{Binding TestProperty}"
+                             ComparisonCondition="Equal"
+                             Value="{x:Null}">
+          <ChangePropertyAction PropertyName="Text" Value="Empty" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </TextBlock>
+
+    <TextBlock x:Name="UnconfiguredTextBlock" Text="Unchanged">
+      <Interaction.Behaviors>
+        <DataTriggerBehavior ComparisonCondition="Equal" Value="{x:Null}">
+          <ChangePropertyAction PropertyName="Text" Value="Incorrectly executed" />
+        </DataTriggerBehavior>
+      </Interaction.Behaviors>
+    </TextBlock>
+  </StackPanel>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior004.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehavior004.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class DataTriggerBehavior004 : Window
+{
+    public DataTriggerBehavior004()
+    {
+        InitializeComponent();
+    }
+}
+
+public class DataTriggerBehavior004BindingSource : AvaloniaObject
+{
+    public static readonly StyledProperty<string?> TestPropertyProperty =
+        AvaloniaProperty.Register<DataTriggerBehavior004BindingSource, string?>(nameof(TestProperty));
+
+    public string? TestProperty
+    {
+        get => GetValue(TestPropertyProperty);
+        set => SetValue(TestPropertyProperty, value);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
@@ -83,12 +83,14 @@ public class DataTriggerBehaviorTests
 
         Assert.Equal("Not empty", window.TargetTextBlock.Text);
         Assert.Equal("Unchanged", window.UnconfiguredTextBlock.Text);
+        Assert.Equal("Unchanged", window.RelationalTextBlock.Text);
 
         source.TestProperty = null;
         Dispatcher.UIThread.RunJobs();
 
         Assert.Equal("Empty", window.TargetTextBlock.Text);
         Assert.Equal("Unchanged", window.UnconfiguredTextBlock.Text);
+        Assert.Equal("Unchanged", window.RelationalTextBlock.Text);
     }
 
     [AvaloniaFact]
@@ -103,5 +105,6 @@ public class DataTriggerBehaviorTests
 
         Assert.Equal("Empty", window.TargetTextBlock.Text);
         Assert.Equal("Unchanged", window.UnconfiguredTextBlock.Text);
+        Assert.Equal("Unchanged", window.RelationalTextBlock.Text);
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Threading;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.Core;
@@ -69,5 +70,38 @@ public class DataTriggerBehaviorTests
 
         Assert.Equal("50 or more", window.TargetTextBlock.Text);
         Assert.Equal(50d, window.TargetSlider.Value);
+    }
+
+    [AvaloniaFact]
+    public void DataTriggerBehavior_ExecutesWhenBoundValueBecomesNull()
+    {
+        var window = new DataTriggerBehavior004();
+        var source = Assert.IsType<DataTriggerBehavior004BindingSource>(window.DataContext);
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Not empty", window.TargetTextBlock.Text);
+        Assert.Equal("Unchanged", window.UnconfiguredTextBlock.Text);
+
+        source.TestProperty = null;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Empty", window.TargetTextBlock.Text);
+        Assert.Equal("Unchanged", window.UnconfiguredTextBlock.Text);
+    }
+
+    [AvaloniaFact]
+    public void DataTriggerBehavior_ExecutesWhenInitialBoundValueIsNull()
+    {
+        var window = new DataTriggerBehavior004();
+        var source = Assert.IsType<DataTriggerBehavior004BindingSource>(window.DataContext);
+        source.TestProperty = null;
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Empty", window.TargetTextBlock.Text);
+        Assert.Equal("Unchanged", window.UnconfiguredTextBlock.Text);
     }
 }


### PR DESCRIPTION
## Summary

Allows `DataTriggerBehavior` to evaluate `null` as a legitimate bound value, including the common `Equal` + `{x:Null}` scenario from the issue.

## Root cause

`DataTriggerBehavior.Execute` returned early whenever the current `Binding` value was `null`. That check conflated two different states:

1. the `Binding` property was never configured; and
2. a configured binding successfully produced `null`.

`ComparisonConditionTypeHelper` already supports `null` equality correctly, but the guard prevented the comparison from ever being reached.

## Changes

- Replace the value-based null guard with an Avalonia-property readiness check.
- Skip execution only when:
  - `BindingProperty` has not been set; or
  - its value is `AvaloniaProperty.UnsetValue`.
- Pass configured `null` values through to the existing comparison helper.
- Document null equality behavior and clarify that an omitted binding is not treated as bound null.

This preserves the initialization safety intended by the old guard while separating “not configured” from “configured and null.”

## Tests

Added a compiled-XAML headless fixture matching the reported usage and coverage that verifies:

- a non-null initial value does not execute the null action;
- changing the bound property to `null` executes the action;
- an initially null bound value executes the action;
- a trigger with no `Binding` does not execute merely because `Value` is `{x:Null}`.

Validation:

- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 91 passed, 2 existing drag tests skipped, 0 failed

Closes #335