### PR TITLE
Synchronize lifecycle for triggers attached after load

### DIFF
--- a/docfx/articles/interactivity/behaviors.md
+++ b/docfx/articles/interactivity/behaviors.md
@@ -93,6 +93,8 @@ In many cases, a behavior needs to perform actions not just when it is attached,
 
 When you attach a behavior collection to a control, the `Interaction` class subscribes to relevant events on that control (like `AttachedToVisualTree`, `DetachedFromVisualTree`, `Loaded`, `Unloaded`, etc.). When these events fire, `Interaction` iterates through the behaviors in the collection and calls the corresponding lifecycle method on each behavior.
 
+If a collection or an individual behavior is attached after the control is already initialized, rooted, or loaded, the current lifecycle state is synchronized immediately. In particular, `OnLoaded` runs once for that current loaded lifetime instead of waiting for the control to unload and load again.
+
 *   **`OnAttached`**: Called when the behavior is attached to an object. Use this method to subscribe to events or initialize the behavior.
 *   **`OnDetaching`**: Called when the behavior is detached from an object. Use this method to unsubscribe from events and clean up resources.
 

--- a/src/Xaml.Behaviors.Interactivity/AvaloniaObject/Behavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/AvaloniaObject/Behavior.cs
@@ -12,6 +12,8 @@ namespace Avalonia.Xaml.Interactivity;
 /// </summary>
 public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandler
 {
+    private bool _isLoaded;
+
     /// <summary>
     /// Identifies the <seealso cref="IsEnabled"/> avalonia property.
     /// </summary>
@@ -64,6 +66,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
     public void Detach()
     {
         OnDetaching();
+        _isLoaded = false;
         AssociatedObject = null;
     }
 
@@ -95,9 +98,27 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
 
     void IBehaviorEventsHandler.DetachedFromLogicalTreeEventHandler() => OnDetachedFromLogicalTree();
 
-    void IBehaviorEventsHandler.LoadedEventHandler() => OnLoaded();
+    void IBehaviorEventsHandler.LoadedEventHandler()
+    {
+        if (_isLoaded)
+        {
+            return;
+        }
 
-    void IBehaviorEventsHandler.UnloadedEventHandler() => OnUnloaded();
+        _isLoaded = true;
+        OnLoaded();
+    }
+
+    void IBehaviorEventsHandler.UnloadedEventHandler()
+    {
+        if (!_isLoaded)
+        {
+            return;
+        }
+
+        _isLoaded = false;
+        OnUnloaded();
+    }
 
     void IBehaviorEventsHandler.InitializedEventHandler() => OnInitializedEvent();
 

--- a/src/Xaml.Behaviors.Interactivity/AvaloniaObject/Behavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/AvaloniaObject/Behavior.cs
@@ -14,6 +14,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
 {
     private bool _isAttachedToLogicalTree;
     private bool _isAttachedToVisualTree;
+    private bool _isInitializedNotified;
     private bool _isLoaded;
 
     /// <summary>
@@ -70,6 +71,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
         OnDetaching();
         _isAttachedToLogicalTree = false;
         _isAttachedToVisualTree = false;
+        _isInitializedNotified = false;
         _isLoaded = false;
         AssociatedObject = null;
     }
@@ -160,7 +162,16 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
         OnUnloaded();
     }
 
-    void IBehaviorEventsHandler.InitializedEventHandler() => OnInitializedEvent();
+    void IBehaviorEventsHandler.InitializedEventHandler()
+    {
+        if (_isInitializedNotified)
+        {
+            return;
+        }
+
+        _isInitializedNotified = true;
+        OnInitializedEvent();
+    }
 
     void IBehaviorEventsHandler.DataContextChangedEventHandler() => OnDataContextChangedEvent();
 

--- a/src/Xaml.Behaviors.Interactivity/AvaloniaObject/Behavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/AvaloniaObject/Behavior.cs
@@ -12,6 +12,8 @@ namespace Avalonia.Xaml.Interactivity;
 /// </summary>
 public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandler
 {
+    private bool _isAttachedToLogicalTree;
+    private bool _isAttachedToVisualTree;
     private bool _isLoaded;
 
     /// <summary>
@@ -66,6 +68,8 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
     public void Detach()
     {
         OnDetaching();
+        _isAttachedToLogicalTree = false;
+        _isAttachedToVisualTree = false;
         _isLoaded = false;
         AssociatedObject = null;
     }
@@ -90,13 +94,49 @@ public abstract class Behavior : AvaloniaObject, IBehavior, IBehaviorEventsHandl
     {
     }
 
-    void IBehaviorEventsHandler.AttachedToVisualTreeEventHandler() => OnAttachedToVisualTree();
+    void IBehaviorEventsHandler.AttachedToVisualTreeEventHandler()
+    {
+        if (_isAttachedToVisualTree)
+        {
+            return;
+        }
 
-    void IBehaviorEventsHandler.DetachedFromVisualTreeEventHandler() => OnDetachedFromVisualTree();
+        _isAttachedToVisualTree = true;
+        OnAttachedToVisualTree();
+    }
 
-    void IBehaviorEventsHandler.AttachedToLogicalTreeEventHandler() => OnAttachedToLogicalTree();
+    void IBehaviorEventsHandler.DetachedFromVisualTreeEventHandler()
+    {
+        if (!_isAttachedToVisualTree)
+        {
+            return;
+        }
 
-    void IBehaviorEventsHandler.DetachedFromLogicalTreeEventHandler() => OnDetachedFromLogicalTree();
+        _isAttachedToVisualTree = false;
+        OnDetachedFromVisualTree();
+    }
+
+    void IBehaviorEventsHandler.AttachedToLogicalTreeEventHandler()
+    {
+        if (_isAttachedToLogicalTree)
+        {
+            return;
+        }
+
+        _isAttachedToLogicalTree = true;
+        OnAttachedToLogicalTree();
+    }
+
+    void IBehaviorEventsHandler.DetachedFromLogicalTreeEventHandler()
+    {
+        if (!_isAttachedToLogicalTree)
+        {
+            return;
+        }
+
+        _isAttachedToLogicalTree = false;
+        OnDetachedFromLogicalTree();
+    }
 
     void IBehaviorEventsHandler.LoadedEventHandler()
     {

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -305,18 +305,20 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         }
 
         var associatedObject = behavior.AssociatedObject;
+        var isOpenTopLevel = associatedObject is TopLevel { IsLoaded: true };
         if (associatedObject is StyledElement { IsInitialized: true })
         {
             eventsHandler.InitializedEventHandler();
         }
 
         if (associatedObject is StyledElement styledElement
-            && ((ILogical)styledElement).IsAttachedToLogicalTree)
+            && (((ILogical)styledElement).IsAttachedToLogicalTree || isOpenTopLevel))
         {
             eventsHandler.AttachedToLogicalTreeEventHandler();
         }
 
-        if (associatedObject is Visual visual && visual.IsAttachedToVisualTree())
+        if (associatedObject is Visual visual
+            && (visual.IsAttachedToVisualTree() || isOpenTopLevel))
         {
             eventsHandler.AttachedToVisualTreeEventHandler();
         }

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -58,18 +58,16 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
         Debug.Assert(associatedObject is not null, "The previous checks should keep us from ever setting null here.");
         AssociatedObject = associatedObject;
+        var behaviors = this.OfType<IBehavior>().ToList();
 
-        foreach (var item in this)
+        foreach (var behavior in behaviors)
         {
-            if (item is IBehavior behavior)
-            {
-                behavior.Attach(AssociatedObject);
-            }
+            behavior.Attach(AssociatedObject);
         }
 
-        foreach (var item in this)
+        foreach (var behavior in behaviors)
         {
-            if (item is IBehavior behavior)
+            if (behavior.AssociatedObject is not null)
             {
                 SynchronizeBehaviorEvents(behavior);
             }
@@ -217,9 +215,20 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
             _oldCollection.Clear();
 
-            foreach (var newItem in this)
+            var attachedBehaviors = new List<IBehavior>(Count);
+            foreach (var newItem in this.ToList())
             {
-                _oldCollection.Add(VerifiedAttach(newItem));
+                var behavior = VerifiedAttach(newItem);
+                _oldCollection.Add(behavior);
+                attachedBehaviors.Add(behavior);
+            }
+
+            foreach (var behavior in attachedBehaviors)
+            {
+                if (behavior.AssociatedObject is not null)
+                {
+                    SynchronizeBehaviorEvents(behavior);
+                }
             }
 #if DEBUG
             VerifyOldCollectionIntegrity();
@@ -233,7 +242,9 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
             {
                 var eventIndex = eventArgs.NewStartingIndex;
                 var changedItem = eventArgs.NewItems?[0] as AvaloniaObject;
-                _oldCollection.Insert(eventIndex, VerifiedAttach(changedItem));
+                var behavior = VerifiedAttach(changedItem);
+                _oldCollection.Insert(eventIndex, behavior);
+                SynchronizeBehaviorEvents(behavior);
                 break;
             }
 
@@ -250,7 +261,9 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
                     oldItem.Detach();
                 }
 
