### PR TITLE
Preserve behavior visual lifecycle on virtualized containers

### DIFF
--- a/docfx/articles/drag-and-drop/context-drag-drop.md
+++ b/docfx/articles/drag-and-drop/context-drag-drop.md
@@ -91,10 +91,12 @@ public class ListBoxDropHandler : DropHandlerBase
         <ListBox.Styles>
             <Style Selector="ListBoxItem">
                 <Setter Property="(Interaction.Behaviors)">
-                    <BehaviorCollection>
-                        <!-- Make items draggable -->
-                        <ContextDragBehavior />
-                    </BehaviorCollection>
+                    <BehaviorCollectionTemplate>
+                        <BehaviorCollection>
+                            <!-- Make items draggable -->
+                            <ContextDragBehavior />
+                        </BehaviorCollection>
+                    </BehaviorCollectionTemplate>
                 </Setter>
             </Style>
         </ListBox.Styles>
@@ -106,3 +108,5 @@ public class ListBoxDropHandler : DropHandlerBase
     </ListBox>
 </UserControl>
 ```
+
+`BehaviorCollectionTemplate` creates an independent behavior collection for each item container. It is safe to use with virtualized item controls: when Avalonia replaces a template-created collection on an attached recycled container, the old collection receives its visual-detach lifecycle and the new collection receives its visual-attach lifecycle.

--- a/src/Xaml.Behaviors.Interactivity/Interaction.cs
+++ b/src/Xaml.Behaviors.Interactivity/Interaction.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Reactive;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -106,8 +107,15 @@ public class Interaction
             return;
         }
 
+        var isAttachedToVisualTree = e.Sender is Visual visual && visual.IsAttachedToVisualTree();
+
         if (oldCollection is { AssociatedObject: not null })
         {
+            if (isAttachedToVisualTree)
+            {
+                oldCollection.DetachedFromVisualTree();
+            }
+
             oldCollection.Detach();
         }
 
@@ -115,6 +123,11 @@ public class Interaction
         {
             newCollection.Attach(e.Sender);
             SetVisualTreeEventHandlersFromChangedEvent(e.Sender);
+
+            if (isAttachedToVisualTree)
+            {
+                newCollection.AttachedToVisualTree();
+            }
         }
     }
 

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/ContextDragBehaviorTests.cs
@@ -1,8 +1,11 @@
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
@@ -28,5 +31,49 @@ public class ContextDragBehaviorTests
 
         Assert.False(window.TestBehavior.BeforeCalled);
         Assert.False(window.TestBehavior.AfterCalled);
+    }
+
+    [AvaloniaFact]
+    public void VirtualizedListBoxItem_ReplacementTransfersContextDragLifecycle()
+    {
+        var window = new VirtualizedContextDragWindow();
+        window.TargetListBox.ItemsSource = Enumerable.Range(0, 100).ToList();
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.TargetListBox.ScrollIntoView(50);
+        Dispatcher.UIThread.RunJobs();
+
+        var container = Assert.IsType<ListBoxItem>(window.TargetListBox.ContainerFromIndex(50));
+        var oldBehaviors = Assert.IsType<BehaviorCollection>(
+            container.GetValue(Interaction.BehaviorsProperty));
+        var oldBehavior = Assert.IsType<TestContextDragBehavior>(Assert.Single(oldBehaviors));
+        var behavior = new TestContextDragBehavior();
+        var behaviors = new BehaviorCollection { behavior };
+
+        Interaction.SetBehaviors(container, behaviors);
+
+        var handled = false;
+
+        container.AddHandler(
+            InputElement.PointerPressedEvent,
+            (_, e) => handled = e.Handled,
+            Avalonia.Interactivity.RoutingStrategies.Bubble,
+            handledEventsToo: true);
+
+        window.TargetListBox.SelectedIndex = 50;
+        window.MouseDown(container, new Point(5, 5), MouseButton.Left);
+        window.MouseUp(container, new Point(5, 5), MouseButton.Left);
+
+        Assert.Null(oldBehaviors.AssociatedObject);
+        Assert.Null(oldBehavior.AssociatedObject);
+        Assert.Equal(1, oldBehavior.AttachedToVisualTreeCount);
+        Assert.Equal(1, oldBehavior.DetachedFromVisualTreeCount);
+        Assert.Same(container, behavior.AssociatedObject);
+        Assert.Same(container, behaviors.AssociatedObject);
+        Assert.Equal(1, behavior.AttachedToVisualTreeCount);
+        Assert.Equal(0, behavior.DetachedFromVisualTreeCount);
+        Assert.True(handled);
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/TestContextDragBehavior.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/TestContextDragBehavior.cs
@@ -7,6 +7,20 @@ internal class TestContextDragBehavior : ContextDragBehaviorBase
 {
     public bool BeforeCalled { get; private set; }
     public bool AfterCalled { get; private set; }
+    public int AttachedToVisualTreeCount { get; private set; }
+    public int DetachedFromVisualTreeCount { get; private set; }
+
+    protected override void OnAttachedToVisualTree()
+    {
+        base.OnAttachedToVisualTree();
+        AttachedToVisualTreeCount++;
+    }
+
+    protected override void OnDetachedFromVisualTree()
+    {
+        base.OnDetachedFromVisualTree();
+        DetachedFromVisualTreeCount++;
+    }
 
     protected override void OnBeforeDragDrop(object? sender, PointerEventArgs e, object? context)
     {

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/VirtualizedContextDragWindow.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/VirtualizedContextDragWindow.axaml
@@ -1,0 +1,20 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.DragAndDrop"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.DragAndDrop.VirtualizedContextDragWindow"
+        Width="400"
+        Height="210">
+  <ListBox x:Name="TargetListBox">
+    <ListBox.Styles>
+      <Style Selector="ListBoxItem">
+        <Setter Property="(Interaction.Behaviors)">
+          <BehaviorCollectionTemplate>
+            <BehaviorCollection>
+              <local:TestContextDragBehavior />
+            </BehaviorCollection>
+          </BehaviorCollectionTemplate>
+        </Setter>
+      </Style>
+    </ListBox.Styles>
+  </ListBox>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/VirtualizedContextDragWindow.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/DragAndDrop/VirtualizedContextDragWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.DragAndDrop;
+
+public partial class VirtualizedContextDragWindow : Window
+{
+    public VirtualizedContextDragWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -98,6 +98,34 @@ public class InteractionTest
     }
 
     [AvaloniaFact]
+    public void SetBehaviors_OnAttachedVisual_TransfersVisualTreeLifecycle()
+    {
+        var oldBehavior = new TestBehavior();
+        var oldCollection = new BehaviorCollection { oldBehavior };
+        var button = new Button();
+        var window = new Window { Content = button };
+        Interaction.SetBehaviors(button, oldCollection);
+
+        window.Show();
+
+        Assert.Equal(1, oldBehavior.VisualAttachCalled);
+        Assert.Equal(0, oldBehavior.VisualDetachCalled);
+
+        var newBehavior = new TestBehavior();
+        var newCollection = new BehaviorCollection { newBehavior };
+
+        Interaction.SetBehaviors(button, newCollection);
+
+        Assert.Equal(1, oldBehavior.VisualDetachCalled);
+        Assert.Equal(1, oldBehavior.DetachingCalled);
+        Assert.Null(oldBehavior.AssociatedObject);
+        Assert.Equal(1, newBehavior.AttachedCalled);
+        Assert.Equal(1, newBehavior.VisualAttachCalled);
+        Assert.Equal(0, newBehavior.VisualDetachCalled);
+        Assert.Same(button, newBehavior.AssociatedObject);
+    }
+
+    [AvaloniaFact]
     public void ExecuteActions_NullParameters_ReturnsEmptyEnumerable()
     {
         // Mostly just want to test that this doesn't throw any exceptions.


### PR DESCRIPTION
## Summary

Keeps template-created behaviors operational when Avalonia replaces a `BehaviorCollection` on a control that is already attached to the visual tree. This fixes `ContextDragBehavior` on virtualized `ListBoxItem` containers after scrolling/recycling.

## Reproduction analysis

The attached reproduction uses a `BehaviorCollectionTemplate` in a `ListBoxItem` style with Avalonia 11.3.13. Initially realized containers work, but newly visible items after scrolling do not start a drag.

The failure is caused by collection replacement on an already-attached item container:

1. The old collection is detached through `Interaction.BehaviorsProperty`.
2. `BehaviorCollection.Detach()` calls each behavior's normal detach hook, but it does not send `OnDetachedFromVisualTree`.
3. The new collection is attached, but no future `AttachedToVisualTree` event is guaranteed for a recycled container that remains in the tree.
4. `ContextDragBehaviorBase` installs/removes pointer handlers in those visual-tree hooks.
5. The old handler can remain installed while the new drag behavior never installs its handlers.

Avalonia 12 currently realizes fresh containers in the equivalent headless scenario, so scrolling alone does not force that older recycling path. The lifecycle defect remains reproducible on current master by replacing the template-created collection on an attached, newly visible item—the exact state transition performed by the older virtualizer.

## Changes

- Detect whether the `Interaction.Behaviors` owner is currently attached to a visual tree.
- Before detaching a replaced collection, send its visual-detach lifecycle callback.
- After attaching the replacement collection and wiring owner events, send its visual-attach lifecycle callback.
- Preserve the existing behavior for collections assigned before visual attachment; they still receive the normal future tree event.
- Correct the drag/drop documentation to use `BehaviorCollectionTemplate` inside a style instead of sharing a stateful `BehaviorCollection`.
- Document virtualized-container lifecycle behavior.

## Tests

### Core lifecycle regression

A new interactivity test shows a window, replaces a button's behavior collection while the button remains attached, and verifies:

- the old behavior receives one visual detach before normal detachment;
- the old behavior releases its associated object;
- the new behavior receives normal attach plus one visual attach;
- the new behavior remains associated with the visible control.

### Virtualized ContextDrag regression

A headless test mirrors the issue's 100-item virtualized `ListBox` and style-based `BehaviorCollectionTemplate`, scrolls to a newly visible item, replaces its template collection while attached, and verifies:

- old `ContextDragBehaviorBase` visual lifecycle is balanced;
- the replacement behavior is visually attached;
- a pointer press on the selected item is handled by the replacement drag behavior.

Validation:

- `dotnet test tests/Xaml.Behaviors.Interactivity.UnitTests/Xaml.Behaviors.Interactivity.UnitTests.csproj --no-restore`
  - 94 passed, 0 failed
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 90 passed, 2 existing drag tests skipped, 0 failed

Closes #336