### PR TITLE
Handle non-convertible data trigger values safely

### DIFF
--- a/docfx/articles/interactions/data-trigger-behavior.md
+++ b/docfx/articles/interactions/data-trigger-behavior.md
@@ -1,5 +1,7 @@
 # DataTriggerBehavior
 
+When a string `Value` cannot be converted to the runtime type of `Binding`, the comparison uses non-equal semantics instead of throwing: `NotEqual` evaluates to `true`, while the other comparison operators evaluate to `false`.
+
 `DataTriggerBehavior` is a behavior that listens for changes to a bound value and invokes actions when the value meets a specified condition.
 
 ## Properties

--- a/src/Xaml.Behaviors.Interactivity/Helpers/ComparisonConditionTypeHelper.cs
+++ b/src/Xaml.Behaviors.Interactivity/Helpers/ComparisonConditionTypeHelper.cs
@@ -16,7 +16,16 @@ internal static class ComparisonConditionTypeHelper
             if (rightOperand is string rightOperandString)
             {
                 var leftOperandType = leftOperand.GetType();
-                var convertedRightOperand = TypeConverterHelper.Convert(rightOperandString, leftOperandType);
+                object? convertedRightOperand = null;
+                try
+                {
+                    convertedRightOperand = TypeConverterHelper.Convert(rightOperandString, leftOperandType);
+                }
+                catch (Exception exception) when (IsConversionException(exception))
+                {
+                    // Keep the original operand so comparable evaluation can use non-equal semantics.
+                }
+
                 if (convertedRightOperand is not null)
                 {
                     rightOperand = convertedRightOperand;
@@ -74,21 +83,26 @@ internal static class ComparisonConditionTypeHelper
         {
             convertedOperand = Convert.ChangeType(rightOperand, leftOperand.GetType(), CultureInfo.CurrentCulture);
         }
-        catch (FormatException)
+        catch (Exception exception) when (IsConversionException(exception))
         {
-            // FormatException: Convert.ChangeType("hello", typeof(double), ...);
-        }
-        catch (InvalidCastException)
-        {
-            // InvalidCastException: Convert.ChangeType(4.0d, typeof(Rectangle), ...);
+            // The operands cannot be converted to a common comparable type.
         }
 
         if (convertedOperand is null)
         {
-            return operatorType == ComparisonConditionType.NotEqual;
+            return IsNonEqualResult(operatorType);
         }
 
-        var comparison = leftOperand.CompareTo((IComparable)convertedOperand);
+        int comparison;
+        try
+        {
+            comparison = leftOperand.CompareTo((IComparable)convertedOperand);
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidCastException)
+        {
+            return IsNonEqualResult(operatorType);
+        }
+
         return operatorType switch
         {
             ComparisonConditionType.Equal => comparison == 0,
@@ -99,5 +113,18 @@ internal static class ComparisonConditionTypeHelper
             ComparisonConditionType.GreaterThanOrEqual => comparison >= 0,
             _ => false
         };
+    }
+
+    private static bool IsConversionException(Exception exception)
+    {
+        return exception is FormatException
+            or InvalidCastException
+            or NotSupportedException
+            or OverflowException;
+    }
+
+    private static bool IsNonEqualResult(ComparisonConditionType operatorType)
+    {
+        return operatorType == ComparisonConditionType.NotEqual;
     }
 }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/DataTriggerBehaviorTests.cs
@@ -1,6 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactions.Core;
+using Avalonia.Xaml.Interactivity;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactions.UnitTests.Core;
@@ -69,5 +74,33 @@ public class DataTriggerBehaviorTests
 
         Assert.Equal("50 or more", window.TargetTextBlock.Text);
         Assert.Equal(50d, window.TargetSlider.Value);