-                _oldCollection[eventIndex] = VerifiedAttach(changedItem);
+                var behavior = VerifiedAttach(changedItem);
+                _oldCollection[eventIndex] = behavior;
+                SynchronizeBehaviorEvents(behavior);
                 break;
             }
 
@@ -298,7 +311,6 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         if (AssociatedObject is not null)
         {
             behavior.Attach(AssociatedObject);
-            SynchronizeBehaviorEvents(behavior);
         }
 
         return behavior;

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -20,7 +20,9 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
     // After a VectorChanged event we need to compare the current state of the collection
     // with the old collection so that we can call Detach on all removed items.
     private readonly List<IBehavior> _oldCollection = [];
+    private readonly List<IBehavior> _pendingSynchronizations = [];
     private bool _isAttachingCollection;
+    private bool _isSynchronizingCollection;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BehaviorCollection"/> class.
@@ -84,13 +86,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
             _isAttachingCollection = false;
         }
 
-        foreach (var behavior in this.OfType<IBehavior>().ToList())
-        {
-            if (behavior.AssociatedObject is not null)
-            {
-                SynchronizeBehaviorEvents(behavior);
-            }
-        }
+        SynchronizeBehaviorEvents(this.OfType<IBehavior>().ToList());
     }
 
     /// <summary>
@@ -244,13 +240,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
             if (!_isAttachingCollection)
             {
-                foreach (var behavior in attachedBehaviors)
-                {
-                    if (behavior.AssociatedObject is not null)
-                    {
-                        SynchronizeBehaviorEvents(behavior);
-                    }
-                }
+                QueueOrSynchronizeBehaviorEvents(attachedBehaviors);
             }
 #if DEBUG
             VerifyOldCollectionIntegrity();
@@ -268,7 +258,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
                 _oldCollection.Insert(eventIndex, behavior);
                 if (!_isAttachingCollection)
                 {
-                    SynchronizeBehaviorEvents(behavior);
+                    QueueOrSynchronizeBehaviorEvents(behavior);
                 }
                 break;
             }
@@ -290,7 +280,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
                 _oldCollection[eventIndex] = behavior;
                 if (!_isAttachingCollection)
                 {
-                    SynchronizeBehaviorEvents(behavior);
+                    QueueOrSynchronizeBehaviorEvents(behavior);
                 }
                 break;
             }
@@ -344,45 +334,121 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         return behavior;
     }
 
-    private static void SynchronizeBehaviorEvents(IBehavior behavior)
+    private void QueueOrSynchronizeBehaviorEvents(IBehavior behavior)
     {
-        if (behavior is not IBehaviorEventsHandler eventsHandler)
+        if (_isSynchronizingCollection)
         {
+            QueuePendingSynchronization(behavior);
             return;
         }
 
-        var associatedObject = behavior.AssociatedObject;
-        var isOpenTopLevel = associatedObject is TopLevel { IsLoaded: true };
-        if (associatedObject is StyledElement { IsInitialized: true })
+        SynchronizeBehaviorEvents([behavior]);
+    }
+
+    private void QueueOrSynchronizeBehaviorEvents(IReadOnlyList<IBehavior> behaviors)
+    {
+        if (_isSynchronizingCollection)
+        {
+            foreach (var behavior in behaviors)
+            {
+                QueuePendingSynchronization(behavior);
+            }
+
+            return;
+        }
+
+        SynchronizeBehaviorEvents(behaviors);
+    }
+
+    private void QueuePendingSynchronization(IBehavior behavior)
+    {
+        if (!_pendingSynchronizations.Contains(behavior))
+        {
+            _pendingSynchronizations.Add(behavior);
+        }
+    }
+
+    private void SynchronizeBehaviorEvents(IReadOnlyList<IBehavior> behaviors)
+    {
+        _isSynchronizingCollection = true;
+        try
+        {
+            var currentBatch = behaviors;
+            while (currentBatch.Count > 0)
+            {
+                foreach (var behavior in currentBatch)
+                {
+                    SynchronizeInitialized(behavior);
+                }
+
+                foreach (var behavior in currentBatch)
+                {
+                    SynchronizeLogicalAttachment(behavior);
+                }
+
+                foreach (var behavior in currentBatch)
+                {
+                    SynchronizeVisualAttachment(behavior);
+                }
+
+                foreach (var behavior in currentBatch)
+                {
+                    SynchronizeLoaded(behavior);
+                }
+
+                if (_pendingSynchronizations.Count == 0)
+                {
+                    break;
+                }
+
+                currentBatch = _pendingSynchronizations.ToList();
+                _pendingSynchronizations.Clear();
+            }
+        }
+        finally
+        {
+            _isSynchronizingCollection = false;
+            _pendingSynchronizations.Clear();
+        }
+    }
+
+    private static void SynchronizeInitialized(IBehavior behavior)
+    {
+        if (behavior is IBehaviorEventsHandler eventsHandler &&
+            behavior.AssociatedObject is StyledElement { IsInitialized: true })
         {
             eventsHandler.InitializedEventHandler();
-            if (!ReferenceEquals(behavior.AssociatedObject, associatedObject))
-            {
-                return;
-            }
         }
+    }
 
-        if (associatedObject is StyledElement styledElement
-            && (((ILogical)styledElement).IsAttachedToLogicalTree || isOpenTopLevel))
+    private static void SynchronizeLogicalAttachment(IBehavior behavior)
+    {
+        var associatedObject = behavior.AssociatedObject;
+        var isOpenTopLevel = associatedObject is TopLevel { IsLoaded: true };
+        if (behavior is IBehaviorEventsHandler eventsHandler &&
+            associatedObject is StyledElement styledElement &&
+            (((ILogical)styledElement).IsAttachedToLogicalTree || isOpenTopLevel))
         {
             eventsHandler.AttachedToLogicalTreeEventHandler();
-            if (!ReferenceEquals(behavior.AssociatedObject, associatedObject))
-            {
-                return;
-            }
         }
+    }
 
-        if (associatedObject is Visual visual
-            && (visual.IsAttachedToVisualTree() || isOpenTopLevel))
+    private static void SynchronizeVisualAttachment(IBehavior behavior)
+    {
+        var associatedObject = behavior.AssociatedObject;
+        var isOpenTopLevel = associatedObject is TopLevel { IsLoaded: true };
+        if (behavior is IBehaviorEventsHandler eventsHandler &&
+            associatedObject is Visual visual &&
+            (visual.IsAttachedToVisualTree() || isOpenTopLevel))
         {
             eventsHandler.AttachedToVisualTreeEventHandler();
-            if (!ReferenceEquals(behavior.AssociatedObject, associatedObject))
-            {
-                return;
-            }
         }
+    }
 
-        if (associatedObject is Control { IsLoaded: true })
+    private static void SynchronizeLoaded(IBehavior behavior)
+    {
+        if (behavior is IBehaviorEventsHandler eventsHandler &&
+            behavior.AssociatedObject is Control { IsLoaded: true })
         {
             eventsHandler.LoadedEventHandler();
         }

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -23,6 +23,10 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
     private readonly List<IBehavior> _pendingSynchronizations = [];
     private bool _isAttachingCollection;
     private bool _isSynchronizingCollection;
+    private bool _hasObservedInitialized;
+    private bool _hasObservedLogicalAttachment;
+    private bool _hasObservedVisualAttachment;
+    private bool _hasObservedLoaded;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BehaviorCollection"/> class.
@@ -87,6 +91,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         }
 
         SynchronizeBehaviorEvents(this.OfType<IBehavior>().ToList());
+        CaptureCurrentLifecycleState();
     }
 
     /// <summary>
@@ -104,40 +109,52 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
         AssociatedObject = null;
         _oldCollection.Clear();
