### PR TITLE
Preserve styled behaviors across virtualized item recycling

### DIFF
--- a/docfx/articles/draggable/list-reorder-drag-behavior.md
+++ b/docfx/articles/draggable/list-reorder-drag-behavior.md
@@ -41,3 +41,5 @@ Attach the behavior to individual items of the `ItemsControl`.
 ## ItemDragBehavior
 
 `ItemDragBehavior` is the base class for `ListReorderDragBehavior`. It provides the fundamental logic for tracking drag operations within an `ItemsControl` but does not implement the reordering logic itself. Use `ListReorderDragBehavior` for standard reordering scenarios.
+
+The style-based pattern above supports virtualized item panels. Recycled containers receive a fresh template-created behavior collection, so an item can be dragged again after it moves or after its containing view leaves and re-enters the visual tree.

--- a/src/Xaml.Behaviors.Interactivity/Interaction.cs
+++ b/src/Xaml.Behaviors.Interactivity/Interaction.cs
@@ -49,6 +49,11 @@ public class Interaction
         return behaviorCollection;
     }
 
+    private static BehaviorCollection? GetExistingBehaviors(AvaloniaObject obj)
+    {
+        return obj.GetValue(BehaviorsProperty);
+    }
+
     /// <summary>
     /// Sets the <see cref="BehaviorCollection"/> associated with a specified object.
     /// </summary>
@@ -267,8 +272,9 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Attach(d);
-        GetBehaviors(d).AttachedToVisualTree();
+        var behaviors = GetExistingBehaviors(d);
+        behaviors?.Attach(d);
+        behaviors?.AttachedToVisualTree();
     }
 
     private static void Visual_DetachedFromVisualTree_FromGetter(object? sender, VisualTreeAttachmentEventArgs e)
@@ -278,8 +284,9 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DetachedFromVisualTree();
-        GetBehaviors(d).Detach();
+        var behaviors = GetExistingBehaviors(d);
+        behaviors?.DetachedFromVisualTree();
+        behaviors?.Detach();
     }
  
     private static void Visual_AttachedToVisualTree_FromChangedEvent(object? sender, VisualTreeAttachmentEventArgs e)
@@ -289,7 +296,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).AttachedToVisualTree();
+        GetExistingBehaviors(d)?.AttachedToVisualTree();
     }
 
     private static void Visual_DetachedFromVisualTree_FromChangedEvent(object? sender, VisualTreeAttachmentEventArgs e)
@@ -299,7 +306,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DetachedFromVisualTree();
+        GetExistingBehaviors(d)?.DetachedFromVisualTree();
     }
 
     // AttachedToLogicalTree / DetachedFromLogicalTree
@@ -311,7 +318,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).AttachedToLogicalTree();
+        GetExistingBehaviors(d)?.AttachedToLogicalTree();
     }
 
     private static void StyledElement_DetachedFromLogicalTree_FromGetter(object? sender, LogicalTreeAttachmentEventArgs e)
@@ -321,7 +328,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DetachedFromLogicalTree();
+        GetExistingBehaviors(d)?.DetachedFromLogicalTree();
     }
  
     private static void StyledElement_AttachedToLogicalTree_FromChangedEvent(object? sender, LogicalTreeAttachmentEventArgs e)
@@ -331,7 +338,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).AttachedToLogicalTree();
+        GetExistingBehaviors(d)?.AttachedToLogicalTree();
     }
 
     private static void StyledElement_DetachedFromLogicalTree_FromChangedEvent(object? sender, LogicalTreeAttachmentEventArgs e)
@@ -341,7 +348,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DetachedFromLogicalTree();
+        GetExistingBehaviors(d)?.DetachedFromLogicalTree();
     }
 
     // Loaded / Unloaded
@@ -353,7 +360,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Loaded();
+        GetExistingBehaviors(d)?.Loaded();
     }
 
     private static void Control_Unloaded_FromGetter(object? sender, RoutedEventArgs e)
@@ -363,7 +370,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Unloaded();
+        GetExistingBehaviors(d)?.Unloaded();
     }
  
     private static void Control_Loaded_FromChangedEvent(object? sender, RoutedEventArgs e)
@@ -373,7 +380,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Loaded();
+        GetExistingBehaviors(d)?.Loaded();
     }
 
     private static void Control_Unloaded_FromChangedEvent(object? sender, RoutedEventArgs e)
@@ -383,7 +390,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Unloaded();
+        GetExistingBehaviors(d)?.Unloaded();
     }
 
     // Initialized
