### PR TITLE
Fix ToolTip opening and closing triggers

### DIFF
--- a/docfx/articles/interactions-custom/tool-tips/tool-tip-closing-trigger.md
+++ b/docfx/articles/interactions-custom/tool-tips/tool-tip-closing-trigger.md
@@ -2,6 +2,8 @@
 
 Trigger that listens for the `ToolTip.ToolTipClosingEvent`.
 
+`ToolTipClosingEvent` uses direct routing. The trigger subscribes with the matching routing strategy and passes the `RoutedEventArgs` instance to its actions.
+
 ## Usage
 
 ```xml
@@ -13,3 +15,5 @@ Trigger that listens for the `ToolTip.ToolTipClosingEvent`.
     </Interaction.Behaviors>
 </Button>
 ```
+
+The same event can be handled by `EventTriggerBehavior` with `EventName="ToolTipClosing"`. Prefer `ToolTipClosingTrigger` when trimming or native AOT compatibility is required.

--- a/docfx/articles/interactions-custom/tool-tips/tool-tip-opening-trigger.md
+++ b/docfx/articles/interactions-custom/tool-tips/tool-tip-opening-trigger.md
@@ -2,6 +2,8 @@
 
 Trigger that listens for the `ToolTip.ToolTipOpeningEvent`.
 
+`ToolTipOpeningEvent` uses direct routing. The trigger subscribes with the matching routing strategy and passes the `CancelRoutedEventArgs` instance to its actions.
+
 ## Usage
 
 ```xml
@@ -13,3 +15,5 @@ Trigger that listens for the `ToolTip.ToolTipOpeningEvent`.
     </Interaction.Behaviors>
 </Button>
 ```
+
+The same event can be handled by `EventTriggerBehavior` with `EventName="ToolTipOpening"`. Prefer `ToolTipOpeningTrigger` when trimming or native AOT compatibility is required.

--- a/src/Xaml.Behaviors.Interactions.Custom/ToolTips/ToolTipClosingTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/ToolTips/ToolTipClosingTrigger.cs
@@ -18,6 +18,6 @@ public class ToolTipClosingTrigger : RoutedEventTrigger
     {
         EventRoutingStrategyProperty.OverrideMetadata<ToolTipClosingTrigger>(
             new StyledPropertyMetadata<RoutingStrategies>(
-                defaultValue: RoutingStrategies.Bubble));
+                defaultValue: RoutingStrategies.Direct));
     }
 }

--- a/src/Xaml.Behaviors.Interactions.Custom/ToolTips/ToolTipOpeningTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/ToolTips/ToolTipOpeningTrigger.cs
@@ -18,6 +18,6 @@ public class ToolTipOpeningTrigger : RoutedEventTriggerBase<CancelRoutedEventArg
     {
         EventRoutingStrategyProperty.OverrideMetadata<ToolTipOpeningTrigger>(
             new StyledPropertyMetadata<RoutingStrategies>(
-                defaultValue: RoutingStrategies.Bubble));
+                defaultValue: RoutingStrategies.Direct));
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/Events/AddEventHandlerRegistry.cs
+++ b/src/Xaml.Behaviors.Interactivity/Events/AddEventHandlerRegistry.cs
@@ -28,6 +28,16 @@ public static class AddEventHandlerRegistry
             nameof(MenuItem.Click), 
             (o, h) => o.Click += h, 
             (o, h) => o.Click -= h));
+
+        Register(new FuncAddEventHandler<Control, CancelRoutedEventArgs>(
+            "ToolTipOpening",
+            ToolTip.AddToolTipOpeningHandler,
+            ToolTip.RemoveToolTipOpeningHandler));
+
+        Register(new FuncAddEventHandler<Control, RoutedEventArgs>(
+            "ToolTipClosing",
+            ToolTip.AddToolTipClosingHandler,
+            ToolTip.RemoveToolTipClosingHandler));
     }
 
     /// <summary>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ToolTipTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/ToolTipTriggerTests.cs