+        _pendingSynchronizations.Clear();
+        _hasObservedInitialized = false;
+        _hasObservedLogicalAttachment = false;
+        _hasObservedVisualAttachment = false;
+        _hasObservedLoaded = false;
     }
 
     internal void AttachedToVisualTree()
     {
+        _hasObservedVisualAttachment = true;
         DispatchBehaviorEvent(static handler => handler.AttachedToVisualTreeEventHandler());
     }
 
     internal void DetachedFromVisualTree()
     {
+        _hasObservedVisualAttachment = false;
         DispatchBehaviorEvent(static handler => handler.DetachedFromVisualTreeEventHandler());
     }
 
     internal void AttachedToLogicalTree()
     {
+        _hasObservedLogicalAttachment = true;
         DispatchBehaviorEvent(static handler => handler.AttachedToLogicalTreeEventHandler());
     }
 
     internal void DetachedFromLogicalTree()
     {
+        _hasObservedLogicalAttachment = false;
         DispatchBehaviorEvent(static handler => handler.DetachedFromLogicalTreeEventHandler());
     }
 
     internal void Loaded()
     {
+        _hasObservedLoaded = true;
         DispatchBehaviorEvent(static handler => handler.LoadedEventHandler());
     }
 
     internal void Unloaded()
     {
+        _hasObservedLoaded = false;
         DispatchBehaviorEvent(static handler => handler.UnloadedEventHandler());
     }
 
     internal void Initialized()
     {
+        _hasObservedInitialized = true;
         DispatchBehaviorEvent(static handler => handler.InitializedEventHandler());
     }
 
@@ -165,7 +182,8 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
             foreach (var item in this.ToList())
             {
                 if (item is IBehaviorEventsHandler behaviorEventsHandler and
-                    IBehavior { AssociatedObject: not null })
+                    IBehavior { AssociatedObject: not null } behavior &&
+                    !_pendingSynchronizations.Contains(behavior))
                 {
                     dispatch(behaviorEventsHandler);
                 }
@@ -303,7 +321,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
     private void QueueOrSynchronizeBehaviorEvents(IBehavior behavior)
     {
-        if (_isSynchronizingCollection)
+        if (_isSynchronizingCollection || HasPendingHostLifecycleEvent())
         {
             QueuePendingSynchronization(behavior);
             return;
@@ -314,7 +332,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
     private void QueueOrSynchronizeBehaviorEvents(IReadOnlyList<IBehavior> behaviors)
     {
-        if (_isSynchronizingCollection)
+        if (_isSynchronizingCollection || HasPendingHostLifecycleEvent())
         {
             foreach (var behavior in behaviors)
             {
@@ -333,6 +351,50 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         {
             _pendingSynchronizations.Add(behavior);
         }
+    }
+
+    private bool HasPendingHostLifecycleEvent()
+    {
+        var associatedObject = AssociatedObject;
+        if (associatedObject is null)
+        {
+            return false;
+        }
+
+        if (!_hasObservedInitialized &&
+            associatedObject is StyledElement { IsInitialized: true })
+        {
+            return true;
+        }
+
+        var isOpenTopLevel = associatedObject is TopLevel { IsLoaded: true };
+        if (!_hasObservedLogicalAttachment &&
+            associatedObject is StyledElement styledElement &&
+            (((ILogical)styledElement).IsAttachedToLogicalTree || isOpenTopLevel))
+        {
+            return true;
+        }
+
+        if (!_hasObservedVisualAttachment &&
+            associatedObject is Visual visual &&
+            (visual.IsAttachedToVisualTree() || isOpenTopLevel))
+        {
+            return true;
+        }
+
+        return !_hasObservedLoaded && associatedObject is Control { IsLoaded: true };
+    }
+
+    private void CaptureCurrentLifecycleState()
+    {
+        var associatedObject = AssociatedObject;
+        var isOpenTopLevel = associatedObject is TopLevel { IsLoaded: true };
+        _hasObservedInitialized = associatedObject is StyledElement { IsInitialized: true };
+        _hasObservedLogicalAttachment = associatedObject is StyledElement styledElement &&
+                                        (((ILogical)styledElement).IsAttachedToLogicalTree || isOpenTopLevel);
+        _hasObservedVisualAttachment = associatedObject is Visual visual &&
+                                       (visual.IsAttachedToVisualTree() || isOpenTopLevel);
+        _hasObservedLoaded = associatedObject is Control { IsLoaded: true };
     }
 
     private void SynchronizeBehaviorEvents(IReadOnlyList<IBehavior> behaviors)

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -173,6 +173,27 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         DispatchBehaviorEvent(static handler => handler.ActualThemeVariantChangedEventHandler());
     }
 
+    internal void Opened()
+    {
+        var wasSynchronizingCollection = _isSynchronizingCollection;
+        _isSynchronizingCollection = true;
+        try
+        {
+            AttachedToVisualTree();
+            AttachedToLogicalTree();
+        }
+        finally
+        {
+            _isSynchronizingCollection = wasSynchronizingCollection;
+            if (!wasSynchronizingCollection && _pendingSynchronizations.Count > 0)
+            {
+                var pending = _pendingSynchronizations.ToList();
+                _pendingSynchronizations.Clear();
+                SynchronizeBehaviorEvents(pending);
+            }
+        }
+    }
+
     private void DispatchBehaviorEvent(Action<IBehaviorEventsHandler> dispatch)
     {
         var wasSynchronizingCollection = _isSynchronizingCollection;

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -392,23 +392,57 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
     private void DrainPendingSynchronizations(List<IBehavior> currentBatch, int currentPhase)
     {
-        while (_pendingSynchronizations.Count > 0)
+        var catchUpBatch = new List<(IBehavior Behavior, int NextPhase)>();
+        while (true)
         {
-            var pending = _pendingSynchronizations.ToList();
-            _pendingSynchronizations.Clear();
-
-            foreach (var behavior in pending)
+            if (_pendingSynchronizations.Count > 0)
             {
-                if (!currentBatch.Contains(behavior))
+                var pending = _pendingSynchronizations.ToList();
+                _pendingSynchronizations.Clear();
+                foreach (var behavior in pending)
                 {
-                    currentBatch.Add(behavior);
-                }
+                    if (!currentBatch.Contains(behavior))
+                    {
+                        currentBatch.Add(behavior);
+                    }
 
-                for (var phase = 0; phase <= currentPhase; phase++)
-                {
-                    SynchronizePhase(behavior, phase);
+                    var isAlreadyQueued = false;
+                    for (var index = 0; index < catchUpBatch.Count; index++)
+                    {
+                        if (ReferenceEquals(catchUpBatch[index].Behavior, behavior))
+                        {
+                            isAlreadyQueued = true;
+                            break;
+                        }
+                    }
+
+                    if (!isAlreadyQueued)
+                    {
+                        catchUpBatch.Add((behavior, 0));
+                    }
                 }
             }
+
+            var nextIndex = -1;
+            var nextPhase = int.MaxValue;
+            for (var index = 0; index < catchUpBatch.Count; index++)
+            {
+                var candidatePhase = catchUpBatch[index].NextPhase;
+                if (candidatePhase <= currentPhase && candidatePhase < nextPhase)
+                {
+                    nextIndex = index;
+                    nextPhase = candidatePhase;
+                }
+            }
+
+            if (nextIndex < 0)
+            {
+                return;
+            }
+
+            var next = catchUpBatch[nextIndex];
+            SynchronizePhase(next.Behavior, next.NextPhase);
+            catchUpBatch[nextIndex] = (next.Behavior, next.NextPhase + 1);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -20,6 +20,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
     // After a VectorChanged event we need to compare the current state of the collection
     // with the old collection so that we can call Detach on all removed items.
     private readonly List<IBehavior> _oldCollection = [];
+    private bool _isAttachingCollection;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BehaviorCollection"/> class.
@@ -59,24 +60,31 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         Debug.Assert(associatedObject is not null, "The previous checks should keep us from ever setting null here.");
         AssociatedObject = associatedObject;
         var behaviors = this.OfType<IBehavior>().ToList();
-
-        foreach (var behavior in behaviors)
+        _isAttachingCollection = true;
+        try
         {
-            var associatedObjectForAttach = AssociatedObject;
-            if (associatedObjectForAttach is null)
+            foreach (var behavior in behaviors)
             {
-                break;
-            }
+                var associatedObjectForAttach = AssociatedObject;
+                if (associatedObjectForAttach is null)
+                {
+                    break;
+                }
 
-            if (behavior is not AvaloniaObject behaviorObject || !Contains(behaviorObject))
-            {
-                continue;
-            }
+                if (behavior is not AvaloniaObject behaviorObject || !Contains(behaviorObject))
+                {
+                    continue;
+                }
 
-            behavior.Attach(associatedObjectForAttach);
+                behavior.Attach(associatedObjectForAttach);
+            }
+        }
+        finally
+        {
+            _isAttachingCollection = false;
         }
 
-        foreach (var behavior in behaviors)
+        foreach (var behavior in this.OfType<IBehavior>().ToList())
         {
             if (behavior.AssociatedObject is not null)
             {
@@ -234,11 +242,14 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
                 attachedBehaviors.Add(behavior);
             }
 
-            foreach (var behavior in attachedBehaviors)
+            if (!_isAttachingCollection)
             {
-                if (behavior.AssociatedObject is not null)
+                foreach (var behavior in attachedBehaviors)
                 {
-                    SynchronizeBehaviorEvents(behavior);
+                    if (behavior.AssociatedObject is not null)
+                    {
+                        SynchronizeBehaviorEvents(behavior);
+                    }
                 }
             }
 #if DEBUG
@@ -255,7 +266,10 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
                 var changedItem = eventArgs.NewItems?[0] as AvaloniaObject;
                 var behavior = VerifiedAttach(changedItem);
                 _oldCollection.Insert(eventIndex, behavior);
-                SynchronizeBehaviorEvents(behavior);
+                if (!_isAttachingCollection)
+                {
+                    SynchronizeBehaviorEvents(behavior);
+                }
                 break;
             }
 
@@ -274,7 +288,10 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
                 var behavior = VerifiedAttach(changedItem);
                 _oldCollection[eventIndex] = behavior;
-                SynchronizeBehaviorEvents(behavior);
+                if (!_isAttachingCollection)
+                {
+                    SynchronizeBehaviorEvents(behavior);
+                }
                 break;
             }
 

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -62,7 +62,18 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
         foreach (var behavior in behaviors)
         {
-            behavior.Attach(AssociatedObject);
+            var associatedObjectForAttach = AssociatedObject;
+            if (associatedObjectForAttach is null)
+            {
+                break;
+            }
+
+            if (behavior is not AvaloniaObject behaviorObject || !Contains(behaviorObject))
+            {
+                continue;
+            }
+
+            behavior.Attach(associatedObjectForAttach);
         }
 
         foreach (var behavior in behaviors)

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -328,18 +328,30 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         if (associatedObject is StyledElement { IsInitialized: true })
         {
             eventsHandler.InitializedEventHandler();
+            if (!ReferenceEquals(behavior.AssociatedObject, associatedObject))
+            {
+                return;
+            }
         }
 
         if (associatedObject is StyledElement styledElement
             && (((ILogical)styledElement).IsAttachedToLogicalTree || isOpenTopLevel))
         {
             eventsHandler.AttachedToLogicalTreeEventHandler();
+            if (!ReferenceEquals(behavior.AssociatedObject, associatedObject))
+            {
+                return;
+            }
         }
 
         if (associatedObject is Visual visual
             && (visual.IsAttachedToVisualTree() || isOpenTopLevel))
         {
             eventsHandler.AttachedToVisualTreeEventHandler();
+            if (!ReferenceEquals(behavior.AssociatedObject, associatedObject))
+            {
+                return;
+            }
         }
 
         if (associatedObject is Control { IsLoaded: true })

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -108,114 +108,81 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
 
     internal void AttachedToVisualTree()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.AttachedToVisualTreeEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.AttachedToVisualTreeEventHandler());
     }
 
     internal void DetachedFromVisualTree()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.DetachedFromVisualTreeEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.DetachedFromVisualTreeEventHandler());
     }
 
     internal void AttachedToLogicalTree()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.AttachedToLogicalTreeEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.AttachedToLogicalTreeEventHandler());
     }
 
     internal void DetachedFromLogicalTree()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.DetachedFromLogicalTreeEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.DetachedFromLogicalTreeEventHandler());
     }
 
     internal void Loaded()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.LoadedEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.LoadedEventHandler());
     }
 
     internal void Unloaded()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.UnloadedEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.UnloadedEventHandler());
     }
 
     internal void Initialized()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.InitializedEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.InitializedEventHandler());
     }
 
     internal void DataContextChanged()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.DataContextChangedEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.DataContextChangedEventHandler());
     }
 
     internal void ResourcesChanged()
     {
-        foreach (var item in this.ToList())
-        {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
-            {
-                behaviorEventsHandler.ResourcesChangedEventHandler();
-            }
-        }
+        DispatchBehaviorEvent(static handler => handler.ResourcesChangedEventHandler());
     }
 
     internal void ActualThemeVariantChanged()
     {
-        foreach (var item in this.ToList())
+        DispatchBehaviorEvent(static handler => handler.ActualThemeVariantChangedEventHandler());
+    }
+
+    private void DispatchBehaviorEvent(Action<IBehaviorEventsHandler> dispatch)
+    {
+        var wasSynchronizingCollection = _isSynchronizingCollection;
+        _isSynchronizingCollection = true;
+        try
         {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
+            foreach (var item in this.ToList())
             {
-                behaviorEventsHandler.ActualThemeVariantChangedEventHandler();
+                if (item is IBehaviorEventsHandler behaviorEventsHandler and
+                    IBehavior { AssociatedObject: not null })
+                {
+                    dispatch(behaviorEventsHandler);
+                }
+            }
+        }
+        finally
+        {
+            _isSynchronizingCollection = wasSynchronizingCollection;
+            if (!wasSynchronizingCollection && _pendingSynchronizations.Count > 0)
+            {
+                var pending = _pendingSynchronizations.ToList();
+                _pendingSynchronizations.Clear();
+                SynchronizeBehaviorEvents(pending);
             }
         }
     }