+    }
+
+    [AvaloniaFact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Validates the reflection-based compatibility trigger.")]
+    public void DataTriggerBehavior_NonConvertibleValue_DoesNotThrowOrExecuteActions()
+    {
+        var commandCalls = 0;
+        var target = new Border();
+        var trigger = new DataTriggerBehavior
+        {
+            Binding = 42,
+            ComparisonCondition = ComparisonConditionType.Equal,
+            Value = "not-an-integer",
+        };
+        var action = new InvokeCommandAction
+        {
+            Command = new Command(_ => commandCalls++),
+        };
+        trigger.Actions ??= [];
+        trigger.Actions.Add(action);
+        Interaction.GetBehaviors(target).Add(trigger);
+        var window = new Window { Content = target };
+        window.Show();
+
+        var exception = Record.Exception(() => Dispatcher.UIThread.RunJobs());
+
+        Assert.Null(exception);
+        Assert.Equal(0, commandCalls);
     }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/ComparisonConditionTypeHelperTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/ComparisonConditionTypeHelperTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactivity.UnitTests;
+
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Validates the reflection-based compatibility comparison helper.")]
+public class ComparisonConditionTypeHelperTests
+{
+    private sealed class ThrowingComparable : IComparable
+    {
+        public int CompareCalls { get; private set; }
+
+        public int CompareTo(object? obj)
+        {
+            CompareCalls++;
+            throw new ArgumentException("Operands are not comparable.", nameof(obj));
+        }
+    }
+
+    [Theory]
+    [InlineData(ComparisonConditionType.Equal, false)]
+    [InlineData(ComparisonConditionType.NotEqual, true)]
+    [InlineData(ComparisonConditionType.LessThan, false)]
+    [InlineData(ComparisonConditionType.LessThanOrEqual, false)]
+    [InlineData(ComparisonConditionType.GreaterThan, false)]
+    [InlineData(ComparisonConditionType.GreaterThanOrEqual, false)]
+    public void Compare_NonConvertibleString_UsesNonEqualSemantics(
+        ComparisonConditionType operatorType,
+        bool expected)
+    {
+        var result = ComparisonConditionTypeHelper.Compare(42, operatorType, "not-an-integer");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Compare_OverflowingString_UsesNonEqualSemantics()
+    {
+        var result = ComparisonConditionTypeHelper.Compare(
+            42,
+            ComparisonConditionType.Equal,
+            "999999999999999999999999999999");
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(ComparisonConditionType.Equal, false)]
+    [InlineData(ComparisonConditionType.NotEqual, true)]
+    public void Compare_IncompatibleComparable_UsesNonEqualSemantics(
+        ComparisonConditionType operatorType,
+        bool expected)
+    {
+        var left = new ThrowingComparable();
+        var right = new ThrowingComparable();
+
+        var result = ComparisonConditionTypeHelper.Compare(left, operatorType, right);
+
+        Assert.Equal(expected, result);
+        Assert.Equal(1, left.CompareCalls);
+    }
+}


### PR DESCRIPTION
## Summary

Prevents `DataTriggerBehavior` and shared comparison conditions from throwing when a string `Value` cannot be converted to the runtime type of `Binding`.

## Contract

A conversion or compatible-comparison failure now uses non-equal semantics:

- `NotEqual` evaluates to `true`.
- `Equal` and all relational operators evaluate to `false`.

This lets dynamically generated or design-time-incomplete triggers remain inert until their values become compatible.

## Root cause

The initial string conversion called `TypeConverterHelper.Convert` without guarding its standard conversion failures. Primitive parsing such as `int.Parse` could therefore propagate `FormatException` or `OverflowException`.

The later comparable path handled only part of the conversion surface and called `IComparable.CompareTo` without guarding incompatible-operand exceptions.

## Changes

- Guard string conversion failures for format, invalid cast, unsupported conversion, and overflow.
- Guard the same standard failures from `Convert.ChangeType`.
- Treat `ArgumentException` or `InvalidCastException` from `CompareTo` as incompatible operands.
- Centralize the non-equal result rule.
- Add direct tests covering:
  - all six comparison operators with a non-convertible integer string;
  - numeric overflow;
  - an `IComparable` implementation that rejects the other operand.
- Add an end-to-end `DataTriggerBehavior` test proving dispatcher evaluation neither throws nor executes actions.
- Document the compatibility semantics.

Unexpected exceptions outside these known conversion/comparison incompatibilities continue to propagate.

## Validation

- Focused comparison tests: 9 passed
- Focused `DataTriggerBehavior` regression: 1 passed
- `Xaml.Behaviors.Interactivity.UnitTests`: 102 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 90 passed, 2 existing skipped
- `git diff --check`: clean

Closes #346