@@ -395,7 +402,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Initialized();
+        GetExistingBehaviors(d)?.Initialized();
     }
 
     private static void StyledElement_Initialized_FromChangedEvent(object? sender, EventArgs e)
@@ -405,7 +412,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Initialized();
+        GetExistingBehaviors(d)?.Initialized();
     }
 
     // DataContextChanged
@@ -417,7 +424,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DataContextChanged();
+        GetExistingBehaviors(d)?.DataContextChanged();
     }
 
     private static void StyledElement_DataContextChanged_FromChangedEvent(object? sender, EventArgs e)
@@ -427,7 +434,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).DataContextChanged();
+        GetExistingBehaviors(d)?.DataContextChanged();
     }
 
     // ResourcesChanged
@@ -439,7 +446,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).ResourcesChanged();
+        GetExistingBehaviors(d)?.ResourcesChanged();
     }
 
     private static void StyledElement_ResourcesChanged_FromChangedEvent(object? sender, ResourcesChangedEventArgs e)
@@ -449,7 +456,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).ResourcesChanged();
+        GetExistingBehaviors(d)?.ResourcesChanged();
     }
 
     // ActualThemeVariantChanged
@@ -461,7 +468,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).ActualThemeVariantChanged();
+        GetExistingBehaviors(d)?.ActualThemeVariantChanged();
     }
 
     private static void StyledElement_ActualThemeVariantChanged_FromChangedEvent(object? sender, EventArgs e)
@@ -471,7 +478,7 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).ActualThemeVariantChanged();
+        GetExistingBehaviors(d)?.ActualThemeVariantChanged();
     }
 
     // TopLevel Opened
@@ -483,9 +490,10 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).Attach(d);
-        GetBehaviors(d).AttachedToVisualTree();
-        GetBehaviors(d).AttachedToLogicalTree();
+        var behaviors = GetExistingBehaviors(d);
+        behaviors?.Attach(d);
+        behaviors?.AttachedToVisualTree();
+        behaviors?.AttachedToLogicalTree();
     }
 
     private static void TopLevel_Opened_FromChangedEvent(object? sender, EventArgs e)