-    
+
     private void BehaviorCollection_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
     {
         if (eventArgs.Action == NotifyCollectionChangedAction.Reset)

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -373,42 +373,61 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         _isSynchronizingCollection = true;
         try
         {
-            var currentBatch = behaviors;
-            while (currentBatch.Count > 0)
+            var currentBatch = behaviors.ToList();
+            for (var phase = 0; phase < 4; phase++)
             {
-                foreach (var behavior in currentBatch)
+                for (var index = 0; index < currentBatch.Count; index++)
                 {
-                    SynchronizeInitialized(behavior);
+                    SynchronizePhase(currentBatch[index], phase);
+                    DrainPendingSynchronizations(currentBatch, phase);
                 }
-
-                foreach (var behavior in currentBatch)
-                {
-                    SynchronizeLogicalAttachment(behavior);
-                }
-
-                foreach (var behavior in currentBatch)
-                {
-                    SynchronizeVisualAttachment(behavior);
-                }
-
-                foreach (var behavior in currentBatch)
-                {
-                    SynchronizeLoaded(behavior);
-                }
-
-                if (_pendingSynchronizations.Count == 0)
-                {
-                    break;
-                }
-
-                currentBatch = _pendingSynchronizations.ToList();
-                _pendingSynchronizations.Clear();
             }
         }
         finally
         {
             _isSynchronizingCollection = false;
             _pendingSynchronizations.Clear();
+        }
+    }
+
+    private void DrainPendingSynchronizations(List<IBehavior> currentBatch, int currentPhase)
+    {
+        while (_pendingSynchronizations.Count > 0)
+        {
+            var pending = _pendingSynchronizations.ToList();
+            _pendingSynchronizations.Clear();
+
+            foreach (var behavior in pending)
+            {
+                if (!currentBatch.Contains(behavior))
+                {
+                    currentBatch.Add(behavior);
+                }
+
+                for (var phase = 0; phase <= currentPhase; phase++)
+                {
+                    SynchronizePhase(behavior, phase);
+                }
+            }
+        }
+    }
+
+    private static void SynchronizePhase(IBehavior behavior, int phase)
+    {
+        switch (phase)
+        {
+            case 0:
+                SynchronizeInitialized(behavior);
+                break;
+            case 1:
+                SynchronizeLogicalAttachment(behavior);
+                break;
+            case 2:
+                SynchronizeVisualAttachment(behavior);
+                break;
+            case 3:
+                SynchronizeLoaded(behavior);
+                break;
         }
     }
 

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -64,6 +64,13 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
             if (item is IBehavior behavior)
             {
                 behavior.Attach(AssociatedObject);
+            }
+        }
+
+        foreach (var item in this)
+        {
+            if (item is IBehavior behavior)
+            {
                 SynchronizeBehaviorEvents(behavior);
             }
         }

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -114,7 +114,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
     {
         foreach (var item in this.ToList())
         {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler)
+            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
             {
                 behaviorEventsHandler.AttachedToVisualTreeEventHandler();
             }
@@ -136,7 +136,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
     {
         foreach (var item in this.ToList())
         {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler)
+            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
             {
                 behaviorEventsHandler.AttachedToLogicalTreeEventHandler();
             }
@@ -158,7 +158,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
     {
         foreach (var item in this.ToList())
         {
-            if (item is IBehaviorEventsHandler behaviorEventsHandler)
+            if (item is IBehaviorEventsHandler behaviorEventsHandler and IBehavior { AssociatedObject: not null })
             {
                 behaviorEventsHandler.LoadedEventHandler();
             }

--- a/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
+++ b/src/Xaml.Behaviors.Interactivity/Collections/BehaviorCollection.cs
@@ -6,6 +6,9 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -61,6 +64,7 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
             if (item is IBehavior behavior)
             {
                 behavior.Attach(AssociatedObject);
+                SynchronizeBehaviorEvents(behavior);
             }
         }
     }
@@ -287,9 +291,40 @@ public class BehaviorCollection : AvaloniaList<AvaloniaObject>
         if (AssociatedObject is not null)
         {
             behavior.Attach(AssociatedObject);
+            SynchronizeBehaviorEvents(behavior);
         }
 
         return behavior;
+    }
+
+    private static void SynchronizeBehaviorEvents(IBehavior behavior)
+    {
+        if (behavior is not IBehaviorEventsHandler eventsHandler)
+        {
+            return;
+        }
+
+        var associatedObject = behavior.AssociatedObject;
+        if (associatedObject is StyledElement { IsInitialized: true })
+        {
+            eventsHandler.InitializedEventHandler();
+        }
+
+        if (associatedObject is StyledElement styledElement
+            && ((ILogical)styledElement).IsAttachedToLogicalTree)
+        {
+            eventsHandler.AttachedToLogicalTreeEventHandler();
+        }
+
+        if (associatedObject is Visual visual && visual.IsAttachedToVisualTree())
+        {
+            eventsHandler.AttachedToVisualTreeEventHandler();
+        }
+
+        if (associatedObject is Control { IsLoaded: true })
+        {
+            eventsHandler.LoadedEventHandler();
+        }
     }
 
     [Conditional("DEBUG")]

--- a/src/Xaml.Behaviors.Interactivity/Interaction.cs
+++ b/src/Xaml.Behaviors.Interactivity/Interaction.cs
@@ -113,8 +113,8 @@ public class Interaction
 
         if (newCollection is not null)
         {
-            newCollection.Attach(e.Sender);
             SetVisualTreeEventHandlersFromChangedEvent(e.Sender);
+            newCollection.Attach(e.Sender);
         }
     }
 

