### PR TITLE
Keep routed window-close triggers active through closure

### DIFF
--- a/docfx/articles/interactions-custom/core/routed-event-trigger.md
+++ b/docfx/articles/interactions-custom/core/routed-event-trigger.md
@@ -5,3 +5,15 @@ The `RoutedEventTrigger` (and its variants `RoutedEventTriggerBase`, `RoutedEven
 ### Properties
 - `RoutedEvent`: The routed event to listen for (e.g., `Button.ClickEvent`).
 - `RoutingStrategies`: The routing strategy to use (Tunnel, Bubble, Direct).
+
+When a `RoutedEventTriggerBehavior` is attached directly to a `TopLevel`, its routed-event subscription and action bindings remain active through the top-level's closed event. They are released when the behavior is actually detached. Other controls continue to subscribe only while attached to the visual tree.
+
+```xml
+<Window>
+  <Interaction.Behaviors>
+    <RoutedEventTriggerBehavior RoutedEvent="{x:Static Window.WindowClosedEvent}">
+      <InvokeCommandAction Command="{Binding WindowClosedCommand}" />
+    </RoutedEventTriggerBehavior>
+  </Interaction.Behaviors>
+</Window>
+```

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/RoutedEventTriggerBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/RoutedEventTriggerBehavior.cs
@@ -108,11 +108,28 @@ public class RoutedEventTriggerBehavior : StyledElementTrigger<Interactive>
     protected override void OnDetachedFromVisualTree()
     {
         _isAttached = false;
+
+        if (AssociatedObject is not TopLevel || ComputeResolvedSourceInteractive() is not TopLevel)
+        {
+            RemoveHandler();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        _isAttached = false;
         RemoveHandler();
+        base.OnDetaching();
     }
 
     private void AddHandler()
     {
+        if (_isInitialized)
+        {
+            return;
+        }
+
         var interactive = ComputeResolvedSourceInteractive();
         if (interactive is not null && RoutedEvent is not null)
         {
@@ -139,6 +156,11 @@ public class RoutedEventTriggerBehavior : StyledElementTrigger<Interactive>
     private void Handler(object? sender, RoutedEventArgs e)
     {
         Execute(e);
+
+        if (!_isAttached)
+        {
+            RemoveHandler();
+        }
     }
 
     private void Execute(object? parameter)

--- a/src/Xaml.Behaviors.Interactivity/Interaction.cs
+++ b/src/Xaml.Behaviors.Interactivity/Interaction.cs
@@ -285,15 +285,7 @@ public class Interaction
 
         if (d is TopLevel topLevel)
         {
-            Dispatcher.UIThread.Post(() =>
-            {
-                if (!topLevel.IsAttachedToVisualTree() &&
-                    ReferenceEquals(d.GetValue(BehaviorsProperty), behaviors) &&
-                    behaviors.AssociatedObject is not null)
-                {
-                    behaviors.Detach();
-                }
-            });
+            ScheduleTopLevelBehaviorDetach(topLevel, behaviors);
         }
         else
         {
@@ -318,7 +310,28 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DetachedFromVisualTree();
+        var behaviors = GetBehaviors(d);
+        behaviors.DetachedFromVisualTree();
+
+        if (d is TopLevel topLevel)
+        {
+            ScheduleTopLevelBehaviorDetach(topLevel, behaviors);
+        }
+    }
+
+    private static void ScheduleTopLevelBehaviorDetach(
+        TopLevel topLevel,
+        BehaviorCollection behaviors)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!topLevel.IsAttachedToVisualTree() &&
+                ReferenceEquals(topLevel.GetValue(BehaviorsProperty), behaviors) &&
+                behaviors.AssociatedObject is not null)
+            {
+                behaviors.Detach();
+            }
+        });
     }
 
     // AttachedToLogicalTree / DetachedFromLogicalTree

--- a/src/Xaml.Behaviors.Interactivity/Interaction.cs
+++ b/src/Xaml.Behaviors.Interactivity/Interaction.cs
@@ -6,6 +6,8 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Reactive;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -278,8 +280,25 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DetachedFromVisualTree();
-        GetBehaviors(d).Detach();
+        var behaviors = GetBehaviors(d);
+        behaviors.DetachedFromVisualTree();
+
+        if (d is TopLevel topLevel)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (!topLevel.IsAttachedToVisualTree() &&
+                    ReferenceEquals(d.GetValue(BehaviorsProperty), behaviors) &&
+                    behaviors.AssociatedObject is not null)
+                {
+                    behaviors.Detach();
+                }
+            });
+        }
+        else
+        {
+            behaviors.Detach();
+        }
     }
  
     private static void Visual_AttachedToVisualTree_FromChangedEvent(object? sender, VisualTreeAttachmentEventArgs e)

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -118,7 +118,10 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.DetachedFromVisualTreeEventHandler()
     {
-        DetachBehaviorFromLogicalTree();
+        if (AssociatedObject is not TopLevel)
+        {
+            DetachBehaviorFromLogicalTree();
+        }
 
         OnDetachedFromVisualTree();
     }
@@ -132,7 +135,10 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.DetachedFromLogicalTreeEventHandler()
     {
-        DetachBehaviorFromLogicalTree();
+        if (AssociatedObject is not TopLevel)
+        {
+            DetachBehaviorFromLogicalTree();
+        }
 
         OnDetachedFromLogicalTree();
     }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/RoutedEventTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/RoutedEventTriggerBehaviorTests.cs
@@ -1,0 +1,73 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class RoutedEventTriggerBehaviorTests
+{
+    [AvaloniaFact]
+    public void WindowClosedEvent_ExecutesBoundCommand()
+    {
+        var window = new WindowClosedRoutedEventWindow();
+        var source = Assert.IsType<WindowClosedBindingSource>(window.DataContext);
+        var behavior = Assert.IsType<RoutedEventTriggerBehavior>(
+            Assert.Single(Interaction.GetBehaviors(window)));
+        var action = new CountingAction();
+        behavior.Actions!.Add(action);
+
+        window.Show();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1, action.ExecutionCount);
+        Assert.Equal(1, source.CloseCommand.ExecutionCount);
+        Assert.Null(behavior.AssociatedObject);
+
+        window.RaiseEvent(new RoutedEventArgs(Window.WindowClosedEvent));
+
+        Assert.Equal(1, action.ExecutionCount);
+        Assert.Equal(1, source.CloseCommand.ExecutionCount);
+    }
+
+    [AvaloniaFact]
+    public void ControlRoutedEvent_UnsubscribesWhenControlLeavesVisualTree()
+    {
+        var button = new Button();
+        var panel = new Panel { Children = { button } };
+        var window = new Window { Content = panel };
+        var behavior = new RoutedEventTriggerBehavior
+        {
+            RoutedEvent = Button.ClickEvent
+        };
+        var action = new CountingAction();
+        behavior.Actions!.Add(action);
+        Interaction.GetBehaviors(button).Add(behavior);
+
+        window.Show();
+        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, action.ExecutionCount);
+
+        panel.Children.Remove(button);
+        Dispatcher.UIThread.RunJobs();
+        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, action.ExecutionCount);
+    }
+
+    private sealed class CountingAction : Avalonia.Xaml.Interactivity.Action
+    {
+        public int ExecutionCount { get; private set; }
+
+        public override object? Execute(object? sender, object? parameter)
+        {
+            ExecutionCount++;
+            return null;
+        }
+    }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/WindowClosedRoutedEventWindow.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/WindowClosedRoutedEventWindow.axaml
@@ -1,0 +1,15 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.Custom"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Custom.WindowClosedRoutedEventWindow"
+        x:DataType="local:WindowClosedBindingSource">
+  <Window.DataContext>
+    <local:WindowClosedBindingSource />
+  </Window.DataContext>
+
+  <Interaction.Behaviors>
+    <RoutedEventTriggerBehavior RoutedEvent="{x:Static Window.WindowClosedEvent}">
+      <InvokeCommandAction Command="{Binding CloseCommand}" />
+    </RoutedEventTriggerBehavior>
+  </Interaction.Behaviors>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/WindowClosedRoutedEventWindow.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/WindowClosedRoutedEventWindow.axaml.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Windows.Input;
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public partial class WindowClosedRoutedEventWindow : Window
+{
+    public WindowClosedRoutedEventWindow()
+    {
+        InitializeComponent();
+    }
+}
+
+public class WindowClosedBindingSource
+{
+    public WindowClosedBindingSource()
+    {
+        CloseCommand = new CountingCommand();
+    }
+
+    public CountingCommand CloseCommand { get; }
+}
+
+public class CountingCommand : ICommand
+{
+    public int ExecutionCount { get; private set; }
+
+    public event EventHandler? CanExecuteChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public bool CanExecute(object? parameter) => true;
+
+    public void Execute(object? parameter)
+    {
+        ExecutionCount++;
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactivity.UnitTests;
@@ -95,6 +96,27 @@ public class InteractionTest
             Assert.Equal(1, behavior.DetachCount); // "Setting BehaviorCollection to null should not call Detach on already Detached Behaviors."
             Assert.Null(behavior.AssociatedObject); // "AssociatedObject should be null after Detach."
         }
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviors_TopLevelClose_DefersThenDetachesCollection()
+    {
+        var behavior = new StubBehavior();
+        var behaviors = new BehaviorCollection { behavior };
+        var window = new Window();
+        Interaction.SetBehaviors(window, behaviors);
+
+        window.Show();
+        window.Close();
+
+        Assert.Same(window, behaviors.AssociatedObject);
+        Assert.Same(window, behavior.AssociatedObject);
+
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Null(behaviors.AssociatedObject);
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(1, behavior.DetachCount);
     }
 
     [AvaloniaFact]

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactivity.UnitTests;
@@ -30,6 +31,29 @@ public class StyledElementBehaviorTests
         Assert.Null(behavior.TemplatedParent);
 
         window.Close();
+    }
+
+    [AvaloniaFact]
+    public void TopLevelClose_PreservesLogicalParentUntilDeferredDetach()
+    {
+        var behavior = new TestStyledElementBehavior();
+        var window = new Window();
+        Interaction.GetBehaviors(window).Add(behavior);
+
+        window.Show();
+
+        Assert.Same(window, behavior.AssociatedObject);
+        Assert.Same(window, behavior.Parent);
+
+        window.Close();
+
+        Assert.Same(window, behavior.AssociatedObject);
+        Assert.Same(window, behavior.Parent);
+
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Null(behavior.Parent);
     }
 
     private sealed class TestStyledElementBehavior : StyledElementBehavior;


### PR DESCRIPTION
## Summary

Allows a `RoutedEventTriggerBehavior` attached directly to a window to receive `Window.WindowClosedEvent` and execute actions whose bindings come from the window data context.

## Root cause

Window shutdown crosses three distinct lifecycle points:

1. the window leaves the visual/logical tree;
2. `WindowClosedEvent` is raised;
3. behavior resources can be released.

The previous implementation treated step 1 as the end of the behavior lifetime:

- `RoutedEventTriggerBehavior.OnDetachedFromVisualTree` removed the routed handler;
- getter-created behavior collections detached immediately;
- `StyledElementBehavior` removed the behavior/action logical parent, clearing the bound `InvokeCommandAction.Command`.

As a result, simply retaining the routed handler was not enough: the event could be observed, but the command binding had already been torn down.

## Changes

- For a trigger attached directly to a `TopLevel` whose resolved event source is also a `TopLevel`:
  - retain the routed handler across visual detachment;
  - execute a routed event that arrives during that closing interval;
  - remove the handler after that post-detach event or on actual behavior detachment.
- Keep ordinary control triggers tied to their existing visual-tree lifetime.
- Preserve a top-level behavior's logical parent and action bindings through the closing event.
- Defer getter-created top-level collection detachment by one dispatcher turn:
  - this lets the synchronous closed event complete first;
  - the collection is then detached if the same top-level/collection has not reattached or been replaced.
- Document the supported window-close pattern.

## Tests

### Exact issue regression

A compiled-XAML headless window uses:

```xml
<RoutedEventTriggerBehavior RoutedEvent="{x:Static Window.WindowClosedEvent}">
  <InvokeCommandAction Command="{Binding CloseCommand}" />
</RoutedEventTriggerBehavior>
```

The test verifies:

- the routed action runs exactly once;
- the compiled bound command runs exactly once;
- the behavior is detached after the closing event;
- raising the event again cannot execute either action.

### Lifecycle safeguards

Additional coverage verifies:

- an ordinary control trigger unsubscribes when its control leaves the visual tree;
- a top-level styled behavior retains its logical parent during the closing interval;
- deferred detachment subsequently clears both the associated object and logical parent.

Validation:

- `dotnet test tests/Xaml.Behaviors.Interactivity.UnitTests/Xaml.Behaviors.Interactivity.UnitTests.csproj --no-restore`
  - 94 passed, 0 failed
- `dotnet test tests/Xaml.Behaviors.Interactions.UnitTests/Xaml.Behaviors.Interactions.UnitTests.csproj --no-restore`
  - 91 passed, 2 existing drag tests skipped, 0 failed

Closes #337