@@ -495,7 +503,8 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).AttachedToVisualTree();
-        GetBehaviors(d).AttachedToLogicalTree();
+        var behaviors = GetExistingBehaviors(d);
+        behaviors?.AttachedToVisualTree();
+        behaviors?.AttachedToLogicalTree();
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ItemDragBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ItemDragBehaviorTests.cs
@@ -1,16 +1,43 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactions.Draggable;
+using Avalonia.Xaml.Interactivity;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.Core;
 
 public class ItemDragBehaviorTests
 {
+    private static void AssertDragCanStart(
+        ListReorderDragBehaviorWindow window,
+        int index)
+    {
+        var container = Assert.IsType<ListBoxItem>(window.TargetListBox.ContainerFromIndex(index));
+        var behaviors = Assert.IsType<BehaviorCollection>(
+            container.GetValue(Interaction.BehaviorsProperty));
+        var behavior = Assert.IsType<ListReorderDragBehavior>(Assert.Single(behaviors));
+
+        Assert.Same(container, behaviors.AssociatedObject);
+        Assert.Same(container, behavior.AssociatedObject);
+
+        window.TargetListBox.SelectedIndex = index;
+
+        window.MouseDown(container, new Point(5, 5), MouseButton.Left);
+
+        Assert.Contains(":dragging", container.Classes);
+
+        window.MouseUp(container, new Point(5, 5), MouseButton.Left);
+
+        Assert.DoesNotContain(":dragging", container.Classes);
+    }
+
     private static void Drag(TopLevel window, Control parent, Control container, bool horizontal)
     {
         var bounds = container.Bounds;
@@ -63,5 +90,48 @@ public class ItemDragBehaviorTests
         Drag(window, window.TargetItemsControl, containers[0], true);
 
         Assert.Equal(new[] { "Item2", "Item3", "Item1" }, window.Items.ToArray());
+    }
+
+    [AvaloniaFact]
+    public void ListReorderDragBehavior_CanStartAgainAfterVirtualizedItemMoves()
+    {
+        var items = new ObservableCollection<int>(Enumerable.Range(0, 100));
+        var window = new ListReorderDragBehaviorWindow();
+        window.TargetListBox.ItemsSource = items;
+
+        window.Show();
+        window.CaptureRenderedFrame();
+
+        AssertDragCanStart(window, 0);
+
+        var movedItem = items[0];
+        items.Move(0, 5);
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame();
+
+        Assert.Equal(movedItem, items[5]);
+        AssertDragCanStart(window, 5);
+    }
+
+    [AvaloniaFact]
+    public void ListReorderDragBehavior_CanStartAfterListReattaches()
+    {
+        var items = new ObservableCollection<int>(Enumerable.Range(0, 100));
+        var window = new ListReorderDragBehaviorWindow();
+        var listBox = window.TargetListBox;
+        listBox.ItemsSource = items;
+
+        window.Show();
+        window.CaptureRenderedFrame();
+
+        AssertDragCanStart(window, 0);
+
+        window.Content = null;
+        Dispatcher.UIThread.RunJobs();
+        window.Content = listBox;
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame();
+
+        AssertDragCanStart(window, 0);
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ListReorderDragBehaviorWindow.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ListReorderDragBehaviorWindow.axaml
@@ -1,0 +1,20 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:draggable="using:Avalonia.Xaml.Interactions.Draggable"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.ListReorderDragBehaviorWindow"
+        Width="400"
+        Height="210">
+  <ListBox x:Name="TargetListBox">
+    <ListBox.Styles>
+      <Style Selector="ListBoxItem">
+        <Setter Property="(Interaction.Behaviors)">
+          <BehaviorCollectionTemplate>
+            <BehaviorCollection>
+              <draggable:ListReorderDragBehavior Orientation="Vertical" />
+            </BehaviorCollection>
+          </BehaviorCollectionTemplate>
+        </Setter>
+      </Style>
+    </ListBox.Styles>
+  </ListBox>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ListReorderDragBehaviorWindow.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/ListReorderDragBehaviorWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class ListReorderDragBehaviorWindow : Window
+{
+    public ListReorderDragBehaviorWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -98,6 +98,26 @@ public class InteractionTest
     }
 
     [AvaloniaFact]
+    public void LifecycleEvents_DoNotCreateCollectionAfterBehaviorsAreRemoved()
+    {
+        var behavior = new TestBehavior();
+        var collection = new BehaviorCollection { behavior };
+        var button = new Button();
+        var panel = new Panel { Children = { button } };
+        var window = new Window { Content = panel };
+        Interaction.SetBehaviors(button, collection);
+
+        window.Show();
+        Interaction.SetBehaviors(button, null);
+        panel.Children.Remove(button);
+
+        Assert.Null(button.GetValue(Interaction.BehaviorsProperty));
+        Assert.Null(collection.AssociatedObject);
+        Assert.Null(behavior.AssociatedObject);
+        Assert.Equal(1, behavior.DetachingCalled);
+    }
+
+    [AvaloniaFact]
     public void ExecuteActions_NullParameters_ReturnsEmptyEnumerable()
     {
         // Mostly just want to test that this doesn't throw any exceptions.


### PR DESCRIPTION
## Summary

Fixes repeat drag failures in `ListReorderDragBehavior` when item containers are recycled by a virtualized panel or when their containing list leaves and re-enters the visual tree.

## Root cause

The lifecycle handlers in `Interaction` called the public `GetBehaviors` accessor. That accessor intentionally creates a collection when none exists. During container recycling, a style-created `BehaviorCollectionTemplate` can be removed before a later detach/unload callback runs. The callback then created a local empty collection on the container.

Because a local attached-property value has higher precedence than the style setter, that empty collection permanently masked the style template when the container was reused. The recycled item therefore had no `ListReorderDragBehavior`, so subsequent drag attempts could not start.

## Changes

- Add a non-creating internal lookup for lifecycle dispatch.
- Use the existing collection only from visual-tree, logical-tree, load/unload, initialization, data-context, resource, theme, and top-level lifecycle callbacks.
- Preserve the public `GetBehaviors` behavior for callers that explicitly request a collection.
- Add an Avalonia Headless fixture that applies `ListReorderDragBehavior` through a style-created `BehaviorCollectionTemplate`.
- Add regressions proving dragging can start again:
  - after a virtualized item moves in the source collection;
  - after the list is removed and reattached.
- Add a lower-level regression proving lifecycle events do not recreate a collection after behaviors are removed.
- Document that the style-based list reorder pattern supports recycled containers.

## Validation

- `Xaml.Behaviors.Interactivity.UnitTests`: 94 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 91 passed, 2 existing skipped
- `git diff --check`: clean

Closes #340