--- a/src/Xaml.Behaviors.Interactivity/Interaction.cs
+++ b/src/Xaml.Behaviors.Interactivity/Interaction.cs
@@ -484,8 +484,7 @@ public class Interaction
         }
 
         GetBehaviors(d).Attach(d);
-        GetBehaviors(d).AttachedToVisualTree();
-        GetBehaviors(d).AttachedToLogicalTree();
+        GetBehaviors(d).Opened();
     }
 
     private static void TopLevel_Opened_FromChangedEvent(object? sender, EventArgs e)
@@ -495,7 +494,6 @@ public class Interaction
             return;
         }
 
-        GetBehaviors(d).AttachedToVisualTree();
-        GetBehaviors(d).AttachedToLogicalTree();
+        GetBehaviors(d).Opened();
     }
 }

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Xaml.Interactivity;
 public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehaviorEventsHandler
 {
     private IDisposable? _dataContextDisposable;
+    private bool _isLoaded;
 
     /// <summary>
     /// Identifies the <seealso cref="IsEnabled"/> avalonia property.
@@ -86,6 +87,7 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
         }
 
         _dataContextDisposable?.Dispose();
+        _isLoaded = false;
         AssociatedObject = null;
     }
 
@@ -137,9 +139,27 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
         OnDetachedFromLogicalTree();
     }
 
-    void IBehaviorEventsHandler.LoadedEventHandler() => OnLoaded();
+    void IBehaviorEventsHandler.LoadedEventHandler()
+    {
+        if (_isLoaded)
+        {
+            return;
+        }
 
-    void IBehaviorEventsHandler.UnloadedEventHandler() => OnUnloaded();
+        _isLoaded = true;
+        OnLoaded();
+    }
+
+    void IBehaviorEventsHandler.UnloadedEventHandler()
+    {
+        if (!_isLoaded)
+        {
+            return;
+        }
+
+        _isLoaded = false;
+        OnUnloaded();
+    }
 
     void IBehaviorEventsHandler.InitializedEventHandler()
     {

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -14,6 +14,8 @@ namespace Avalonia.Xaml.Interactivity;
 public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehaviorEventsHandler
 {
     private IDisposable? _dataContextDisposable;
+    private bool _isAttachedToLogicalTree;
+    private bool _isAttachedToVisualTree;
     private bool _isLoaded;
 
     /// <summary>
@@ -87,6 +89,8 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
         }
 
         _dataContextDisposable?.Dispose();
+        _isAttachedToLogicalTree = false;
+        _isAttachedToVisualTree = false;
         _isLoaded = false;
         AssociatedObject = null;
     }
@@ -113,6 +117,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.AttachedToVisualTreeEventHandler()
     {
+        if (_isAttachedToVisualTree)
+        {
+            return;
+        }
+
+        _isAttachedToVisualTree = true;
         AttachBehaviorToLogicalTree();
 
         OnAttachedToVisualTree();
@@ -120,6 +130,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.DetachedFromVisualTreeEventHandler()
     {
+        if (!_isAttachedToVisualTree)
+        {
+            return;
+        }
+
+        _isAttachedToVisualTree = false;
         DetachBehaviorFromLogicalTree();
 
         OnDetachedFromVisualTree();
@@ -127,6 +143,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.AttachedToLogicalTreeEventHandler()
     {
+        if (_isAttachedToLogicalTree)
+        {
+            return;
+        }
+
+        _isAttachedToLogicalTree = true;
         AttachBehaviorToLogicalTree();
 
         OnAttachedToLogicalTree();
@@ -134,6 +156,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.DetachedFromLogicalTreeEventHandler()
     {
+        if (!_isAttachedToLogicalTree)
+        {
+            return;
+        }
+
+        _isAttachedToLogicalTree = false;
         DetachBehaviorFromLogicalTree();
 
         OnDetachedFromLogicalTree();

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -16,6 +16,7 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
     private IDisposable? _dataContextDisposable;
     private bool _isAttachedToLogicalTree;
     private bool _isAttachedToVisualTree;
+    private bool _isInitializedNotified;
     private bool _isLoaded;
 
     /// <summary>
@@ -91,6 +92,7 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
         _dataContextDisposable?.Dispose();
         _isAttachedToLogicalTree = false;
         _isAttachedToVisualTree = false;
+        _isInitializedNotified = false;
         _isLoaded = false;
         AssociatedObject = null;
     }
@@ -191,6 +193,12 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.InitializedEventHandler()
     {
+        if (_isInitializedNotified)
+        {
+            return;
+        }
+
+        _isInitializedNotified = true;
         Initialize();
 
         OnInitializedEvent();

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -261,6 +261,39 @@ public class InteractionTest
         }
     }
 
+    private sealed class RecordingTopLevelPhaseTrigger(
+        string name,
+        List<string> eventOrder,
+        AvaloniaObject? siblingToAdd = null) : StyledElementTrigger<TopLevel>
+    {
+        private bool _addSiblingOnNextVisual;
+
+        public void ArmVisualAddition()
+        {
+            _addSiblingOnNextVisual = true;
+        }
+
+        protected override void OnAttachedToLogicalTree()
+        {
+            eventOrder.Add($"{name}-Logical");
+        }
+
+        protected override void OnAttachedToVisualTree()
+        {
+            eventOrder.Add($"{name}-Visual");
+            if (_addSiblingOnNextVisual && siblingToAdd is not null && AssociatedObject is not null)
+            {
+                _addSiblingOnNextVisual = false;
+                Interaction.GetBehaviors(AssociatedObject).Add(siblingToAdd);
+            }
+        }
+
+        protected override void OnLoaded()
+        {
+            eventOrder.Add($"{name}-Loaded");
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -667,6 +700,33 @@ public class InteractionTest
         Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(["A", "C", "B"], eventOrder);
+        Assert.Contains(added, behaviors);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void TopLevelOpened_Replays_Visual_Addition_After_Existing_Logical_Phase()
+    {
+        var eventOrder = new List<string>();
+        var window = new Window();
+        var added = new RecordingTopLevelPhaseTrigger("B", eventOrder);
+        var first = new RecordingTopLevelPhaseTrigger("A", eventOrder, added);
+        var laterExisting = new RecordingTopLevelPhaseTrigger("C", eventOrder);
+        var behaviors = new BehaviorCollection { first, laterExisting };
+        Interaction.SetBehaviors(window, behaviors);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        eventOrder.Clear();
+        behaviors.DetachedFromVisualTree();
+        behaviors.DetachedFromLogicalTree();
+        first.ArmVisualAddition();
+
+        behaviors.Opened();
+
+        Assert.Equal(
+            ["A-Visual", "C-Visual", "A-Logical", "C-Logical", "B-Logical", "B-Visual", "B-Loaded"],
+            eventOrder);
         Assert.Contains(added, behaviors);
         window.Close();
     }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -223,6 +224,21 @@ public class InteractionTest
             if (AssociatedObject is not null)
             {
                 Interaction.GetBehaviors(AssociatedObject).Remove(sibling);
+            }
+        }
+    }
+
+    private sealed class RecordingLoadedTrigger(
+        string name,
+        List<string> eventOrder,
+        AvaloniaObject? siblingToAdd = null) : StyledElementTrigger<Button>
+    {
+        protected override void OnLoaded()
+        {
+            eventOrder.Add(name);
+            if (siblingToAdd is not null && AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Add(siblingToAdd);
             }
         }
     }
@@ -571,6 +587,26 @@ public class InteractionTest
         Dispatcher.UIThread.RunJobs();
 
         AssertCurrentLifecycle(trigger, button);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void LoadedDispatch_Replays_Additions_After_Existing_Siblings()
+    {
+        var eventOrder = new List<string>();
+        var added = new RecordingLoadedTrigger("B", eventOrder);
+        var first = new RecordingLoadedTrigger("A", eventOrder, added);
+        var laterExisting = new RecordingLoadedTrigger("C", eventOrder);
+        var button = new Button();
+        var behaviors = new BehaviorCollection { first, laterExisting };
+        Interaction.SetBehaviors(button, behaviors);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(["A", "C", "B"], eventOrder);
+        Assert.Contains(added, behaviors);
         window.Close();
     }
 

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -323,6 +323,23 @@ public class InteractionTest
     }
 
     [AvaloniaFact]
+    public void AddBehaviorFromEarlierLoadedHandler_NotifiesLoadedOnce()
+    {
+        var button = new Button();
+        BehaviorCollection? behaviors = null;
+        var trigger = new LoadedTrigger();
+        button.Loaded += (_, _) => behaviors!.Add(trigger);
+        behaviors = Interaction.GetBehaviors(button);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        AssertCurrentLifecycle(trigger, button);
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void AddBehaviorAfterShow_AllowsBehaviorToRemoveItselfDuringLoaded()
     {
         var button = new Button();

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -149,6 +149,17 @@ public class InteractionTest
         }
     }
 
+    private sealed class SiblingRemovingLoadedTrigger(AvaloniaObject sibling) : StyledElementTrigger<Button>
+    {
+        protected override void OnLoaded()
+        {
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Remove(sibling);
+            }
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -433,6 +444,29 @@ public class InteractionTest
         Dispatcher.UIThread.RunJobs();
 
         AssertCurrentLifecycle(trigger, button);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void LoadedDispatch_Does_Not_Notify_Removed_Sibling_After_Detach()
+    {
+        var button = new Button();
+        var removedTrigger = new LoadedTrigger();
+        var remover = new SiblingRemovingLoadedTrigger(removedTrigger);
+        var behaviors = new BehaviorCollection { remover, removedTrigger };
+        Interaction.SetBehaviors(button, behaviors);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, removedTrigger.LoadedCount);
+        Assert.Null(removedTrigger.AssociatedObject);
+
+        behaviors.Add(removedTrigger);
+
+        Assert.Equal(1, removedTrigger.LoadedCount);
+        Assert.Same(button, removedTrigger.AssociatedObject);
         window.Close();
     }
 

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -137,6 +137,18 @@ public class InteractionTest
         }
     }
 