@@ -1,0 +1,109 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactions.Core;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class ToolTipTriggerTests
+{
+    [AvaloniaFact]
+    public void ToolTipOpeningTrigger_ExecutesActionsForDirectEvent()
+    {
+        object? commandParameter = null;
+        var target = new Border();
+        var trigger = new ToolTipOpeningTrigger();
+        var action = new InvokeCommandAction
+        {
+            Command = new Command(parameter => commandParameter = parameter),
+            PassEventArgsToCommand = true,
+        };
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+        var window = new Window { Content = target };
+        window.Show();
+        var eventArgs = new CancelRoutedEventArgs(ToolTip.ToolTipOpeningEvent);
+
+        target.RaiseEvent(eventArgs);
+
+        Assert.Equal(RoutingStrategies.Direct, trigger.EventRoutingStrategy);
+        Assert.Same(eventArgs, commandParameter);
+    }
+
+    [AvaloniaFact]
+    public void ToolTipClosingTrigger_ExecutesActionsForDirectEvent()
+    {
+        object? commandParameter = null;
+        var target = new Border();
+        var trigger = new ToolTipClosingTrigger();
+        var action = new InvokeCommandAction
+        {
+            Command = new Command(parameter => commandParameter = parameter),
+            PassEventArgsToCommand = true,
+        };
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+        var window = new Window { Content = target };
+        window.Show();
+        var eventArgs = new RoutedEventArgs(ToolTip.ToolTipClosingEvent);
+
+        target.RaiseEvent(eventArgs);
+
+        Assert.Equal(RoutingStrategies.Direct, trigger.EventRoutingStrategy);
+        Assert.Same(eventArgs, commandParameter);
+    }
+
+    [AvaloniaFact]
+    public void EventTriggerBehavior_ExecutesActionsForToolTipOpeningEvent()
+    {
+        object? commandParameter = null;
+        var target = new Border();
+        var trigger = new EventTriggerBehavior
+        {
+            EventName = "ToolTipOpening",
+        };
+        var action = new InvokeCommandAction
+        {
+            Command = new Command(parameter => commandParameter = parameter),
+            PassEventArgsToCommand = true,
+        };
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+        var eventArgs = new CancelRoutedEventArgs(ToolTip.ToolTipOpeningEvent);
+
+        target.RaiseEvent(eventArgs);
+
+        Assert.Same(eventArgs, commandParameter);
+    }
+
+    [AvaloniaFact]
+    public void EventTriggerBehavior_ExecutesActionsForToolTipClosingEvent()
+    {
+        object? commandParameter = null;
+        var target = new Border();
+        var trigger = new EventTriggerBehavior
+        {
+            EventName = "ToolTipClosing",
+        };
+        var action = new InvokeCommandAction
+        {
+            Command = new Command(parameter => commandParameter = parameter),
+            PassEventArgsToCommand = true,
+        };
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+        var eventArgs = new RoutedEventArgs(ToolTip.ToolTipClosingEvent);
+
+        target.RaiseEvent(eventArgs);
+
+        Assert.Same(eventArgs, commandParameter);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes ToolTip opening and closing triggers so both the dedicated trigger types and `EventTriggerBehavior` receive Avalonia's attached ToolTip events.

## Root cause

Avalonia registers `ToolTipOpeningEvent` and `ToolTipClosingEvent` with `RoutingStrategies.Direct`. The dedicated behavior types overrode their default subscription strategy to `Bubble`, so their handlers were excluded from the event route.

The generic `EventTriggerBehavior` fallback also could not find these events: ToolTip exposes them as attached routed events rather than CLR instance events on the associated control.

## Changes

- Change `ToolTipOpeningTrigger` and `ToolTipClosingTrigger` to subscribe using direct routing.
- Register explicit, strongly typed ToolTip opening and closing handlers in `AddEventHandlerRegistry`.
- Support `EventTriggerBehavior EventName="ToolTipOpening"` and `EventName="ToolTipClosing"` without adding reflection.
- Add headless regression coverage for all four reported paths.
- Verify that the original event-argument instances reach actions.
- Document the routing behavior and recommend the dedicated triggers for trimming/native AOT scenarios.

## Validation

- Focused ToolTip regressions: 4 passed
- `Xaml.Behaviors.Interactivity.UnitTests`: 93 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 93 passed, 2 existing skipped
- `git diff --check`: clean

Closes #341