### PR TITLE
Support bound Flyout opened and closed events

### DIFF
--- a/docfx/articles/interactions/event-trigger-behavior.md
+++ b/docfx/articles/interactions/event-trigger-behavior.md
@@ -19,6 +19,29 @@
 </Button>
 ```
 
+### Flyout lifecycle events
+
+Behaviors can be attached directly to a `Flyout` to observe its `Opened` and `Closed` events. When the flyout is shown, the behavior and its actions inherit the placement target's data context, so command bindings resolve normally.
+
+```xml
+<Button Content="Open menu">
+    <Button.Flyout>
+        <Flyout>
+            <Interaction.Behaviors>
+                <EventTriggerBehavior EventName="Opened">
+                    <InvokeCommandAction Command="{Binding FlyoutOpenedCommand}" />
+                </EventTriggerBehavior>
+                <EventTriggerBehavior EventName="Closed">
+                    <InvokeCommandAction Command="{Binding FlyoutClosedCommand}" />
+                </EventTriggerBehavior>
+            </Interaction.Behaviors>
+
+            <TextBlock Text="Flyout content" />
+        </Flyout>
+    </Button.Flyout>
+</Button>
+```
+
 ## EventTrigger
 
 `EventTrigger` is a deprecated class that functions similarly to `EventTriggerBehavior` but inherits from `Trigger`. It is recommended to use `EventTriggerBehavior` instead.

--- a/src/Xaml.Behaviors.Interactivity/Events/AddEventHandlerRegistry.cs
+++ b/src/Xaml.Behaviors.Interactivity/Events/AddEventHandlerRegistry.cs
@@ -28,6 +28,8 @@ public static class AddEventHandlerRegistry
             nameof(MenuItem.Click), 
             (o, h) => o.Click += h, 
             (o, h) => o.Click -= h));
+
+        Register(new FlyoutEventHandler());
     }
 
     /// <summary>

--- a/src/Xaml.Behaviors.Interactivity/Events/Handlers/FlyoutEventHandler.cs
+++ b/src/Xaml.Behaviors.Interactivity/Events/Handlers/FlyoutEventHandler.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Avalonia.Controls.Primitives;
+
+namespace Avalonia.Xaml.Interactivity;
+
+internal sealed class FlyoutEventHandler : IAddEventHandler
+{
+    public bool Matches(object source, string eventName)
+    {
+        return source is FlyoutBase &&
+               eventName is nameof(FlyoutBase.Opened) or nameof(FlyoutBase.Closed);
+    }
+
+    public IDisposable? AddHandler(
+        object source,
+        string eventName,
+        Action<object?, object> handler)
+    {
+        if (source is not FlyoutBase target)
+        {
+            return null;
+        }
+
+        EventHandler eventHandler = (sender, eventArgs) => handler(sender, eventArgs);
+
+        switch (eventName)
+        {
+            case nameof(FlyoutBase.Opened):
+                target.Opened += eventHandler;
+                return DisposableAction.Create(() => target.Opened -= eventHandler);
+
+            case nameof(FlyoutBase.Closed):
+                target.Closed += eventHandler;
+                return DisposableAction.Create(() => target.Closed -= eventHandler);
+
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Reactive;
 
 namespace Avalonia.Xaml.Interactivity;
@@ -269,16 +270,20 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
             parent = topLevel;
             templatedParent = topLevel.TemplatedParent;
         }
+        else if (AssociatedObject is FlyoutBase { Target: { } target })
+        {
+            parent = target;
+            templatedParent = target.TemplatedParent;
+        }
+        else if (AssociatedObject is StyledElement styledElement && styledElement.Parent is not null)
+        {
+            parent = styledElement;
+            templatedParent = styledElement.TemplatedParent;
+        }
 
         if (parent is null)
         {
-            if (AssociatedObject is not StyledElement styledElement || styledElement.Parent is null)
-            {
-                return;
-            }
-
-            parent = styledElement;
-            templatedParent = styledElement.TemplatedParent;
+            return;
         }
 
         // Required for $parent binding in XAML
@@ -317,6 +322,46 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
                 {
                     SetCurrentValue(DataContextProperty, x);
                 }));
+        }
+
+        if (associatedObject is FlyoutBase flyout)
+        {
+            IDisposable? targetDataContextSubscription = null;
+
+            void TargetChanged(Control? target)
+            {
+                targetDataContextSubscription?.Dispose();
+                targetDataContextSubscription = null;
+
+                if (Parent is not null || TemplatedParent is not null)
+                {
+                    DetachBehaviorFromLogicalTree();
+                }
+
+                if (target is null)
+                {
+                    SetCurrentValue(DataContextProperty, null);
+                    return;
+                }
+
+                AttachBehaviorToLogicalTree();
+                targetDataContextSubscription = target
+                    .GetObservable(DataContextProperty)
+                    .Subscribe(new AnonymousObserver<object?>(x =>
+                    {
+                        SetCurrentValue(DataContextProperty, x);
+                    }));
+            }
+
+            var targetSubscription = flyout
+                .GetObservable(FlyoutBase.TargetProperty)
+                .Subscribe(new AnonymousObserver<Control?>(TargetChanged));
+
+            return DisposableAction.Create(() =>
+            {
+                targetSubscription.Dispose();
+                targetDataContextSubscription?.Dispose();
+            });
         }
 
         return default;

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementTrigger.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementTrigger.cs
@@ -92,7 +92,7 @@ public abstract class StyledElementTrigger : StyledElementBehavior, ITrigger
         }
         else
         {
-            if (AssociatedObject is not StyledElement styledElement || styledElement.Parent is null)
+            if (Parent is null)
             {
                 return;
             }

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/EventTriggerBehavior005.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/EventTriggerBehavior005.axaml
@@ -1,0 +1,27 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.Core"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Core.EventTriggerBehavior005"
+        x:DataType="local:FlyoutEventBindingSource">
+  <Window.DataContext>
+    <local:FlyoutEventBindingSource />
+  </Window.DataContext>
+
+  <Button x:Name="TargetButton" Content="Open flyout">
+    <Button.Flyout>
+      <Flyout>
+        <Interaction.Behaviors>
+          <EventTriggerBehavior EventName="Opened">
+            <InvokeCommandAction Command="{Binding OpenedCommand}"
+                                 PassEventArgsToCommand="True" />
+          </EventTriggerBehavior>
+          <EventTriggerBehavior EventName="Closed">
+            <InvokeCommandAction Command="{Binding ClosedCommand}"
+                                 PassEventArgsToCommand="True" />
+          </EventTriggerBehavior>
+        </Interaction.Behaviors>
+        <TextBlock Text="Flyout content" />
+      </Flyout>
+    </Button.Flyout>
+  </Button>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/EventTriggerBehavior005.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/EventTriggerBehavior005.axaml.cs
@@ -1,0 +1,41 @@
+using System.Windows.Input;
+using Avalonia.Controls;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Core;
+
+public partial class EventTriggerBehavior005 : Window
+{
+    public EventTriggerBehavior005()
+    {
+        InitializeComponent();
+    }
+}
+
+public sealed class FlyoutEventBindingSource
+{
+    public FlyoutEventBindingSource()
+    {
+        OpenedCommand = new Command(parameter =>
+        {
+            OpenedCount++;
+            OpenedParameter = parameter;
+        });
+        ClosedCommand = new Command(parameter =>
+        {
+            ClosedCount++;
+            ClosedParameter = parameter;
+        });
+    }
+
+    public ICommand OpenedCommand { get; }
+
+    public ICommand ClosedCommand { get; }
+
+    public int OpenedCount { get; private set; }
+
+    public int ClosedCount { get; private set; }
+
+    public object? OpenedParameter { get; private set; }
+
+    public object? ClosedParameter { get; private set; }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Core/EventTriggerBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Core/EventTriggerBehaviorTests.cs
@@ -1,3 +1,5 @@
+using System;
+using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Xunit;
@@ -61,5 +63,25 @@ public class EventTriggerBehaviorTests
         window.CaptureRenderedFrame()?.Save("EventTriggerBehavior_004_0.png");
 
         Assert.Equal("Loaded Text", window.TargetTextBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void EventTriggerBehavior_005_FlyoutEventsExecuteBoundCommands()
+    {
+        var window = new EventTriggerBehavior005();
+        var source = Assert.IsType<FlyoutEventBindingSource>(window.DataContext);
+        var flyout = Assert.IsType<Flyout>(window.TargetButton.Flyout);
+
+        window.Show();
+        flyout.ShowAt(window.TargetButton);
+
+        Assert.Equal(1, source.OpenedCount);
+        Assert.Same(EventArgs.Empty, source.OpenedParameter);
+        Assert.Equal(0, source.ClosedCount);
+
+        flyout.Hide();
+
+        Assert.Equal(1, source.ClosedCount);
+        Assert.Same(EventArgs.Empty, source.ClosedParameter);
     }
 }


### PR DESCRIPTION
## Summary

- make `EventTriggerBehavior` observe `Flyout.Opened` and `Flyout.Closed` through strongly typed subscriptions
- synchronize Flyout-attached behaviors and actions with the placement target's logical/data-context scope
- preserve compiled command bindings when the Flyout is hosted outside the normal logical tree
- document the direct Flyout usage and add an end-to-end headless regression

## Root cause

Avalonia 12's `FlyoutBase` derives from `AvaloniaObject`, not `StyledElement`. A behavior attached directly to a Flyout could register the requested CLR event through the reflection fallback, but it had no logical parent or inherited data context. Consequently, `InvokeCommandAction.Command="{Binding ...}"` remained unresolved and made the event appear not to fire.

The generic reflection path was also unnecessary for the two known Flyout lifecycle events.

## Changes

- register `Opened` and `Closed` in `AddEventHandlerRegistry` through a focused `FlyoutEventHandler`
- avoid adding any new reflection and make these event paths trimming/AOT friendly
- observe `FlyoutBase.TargetProperty`
- when a placement target is assigned:
  - attach the behavior/action logical scope to that target
  - mirror the target's data context
  - update both when a Flyout is reused with another target
- dispose target and data-context subscriptions when the behavior detaches
- allow trigger actions to attach whenever their behavior has a valid logical parent
- document Flyout lifecycle event usage

## Tests

A compiled-XAML headless fixture matches the reported pattern:

- behaviors are attached directly to a `Flyout`
- `Opened` and `Closed` each invoke a compiled-bound command exactly once
- the command binding comes from the placement button/window data context
- `PassEventArgsToCommand` receives the original event argument

## Validation

- focused `EventTriggerBehaviorTests`: 5 passed
- `Xaml.Behaviors.Interactivity.UnitTests`: 93 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 90 passed, 2 pre-existing skipped
- `git diff --check`: clean

Closes #350