+    private sealed class SiblingAddingBehavior(AvaloniaObject sibling) : Behavior<Button>
+    {
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Add(sibling);
+            }
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -347,6 +359,26 @@ public class InteractionTest
 
         Interaction.SetBehaviors(button, new BehaviorCollection { trigger, sibling });
 
+        Assert.True(trigger.SiblingWasAttachedWhenLoaded);
+        Assert.Same(button, sibling.AssociatedObject);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_Defers_Reentrant_Add_Replay_Until_All_Siblings_Attach()
+    {
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var sibling = new StubBehavior();
+        var trigger = new SiblingAwareLoadedTrigger(sibling);
+        var adder = new SiblingAddingBehavior(trigger);
+        var behaviors = new BehaviorCollection { adder, sibling };
+
+        Interaction.SetBehaviors(button, behaviors);
+
+        Assert.Contains(trigger, behaviors);
         Assert.True(trigger.SiblingWasAttachedWhenLoaded);
         Assert.Same(button, sibling.AssociatedObject);
         window.Close();

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -174,6 +174,48 @@ public class InteractionTest
         }
     }
 
+    private sealed class SiblingAddingVisualTrigger(AvaloniaObject sibling) : StyledElementTrigger<Button>
+    {
+        protected override void OnAttachedToVisualTree()
+        {
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Add(sibling);
+            }
+        }
+    }
+
+    private sealed class NestedSiblingAddingInitializedTrigger(LoadedTrigger sibling) : StyledElementTrigger<Button>
+    {
+        public bool SiblingCompletedEachEarlierPhase { get; private set; } = true;
+        public int LogicalCheckCount { get; private set; }
+        public int VisualCheckCount { get; private set; }
+
+        protected override void OnInitializedEvent()
+        {
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Add(sibling);
+            }
+        }
+
+        protected override void OnAttachedToLogicalTree()
+        {
+            LogicalCheckCount++;
+            SiblingCompletedEachEarlierPhase &=
+                sibling.InitializedCount == 1 && sibling.LogicalAttachCount == 0;
+        }
+
+        protected override void OnAttachedToVisualTree()
+        {
+            VisualCheckCount++;
+            SiblingCompletedEachEarlierPhase &=
+                sibling.InitializedCount == 1 &&
+                sibling.LogicalAttachCount == 1 &&
+                sibling.VisualAttachCount == 0;
+        }
+    }
+
     private sealed class SiblingRemovingLoadedTrigger(AvaloniaObject sibling) : StyledElementTrigger<Button>
     {
         protected override void OnLoaded()
@@ -434,6 +476,29 @@ public class InteractionTest
         Assert.Contains(added, behaviors);
         Assert.True(observer.SiblingCompletedEarlierPhasesWhenLoaded);
         Assert.Equal(1, added.LoadedCount);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_Catches_Up_Nested_Additions_Between_Replayed_Phases()
+    {
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var nested = new LoadedTrigger();
+        var firstAddition = new NestedSiblingAddingInitializedTrigger(nested);
+        var visualAdder = new SiblingAddingVisualTrigger(firstAddition);
+        var behaviors = new BehaviorCollection { visualAdder };
+
+        Interaction.SetBehaviors(button, behaviors);
+
+        Assert.Contains(firstAddition, behaviors);
+        Assert.Contains(nested, behaviors);
+        Assert.True(firstAddition.SiblingCompletedEachEarlierPhase);
+        Assert.Equal(1, firstAddition.LogicalCheckCount);
+        Assert.Equal(1, firstAddition.VisualCheckCount);
+        AssertCurrentLifecycle(nested, button);
         window.Close();
     }
 

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -163,6 +163,17 @@ public class InteractionTest
         }
     }
 
+    private sealed class SiblingAddingInitializedTrigger(AvaloniaObject sibling) : StyledElementTrigger<Button>
+    {
+        protected override void OnInitializedEvent()
+        {
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Add(sibling);
+            }
+        }
+    }
+
     private sealed class SiblingRemovingLoadedTrigger(AvaloniaObject sibling) : StyledElementTrigger<Button>
     {
         protected override void OnLoaded()
@@ -403,6 +414,26 @@ public class InteractionTest
 
         Assert.True(observer.SiblingCompletedEarlierPhasesWhenLoaded);
         Assert.Equal(1, sibling.LoadedCount);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_Catches_Up_Reentrant_Additions_Before_Later_Phases()
+    {
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var added = new LoadedTrigger();
+        var adder = new SiblingAddingInitializedTrigger(added);
+        var observer = new LifecycleAwareLoadedTrigger(added);
+        var behaviors = new BehaviorCollection { adder, observer };
+
+        Interaction.SetBehaviors(button, behaviors);
+
+        Assert.Contains(added, behaviors);
+        Assert.True(observer.SiblingCompletedEarlierPhasesWhenLoaded);
+        Assert.Equal(1, added.LoadedCount);
         window.Close();
     }
 

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -74,6 +74,20 @@ public class InteractionTest
         }
     }
 
+    private sealed class SelfRemovingLoadedTrigger : StyledElementTrigger<Button>
+    {
+        public int LoadedCount { get; private set; }
+
+        protected override void OnLoaded()
+        {
+            LoadedCount++;
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Remove(this);
+            }
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -274,6 +288,26 @@ public class InteractionTest
     }
 
     [AvaloniaFact]
