### PR TITLE
Dispose routed event subscriptions on visual detach

### DIFF
--- a/docfx/articles/interactions-custom/input-element/pointer-entered-trigger.md
+++ b/docfx/articles/interactions-custom/input-element/pointer-entered-trigger.md
@@ -1,5 +1,7 @@
 # PointerEnteredTrigger
 
+The trigger owns its routed-event subscription for exactly one visual-tree lifetime. Removing and re-adding the associated control does not accumulate handlers or execute actions more than once per pointer entry.
+
 A trigger that executes when the pointer enters the bounds of the associated `InputElement`.
 
 ## Usage

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/AttachedToVisualTreeBehavior.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/AttachedToVisualTreeBehavior.cs
@@ -22,13 +22,20 @@ public abstract class AttachedToVisualTreeBehavior<T> : DisposingBehavior<T> whe
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
+        OnDelayedDispose();
         _disposable = OnAttachedToVisualTreeOverride();
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        OnDelayedDispose();
     }
 
     /// <summary>
     /// Called after the <see cref="StyledElementBehavior{T}.AssociatedObject"/> is attached to the visual tree.
     /// </summary>
-    /// <returns>A disposable resource to be disposed when the behavior is detached.</returns>
+    /// <returns>A resource disposed when the associated object leaves the visual tree or the behavior is detached.</returns>
 	protected abstract IDisposable OnAttachedToVisualTreeOverride();
 
     private void OnDelayedDispose()

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/AttachedToVisualTreeTriggerBase.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/AttachedToVisualTreeTriggerBase.cs
@@ -22,13 +22,20 @@ public abstract class AttachedToVisualTreeTriggerBase<T>  : DisposingTrigger<T> 
     /// <inheritdoc />
     protected override void OnAttachedToVisualTree()
     {
+        OnDelayedDispose();
         _disposable = OnAttachedToVisualTreeOverride();
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree()
+    {
+        OnDelayedDispose();
     }
 
     /// <summary>
     /// Called after the <see cref="StyledElementBehavior{T}.AssociatedObject"/> is attached to the visual tree.
     /// </summary>
-    /// <returns>A disposable resource to be disposed when the behavior is detached.</returns>
+    /// <returns>A resource disposed when the associated object leaves the visual tree or the trigger is detached.</returns>
     protected abstract IDisposable OnAttachedToVisualTreeOverride();
 
     private void OnDelayedDispose()

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/RoutedEventTrigger.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/RoutedEventTrigger.cs
@@ -11,19 +11,11 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// </summary>
 public abstract class RoutedEventTrigger : RoutedEventTriggerBase
 {
-    private IDisposable? _disposable;
-    
     /// <summary>
     /// 
     /// </summary>
     protected abstract RoutedEvent RoutedEvent { get; }
 
-    /// <inheritdoc />
-    protected override IDisposable OnAttachedOverride()
-    {
-        return new DisposableAction(OnDelayedDispose);
-    }
-    
     /// <summary>
     /// 
     /// </summary>
@@ -66,12 +58,6 @@ public abstract class RoutedEventTrigger : RoutedEventTriggerBase
     {
         e.Handled = MarkAsHandled;
         Interaction.ExecuteActions(AssociatedObject, Actions, e);
-    }
-
-    private void OnDelayedDispose()
-    {
-        _disposable?.Dispose();
-        _disposable = null;
     }
 
     private static IDisposable AddDisposableHandler(

--- a/src/Xaml.Behaviors.Interactions.Custom/Core/RoutedEventTriggerBaseOfT.cs
+++ b/src/Xaml.Behaviors.Interactions.Custom/Core/RoutedEventTriggerBaseOfT.cs
@@ -12,19 +12,11 @@ namespace Avalonia.Xaml.Interactions.Custom;
 /// <typeparam name="T"></typeparam>
 public abstract class RoutedEventTriggerBase<T> : RoutedEventTriggerBase where T : RoutedEventArgs
 {
-    private IDisposable? _disposable;
-    
     /// <summary>
     /// 
     /// </summary>
     protected abstract RoutedEvent<T> RoutedEvent { get; }
 
-    /// <inheritdoc />
-    protected override IDisposable OnAttachedOverride()
-    {
-        return new DisposableAction(OnDelayedDispose);
-    }
-    
     /// <summary>
     /// 
     /// </summary>
@@ -68,9 +60,4 @@ public abstract class RoutedEventTriggerBase<T> : RoutedEventTriggerBase where T
         Interaction.ExecuteActions(AssociatedObject, Actions, e);
     }
 
-    private void OnDelayedDispose()
-    {
-        _disposable?.Dispose();
-        _disposable = null;
-    }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/AttachedToVisualTreeLifecycleTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/AttachedToVisualTreeLifecycleTests.cs
@@ -1,0 +1,194 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactions.Core;
+using Avalonia.Xaml.Interactions.Custom;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+using Avalonia.Xaml.Interactivity;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class AttachedToVisualTreeLifecycleTests
+{
+    private sealed class TrackingTrigger : AttachedToVisualTreeTriggerBase<Border>
+    {
+        public int ActiveSubscriptions { get; private set; }
+        public int CreatedSubscriptions { get; private set; }
+        public int DisposedSubscriptions { get; private set; }
+
+        protected override IDisposable OnAttachedToVisualTreeOverride()
+        {
+            ActiveSubscriptions++;
+            CreatedSubscriptions++;
+
+            return DisposableAction.Create(() =>
+            {
+                ActiveSubscriptions--;
+                DisposedSubscriptions++;
+            });
+        }
+    }
+
+    private sealed class NonGenericPointerEnteredTrigger : RoutedEventTrigger
+    {
+        protected override RoutedEvent RoutedEvent => InputElement.PointerEnteredEvent;
+    }
+
+    private sealed class TrackingBehavior : AttachedToVisualTreeBehavior<Border>
+    {
+        public int ActiveSubscriptions { get; private set; }
+        public int CreatedSubscriptions { get; private set; }
+        public int DisposedSubscriptions { get; private set; }
+
+        protected override IDisposable OnAttachedToVisualTreeOverride()
+        {
+            ActiveSubscriptions++;
+            CreatedSubscriptions++;
+
+            return DisposableAction.Create(() =>
+            {
+                ActiveSubscriptions--;
+                DisposedSubscriptions++;
+            });
+        }
+    }
+
+    [AvaloniaFact]
+    public void PointerEnteredTrigger_ExecutesOnceAfterVisualTreeReattach()
+    {
+        var commandCalls = 0;
+        var nonGenericCommandCalls = 0;
+        var target = new Border
+        {
+            Width = 100,
+            Height = 100,
+            Background = Brushes.Red,
+        };
+        var outside = new Border
+        {
+            Width = 100,
+            Height = 100,
+            Background = Brushes.Blue,
+        };
+        var panel = new StackPanel
+        {
+            Children = { target, outside },
+        };
+        var trigger = new PointerEnteredTrigger();
+        var action = new InvokeCommandAction
+        {
+            Command = new Command(_ => commandCalls++),
+        };
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        var nonGenericTrigger = new NonGenericPointerEnteredTrigger();
+        var nonGenericAction = new InvokeCommandAction
+        {
+            Command = new Command(_ => nonGenericCommandCalls++),
+        };
+        nonGenericTrigger.Actions ??= [];
+        nonGenericTrigger.Actions.Add(nonGenericAction);
+        var behaviors = Interaction.GetBehaviors(target);
+        behaviors.Add(trigger);
+        behaviors.Add(nonGenericTrigger);
+        var window = new Window
+        {
+            Width = 240,
+            Height = 240,
+            Content = panel,
+        };
+        window.Show();
+        window.CaptureRenderedFrame();
+
+        window.MouseMove(outside, new Point(10, 10));
+        window.MouseMove(target, new Point(10, 10));
+
+        Assert.Equal(1, commandCalls);
+        Assert.Equal(1, nonGenericCommandCalls);
+
+        panel.Children.Remove(target);
+        Dispatcher.UIThread.RunJobs();
+        panel.Children.Insert(0, target);
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame();
+
+        window.MouseMove(outside, new Point(10, 10));
+        var callsBeforeSecondEntry = commandCalls;
+        var nonGenericCallsBeforeSecondEntry = nonGenericCommandCalls;
+        window.MouseMove(target, new Point(10, 10));
+
+        Assert.Equal(callsBeforeSecondEntry + 1, commandCalls);
+        Assert.Equal(nonGenericCallsBeforeSecondEntry + 1, nonGenericCommandCalls);
+
+        Interaction.SetBehaviors(target, null);
+        window.MouseMove(outside, new Point(10, 10));
+        var callsBeforeDetachedEntry = commandCalls;
+        var nonGenericCallsBeforeDetachedEntry = nonGenericCommandCalls;
+        window.MouseMove(target, new Point(10, 10));
+
+        Assert.Equal(callsBeforeDetachedEntry, commandCalls);
+        Assert.Equal(nonGenericCallsBeforeDetachedEntry, nonGenericCommandCalls);
+    }
+
+    [AvaloniaFact]
+    public void AttachedToVisualTreeTriggerBase_DisposesForEachVisualTreeLifetime()
+    {
+        var target = new Border();
+        var panel = new Panel { Children = { target } };
+        var trigger = new TrackingTrigger();
+        Interaction.GetBehaviors(target).Add(trigger);
+        var window = new Window { Content = panel };
+        window.Show();
+
+        Assert.Equal(1, trigger.ActiveSubscriptions);
+
+        panel.Children.Remove(target);
+
+        Assert.Equal(0, trigger.ActiveSubscriptions);
+        Assert.Equal(1, trigger.DisposedSubscriptions);
+
+        panel.Children.Add(target);
+
+        Assert.Equal(1, trigger.ActiveSubscriptions);
+        Assert.Equal(2, trigger.CreatedSubscriptions);
+
+        panel.Children.Remove(target);
+
+        Assert.Equal(0, trigger.ActiveSubscriptions);
+        Assert.Equal(2, trigger.DisposedSubscriptions);
+    }
+
+    [AvaloniaFact]
+    public void AttachedToVisualTreeBehavior_DisposesForEachVisualTreeLifetime()
+    {
+        var target = new Border();
+        var panel = new Panel { Children = { target } };
+        var behavior = new TrackingBehavior();
+        Interaction.GetBehaviors(target).Add(behavior);
+        var window = new Window { Content = panel };
+        window.Show();
+
+        Assert.Equal(1, behavior.ActiveSubscriptions);
+
+        panel.Children.Remove(target);
+
+        Assert.Equal(0, behavior.ActiveSubscriptions);
+        Assert.Equal(1, behavior.DisposedSubscriptions);
+
+        panel.Children.Add(target);
+
+        Assert.Equal(1, behavior.ActiveSubscriptions);
+        Assert.Equal(2, behavior.CreatedSubscriptions);
+
+        panel.Children.Remove(target);
+
+        Assert.Equal(0, behavior.ActiveSubscriptions);
+        Assert.Equal(2, behavior.DisposedSubscriptions);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes routed-event triggers accumulating handlers whenever their associated control leaves and re-enters the visual tree.

## Reproduction

A headless regression mirrors the reported flow:

1. attach `PointerEnteredTrigger` to a control;
2. enter the control once;
3. remove and re-add the same control;
4. enter it again.

Before the fix, the second entry executed the action twice. Repeating the cycle continued increasing the number of callbacks.

## Root cause

`AttachedToVisualTreeTriggerBase<T>` created a subscription disposable when the control entered the visual tree, but only disposed it when the behavior itself detached. A visual-tree detach therefore left the old handler registered, and the next attach overwrote the stored disposable after registering another handler.

The generic and non-generic routed-event trigger implementations also shadowed the base attachment disposable with private fields that were never assigned. Removing a trigger while its control remained visible could consequently leave its handler active.

The parallel `AttachedToVisualTreeBehavior<T>` base had the same visual-lifetime ownership defect.

## Changes

- Dispose the current visual-tree resource when a control leaves the visual tree.
- Defensively dispose any previous resource before establishing a new visual-tree lifetime.
- Remove the unused shadow disposable implementations from generic and non-generic routed-event triggers.
- Apply the same lifetime correction to `AttachedToVisualTreeBehavior<T>`.
- Add headless coverage proving:
  - `PointerEnteredTrigger` executes once after reattachment;
  - generic and non-generic routed triggers stop executing after removal;
  - trigger-base resources are disposed once per visual-tree lifetime;
  - behavior-base resources are disposed once per visual-tree lifetime.
- Document the one-subscription-per-visual-lifetime guarantee.

## Validation

- Focused lifecycle regressions: 3 passed
- `Xaml.Behaviors.Interactivity.UnitTests`: 93 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 92 passed, 2 existing skipped
- `git diff --check`: clean

Closes #344