+    public void SetBehaviorsAfterShow_AllowsLifecycleCallbackToRemoveBehavior()
+    {
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var trigger = new SelfRemovingLoadedTrigger();
+        var sibling = new StubBehavior();
+        var behaviors = new BehaviorCollection { trigger, sibling };
+
+        Interaction.SetBehaviors(button, behaviors);
+
+        Assert.Equal(1, trigger.LoadedCount);
+        Assert.DoesNotContain(trigger, behaviors);
+        Assert.Null(trigger.AssociatedObject);
+        Assert.Same(button, sibling.AssociatedObject);
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void AddBehaviorAfterShow_NotifiesLoadedOnce()
     {
         var button = new Button();
@@ -286,6 +320,25 @@ public class InteractionTest
         behaviors.Add(trigger);
 
         AssertCurrentLifecycle(trigger, button);
+    }
+
+    [AvaloniaFact]
+    public void AddBehaviorAfterShow_AllowsBehaviorToRemoveItselfDuringLoaded()
+    {
+        var button = new Button();
+        var behaviors = Interaction.GetBehaviors(button);
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var trigger = new SelfRemovingLoadedTrigger();
+
+        behaviors.Add(trigger);
+
+        Assert.Equal(1, trigger.LoadedCount);
+        Assert.DoesNotContain(trigger, behaviors);
+        Assert.Null(trigger.AssociatedObject);
+        Assert.Empty(behaviors);
+        window.Close();
     }
 
     [AvaloniaFact]

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -340,6 +340,23 @@ public class InteractionTest
     }
 
     [AvaloniaFact]
+    public void AddBehaviorFromEarlierVisualAttachHandler_NotifiesLifecycleOnce()
+    {
+        var button = new Button();
+        BehaviorCollection? behaviors = null;
+        var trigger = new LoadedTrigger();
+        button.AttachedToVisualTree += (_, _) => behaviors!.Add(trigger);
+        behaviors = Interaction.GetBehaviors(button);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        AssertCurrentLifecycle(trigger, button);
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void AddBehaviorAfterShow_AllowsBehaviorToRemoveItselfDuringLoaded()
     {
         var button = new Button();

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -1,12 +1,50 @@
 ﻿using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Xunit;
 
 namespace Avalonia.Xaml.Interactivity.UnitTests;
 
 public class InteractionTest
 {
+    private sealed class LoadedTrigger : StyledElementTrigger<Button>
+    {
+        public int InitializedCount { get; private set; }
+        public int LogicalAttachCount { get; private set; }
+        public int VisualAttachCount { get; private set; }
+        public int LoadedCount { get; private set; }
+
+        protected override void OnInitializedEvent()
+        {
+            InitializedCount++;
+        }
+
+        protected override void OnAttachedToLogicalTree()
+        {
+            LogicalAttachCount++;
+        }
+
+        protected override void OnAttachedToVisualTree()
+        {
+            VisualAttachCount++;
+        }
+
+        protected override void OnLoaded()
+        {
+            LoadedCount++;
+        }
+    }
+
+    private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
+    {
+        Assert.Equal(1, trigger.InitializedCount);
+        Assert.Equal(1, trigger.LogicalAttachCount);
+        Assert.Equal(1, trigger.VisualAttachCount);
+        Assert.Equal(1, trigger.LoadedCount);
+        Assert.Same(button, trigger.Parent);
+    }
+
     [AvaloniaFact]
     public void SetBehaviors_MultipleBehaviors_AllAttached()
     {
@@ -150,5 +188,48 @@ public class InteractionTest
         {
             Assert.Equal(expectedReturnValues[resultIndex], results[resultIndex]); // "Results should be returned in the order of the actions in the ActionCollection."
         }
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsBeforeShow_NotifiesLoadedOnce()
+    {
+        var trigger = new LoadedTrigger();
+        var button = new Button();
+        Interaction.SetBehaviors(button, new BehaviorCollection { trigger });
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        AssertCurrentLifecycle(trigger, button);
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_NotifiesLoadedOnce()
+    {
+        var trigger = new LoadedTrigger();
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Interaction.SetBehaviors(button, new BehaviorCollection { trigger });
+
+        AssertCurrentLifecycle(trigger, button);
+    }
+
+    [AvaloniaFact]
+    public void AddBehaviorAfterShow_NotifiesLoadedOnce()
+    {
+        var button = new Button();
+        var behaviors = Interaction.GetBehaviors(button);
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var trigger = new LoadedTrigger();
+
+        behaviors.Add(trigger);
+
+        AssertCurrentLifecycle(trigger, button);
     }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -125,6 +125,18 @@ public class InteractionTest
         }
     }
 
+    private sealed class SiblingRemovingBehavior(AvaloniaObject sibling) : Behavior<Button>
+    {
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Remove(sibling);
+            }
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -153,6 +165,22 @@ public class InteractionTest
             Assert.Equal(0, behavior.DetachCount); // "Should not have called Detach."
             Assert.Equal(button, behavior.AssociatedObject); // "Should be attached to the host of the BehaviorCollection."
         }
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviors_OnAttachedRemoval_DoesNotAttachRemovedSibling()
+    {
+        var sibling = new StubBehavior();
+        var remover = new SiblingRemovingBehavior(sibling);
+        var behaviors = new BehaviorCollection { remover, sibling };
+        var button = new Button();
+
+        Interaction.SetBehaviors(button, behaviors);
+
+        Assert.DoesNotContain(sibling, behaviors);
+        Assert.Equal(0, sibling.AttachCount);
+        Assert.Null(sibling.AssociatedObject);
+        Assert.Same(button, remover.AssociatedObject);
     }
 
     [AvaloniaFact]

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -36,6 +36,34 @@ public class InteractionTest
         }
     }
 
+    private sealed class TopLevelLoadedTrigger : StyledElementTrigger<TopLevel>
+    {
+        public int InitializedCount { get; private set; }
+        public int LogicalAttachCount { get; private set; }
+        public int VisualAttachCount { get; private set; }
+        public int LoadedCount { get; private set; }
+
+        protected override void OnInitializedEvent()
+        {
+            InitializedCount++;
+        }
+
+        protected override void OnAttachedToLogicalTree()
+        {
+            LogicalAttachCount++;
+        }
+
+        protected override void OnAttachedToVisualTree()
+        {
+            VisualAttachCount++;
+        }
+
+        protected override void OnLoaded()
+        {
+            LoadedCount++;
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -231,5 +259,25 @@ public class InteractionTest
         behaviors.Add(trigger);
 
         AssertCurrentLifecycle(trigger, button);
+    }
+
+    [AvaloniaFact]
+    public void AddBehaviorToOpenTopLevel_NotifiesCurrentLifecycleOnce()
+    {
+        var window = new Window();
+        var behaviors = Interaction.GetBehaviors(window);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var trigger = new TopLevelLoadedTrigger();
+
+        behaviors.Add(trigger);
+
+        Assert.Equal(1, trigger.InitializedCount);
+        Assert.Equal(1, trigger.LogicalAttachCount);
+        Assert.Equal(1, trigger.VisualAttachCount);
+        Assert.Equal(1, trigger.LoadedCount);
+        Assert.Same(window, trigger.Parent);
+
+        window.Close();
     }
 }

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -357,6 +357,23 @@ public class InteractionTest
     }
 
     [AvaloniaFact]
+    public void AddBehaviorFromEarlierInitializedHandler_NotifiesLifecycleOnce()
+    {
+        var button = new Button();
+        BehaviorCollection? behaviors = null;
+        var trigger = new LoadedTrigger();
+        button.Initialized += (_, _) => behaviors!.Add(trigger);
+        behaviors = Interaction.GetBehaviors(button);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        AssertCurrentLifecycle(trigger, button);
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void AddBehaviorAfterShow_AllowsBehaviorToRemoveItselfDuringLoaded()
     {
         var button = new Button();

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -243,6 +243,24 @@ public class InteractionTest
         }
     }
 
+    private sealed class RecordingVisualTrigger(string name, List<string> eventOrder)
+        : StyledElementTrigger<Button>
+    {
+        protected override void OnAttachedToVisualTree()
+        {
+            eventOrder.Add(name);
+        }
+    }
+
+    private sealed class RecordingInitializedTrigger(string name, List<string> eventOrder)
+        : StyledElementTrigger<Button>
+    {
+        protected override void OnInitializedEvent()
+        {
+            eventOrder.Add(name);
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -587,6 +605,69 @@ public class InteractionTest
         Dispatcher.UIThread.RunJobs();
 
         AssertCurrentLifecycle(trigger, button);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void EarlierLoadedHandler_Replays_Addition_After_Existing_Behaviors()
+    {
+        var eventOrder = new List<string>();
+        var button = new Button();
+        var added = new RecordingLoadedTrigger("B", eventOrder);
+        button.Loaded += (_, _) => Interaction.GetBehaviors(button).Add(added);
+        var first = new RecordingLoadedTrigger("A", eventOrder);
+        var laterExisting = new RecordingLoadedTrigger("C", eventOrder);
+        var behaviors = new BehaviorCollection { first, laterExisting };
+        Interaction.SetBehaviors(button, behaviors);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(["A", "C", "B"], eventOrder);
+        Assert.Contains(added, behaviors);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void EarlierVisualHandler_Replays_Addition_After_Existing_Behaviors()
+    {
+        var eventOrder = new List<string>();
+        var button = new Button();
+        var added = new RecordingVisualTrigger("B", eventOrder);
+        button.AttachedToVisualTree += (_, _) => Interaction.GetBehaviors(button).Add(added);
+        var first = new RecordingVisualTrigger("A", eventOrder);
+        var laterExisting = new RecordingVisualTrigger("C", eventOrder);
+        var behaviors = new BehaviorCollection { first, laterExisting };
+        Interaction.SetBehaviors(button, behaviors);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(["A", "C", "B"], eventOrder);
+        Assert.Contains(added, behaviors);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void EarlierInitializedHandler_Replays_Addition_After_Existing_Behaviors()
+    {
+        var eventOrder = new List<string>();
+        var button = new Button();
+        var added = new RecordingInitializedTrigger("B", eventOrder);
+        button.Initialized += (_, _) => Interaction.GetBehaviors(button).Add(added);
+        var first = new RecordingInitializedTrigger("A", eventOrder);
+        var laterExisting = new RecordingInitializedTrigger("C", eventOrder);
+        var behaviors = new BehaviorCollection { first, laterExisting };
+        Interaction.SetBehaviors(button, behaviors);
+        var window = new Window { Content = button };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(["A", "C", "B"], eventOrder);
+        Assert.Contains(added, behaviors);
         window.Close();
     }
 

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -64,6 +64,16 @@ public class InteractionTest
         }
     }
 
+    private sealed class SiblingAwareLoadedTrigger(IBehavior sibling) : StyledElementTrigger<Button>
+    {
+        public bool SiblingWasAttachedWhenLoaded { get; private set; }
+
+        protected override void OnLoaded()
+        {
+            SiblingWasAttachedWhenLoaded = ReferenceEquals(AssociatedObject, sibling.AssociatedObject);
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -244,6 +254,23 @@ public class InteractionTest
         Interaction.SetBehaviors(button, new BehaviorCollection { trigger });
 
         AssertCurrentLifecycle(trigger, button);
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_AttachesAllSiblingsBeforeLoadedCallbacks()
+    {
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var sibling = new StubBehavior();
+        var trigger = new SiblingAwareLoadedTrigger(sibling);
+
+        Interaction.SetBehaviors(button, new BehaviorCollection { trigger, sibling });
+
+        Assert.True(trigger.SiblingWasAttachedWhenLoaded);
+        Assert.Same(button, sibling.AssociatedObject);
+        window.Close();
     }
 
     [AvaloniaFact]

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -74,6 +74,20 @@ public class InteractionTest
         }
     }
 
+    private sealed class LifecycleAwareLoadedTrigger(LoadedTrigger sibling) : StyledElementTrigger<Button>
+    {
+        public bool SiblingCompletedEarlierPhasesWhenLoaded { get; private set; }
+
+        protected override void OnLoaded()
+        {
+            SiblingCompletedEarlierPhasesWhenLoaded =
+                sibling.InitializedCount == 1 &&
+                sibling.LogicalAttachCount == 1 &&
+                sibling.VisualAttachCount == 1 &&
+                sibling.LoadedCount == 0;
+        }
+    }
+
     private sealed class SelfRemovingLoadedTrigger : StyledElementTrigger<Button>
     {
         public int LoadedCount { get; private set; }
@@ -372,6 +386,23 @@ public class InteractionTest
 
         Assert.True(trigger.SiblingWasAttachedWhenLoaded);
         Assert.Same(button, sibling.AssociatedObject);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_Replays_Lifecycle_In_Collection_Phases()
+    {
+        var button = new Button();
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var sibling = new LoadedTrigger();
+        var observer = new LifecycleAwareLoadedTrigger(sibling);
+
+        Interaction.SetBehaviors(button, new BehaviorCollection { observer, sibling });
+
+        Assert.True(observer.SiblingCompletedEarlierPhasesWhenLoaded);
+        Assert.Equal(1, sibling.LoadedCount);
         window.Close();
     }
 

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/InteractionTest.cs
@@ -88,6 +88,43 @@ public class InteractionTest
         }
     }
 
+    private sealed class SelfRemovingInitializedTrigger : StyledElementTrigger<Button>
+    {
+        public int InitializedCount { get; private set; }
+        public int LogicalAttachCount { get; private set; }
+        public int VisualAttachCount { get; private set; }
+        public int LoadedCount { get; private set; }
+
+        protected override void OnInitializedEvent()
+        {
+            InitializedCount++;
+            if (AssociatedObject is not null)
+            {
+                Interaction.GetBehaviors(AssociatedObject).Remove(this);
+            }
+        }
+
+        protected override void OnAttachedToLogicalTree() => LogicalAttachCount++;
+
+        protected override void OnAttachedToVisualTree() => VisualAttachCount++;
+
+        protected override void OnLoaded() => LoadedCount++;
+    }
+
+    private sealed class RemovingLoadedTrigger(Panel parent) : StyledElementTrigger<Button>
+    {
+        public int LoadedCount { get; private set; }
+
+        protected override void OnLoaded()
+        {
+            LoadedCount++;
+            if (LoadedCount == 1 && AssociatedObject is not null)
+            {
+                parent.Children.Remove(AssociatedObject);
+            }
+        }
+    }
+
     private static void AssertCurrentLifecycle(LoadedTrigger trigger, Button button)
     {
         Assert.Equal(1, trigger.InitializedCount);
@@ -389,6 +426,46 @@ public class InteractionTest
         Assert.DoesNotContain(trigger, behaviors);
         Assert.Null(trigger.AssociatedObject);
         Assert.Empty(behaviors);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void AddBehaviorAfterShow_StopsReplayWhenInitializedRemovesBehavior()
+    {
+        var button = new Button();
+        var behaviors = Interaction.GetBehaviors(button);
+        var window = new Window { Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var trigger = new SelfRemovingInitializedTrigger();
+
+        behaviors.Add(trigger);
+
+        Assert.Equal(1, trigger.InitializedCount);
+        Assert.Equal(0, trigger.LogicalAttachCount);
+        Assert.Equal(0, trigger.VisualAttachCount);
+        Assert.Equal(0, trigger.LoadedCount);
+        Assert.Null(trigger.AssociatedObject);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SetBehaviorsAfterShow_SubscribesHostEventsBeforeLoadedReplay()
+    {
+        var button = new Button();
+        var panel = new StackPanel { Children = { button } };
+        var window = new Window { Content = panel };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var trigger = new RemovingLoadedTrigger(panel);
+
+        Interaction.SetBehaviors(button, new BehaviorCollection { trigger });
+        Assert.DoesNotContain(button, panel.Children);
+
+        panel.Children.Add(button);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, trigger.LoadedCount);
         window.Close();
     }
 


### PR DESCRIPTION
## Summary

Restores `StyledElementTrigger<T>.OnLoaded` for behaviors that are attached after their associated control has already entered its current loaded lifetime.

## Root cause

`Interaction` forwards lifecycle events that occur after a behavior collection is installed. If Avalonia 12 initializes a style/template-provided collection after `Loaded` has already been raised, the new trigger is attached successfully but has no way to observe the event that already happened. The same gap affects behaviors added to an already-attached collection.

Waiting for a future unload/reload is incorrect for initialization triggers such as the reported ScottPlot setup trigger.

## Changes

- Synchronize a newly attached behavior with the associated object's current lifecycle state.
- Preserve lifecycle ordering:
  1. initialized;
  2. attached to logical tree;
  3. attached to visual tree;
  4. loaded.
- Apply synchronization both when a whole collection attaches and when an individual behavior is added later.
- Keep the normal pre-load path event-driven, preventing duplicate notifications.
- Ensure logical-tree attachment is established before `OnLoaded`, so action bindings and inherited data context are available.
- Document late-attachment lifecycle behavior.

## Regression coverage

Headless tests cover:

- a trigger installed before `Window.Show`;
- a collection installed after the control is loaded;
- a trigger added to an already-attached collection after load.

Each path verifies initialization, logical attachment, visual attachment, and `OnLoaded` occur exactly once, and that the trigger has the expected logical parent.

## Validation

- Focused lifecycle regressions: 3 passed
- `Xaml.Behaviors.Interactivity.UnitTests`: 96 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 89 passed, 2 existing skipped
- `git diff --check`: clean

Closes #347