### PR TITLE
Preserve bound actions during detach triggers

### DIFF
--- a/docfx/articles/interactions-custom/core/detached-from-logical-tree-trigger.md
+++ b/docfx/articles/interactions-custom/core/detached-from-logical-tree-trigger.md
@@ -1,3 +1,5 @@
 # DetachedFromLogicalTreeTrigger
 
 Executes when the associated object is detached from the logical tree.
+
+The trigger executes before its behavior/action logical scope is released, so bound actions retain their data context for the detach callback.

--- a/docfx/articles/interactions-custom/core/detached-from-visual-tree-trigger.md
+++ b/docfx/articles/interactions-custom/core/detached-from-visual-tree-trigger.md
@@ -1,3 +1,5 @@
 # DetachedFromVisualTreeTrigger
 
 Executes when the associated object is detached from the visual tree.
+
+The trigger executes before its behavior/action logical scope is released. Bound actions therefore retain their data context for the detach callback, including when content leaves the visual tree because a `TabControl` selection changes.

--- a/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
+++ b/src/Xaml.Behaviors.Interactivity/StyledElement/StyledElementBehavior.cs
@@ -118,9 +118,14 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.DetachedFromVisualTreeEventHandler()
     {
-        DetachBehaviorFromLogicalTree();
-
-        OnDetachedFromVisualTree();
+        try
+        {
+            OnDetachedFromVisualTree();
+        }
+        finally
+        {
+            DetachBehaviorFromLogicalTree();
+        }
     }
 
     void IBehaviorEventsHandler.AttachedToLogicalTreeEventHandler()
@@ -132,9 +137,14 @@ public abstract class StyledElementBehavior : StyledElement, IBehavior, IBehavio
 
     void IBehaviorEventsHandler.DetachedFromLogicalTreeEventHandler()
     {
-        DetachBehaviorFromLogicalTree();
-
-        OnDetachedFromLogicalTree();
+        try
+        {
+            OnDetachedFromLogicalTree();
+        }
+        finally
+        {
+            DetachBehaviorFromLogicalTree();
+        }
     }
 
     void IBehaviorEventsHandler.LoadedEventHandler() => OnLoaded();

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/DetachedFromVisualTreeTrigger001.axaml
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/DetachedFromVisualTreeTrigger001.axaml
@@ -1,0 +1,24 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:Avalonia.Xaml.Interactions.UnitTests.Custom"
+        x:Class="Avalonia.Xaml.Interactions.UnitTests.Custom.DetachedFromVisualTreeTrigger001"
+        x:DataType="local:DetachedTriggerBindingSource">
+  <Window.DataContext>
+    <local:DetachedTriggerBindingSource />
+  </Window.DataContext>
+
+  <TabControl x:Name="TargetTabs">
+    <TabItem Header="Tab 1">
+      <TextBlock Text="Tab 1">
+        <Interaction.Behaviors>
+          <DetachedFromVisualTreeTrigger>
+            <InvokeCommandAction Command="{Binding DetachedCommand}" />
+          </DetachedFromVisualTreeTrigger>
+        </Interaction.Behaviors>
+      </TextBlock>
+    </TabItem>
+    <TabItem Header="Tab 2">
+      <TextBlock Text="Tab 2" />
+    </TabItem>
+  </TabControl>
+</Window>

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/DetachedFromVisualTreeTrigger001.axaml.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/DetachedFromVisualTreeTrigger001.axaml.cs
@@ -1,0 +1,25 @@
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactions.UnitTests.Core;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public partial class DetachedFromVisualTreeTrigger001 : Window
+{
+    public DetachedFromVisualTreeTrigger001()
+    {
+        InitializeComponent();
+    }
+}
+
+public sealed class DetachedTriggerBindingSource
+{
+    public DetachedTriggerBindingSource()
+    {
+        DetachedCommand = new Command(_ => DetachedCount++);
+    }
+
+    public ICommand DetachedCommand { get; }
+
+    public int DetachedCount { get; private set; }
+}

--- a/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/DetachedFromVisualTreeTriggerTests.cs
+++ b/tests/Xaml.Behaviors.Interactions.UnitTests/Custom/DetachedFromVisualTreeTriggerTests.cs
@@ -1,0 +1,25 @@
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace Avalonia.Xaml.Interactions.UnitTests.Custom;
+
+public class DetachedFromVisualTreeTriggerTests
+{
+    [AvaloniaFact]
+    public void SwitchingTabs_ExecutesBoundDetachedCommand()
+    {
+        var window = new DetachedFromVisualTreeTrigger001();
+        var source = Assert.IsType<DetachedTriggerBindingSource>(window.DataContext);
+
+        window.Show();
+        window.CaptureRenderedFrame();
+
+        window.TargetTabs.SelectedIndex = 1;
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame();
+
+        Assert.Equal(1, source.DetachedCount);
+    }
+}

--- a/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
+++ b/tests/Xaml.Behaviors.Interactivity.UnitTests/StyledElementBehaviorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Xunit;
@@ -32,5 +33,36 @@ public class StyledElementBehaviorTests
         window.Close();
     }
 
+    [AvaloniaFact]
+    public void DetachVisualTree_ClearsLogicalScopeWhenCallbackThrows()
+    {
+        var behavior = new ThrowingDetachBehavior();
+        var button = new Button();
+        var templatedParent = new ContentControl();
+        var window = new Window { Content = button };
+
+        TemplatedParentHelper.SetTemplatedParent(button, templatedParent);
+        Interaction.GetBehaviors(button).Add(behavior);
+        window.Show();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ((IBehaviorEventsHandler)behavior).DetachedFromVisualTreeEventHandler());
+
+        Assert.Null(behavior.Parent);
+        Assert.Null(behavior.TemplatedParent);
+
+        behavior.Detach();
+        Interaction.SetBehaviors(button, null);
+        window.Close();
+    }
+
     private sealed class TestStyledElementBehavior : StyledElementBehavior;
+
+    private sealed class ThrowingDetachBehavior : StyledElementBehavior
+    {
+        protected override void OnDetachedFromVisualTree()
+        {
+            throw new InvalidOperationException("Expected test exception.");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- execute visual/logical detach callbacks before releasing behavior and action logical scope
- keep bound detach-trigger commands valid during the callback
- guarantee scope cleanup with `try/finally`, even when a custom callback throws
- add the exact compiled-XAML TabControl regression and document detach semantics

## Root cause

The recent synchronous action-logical-tree cleanup exposed an ordering problem in `StyledElementBehavior`:

1. `DetachedFromVisualTreeEventHandler` detached the behavior/action logical tree
2. command bindings and inherited data context were released
3. `DetachedFromVisualTreeTrigger.OnDetachedFromVisualTree` executed its actions

The trigger itself still fired, but `InvokeCommandAction.Command` was already null. This made the reported bound method/command appear not to run when switching tabs.

The logical-tree detach path had the same ordering contract and is corrected alongside the visual path.

## Changes

- notify `OnDetachedFromVisualTree` before `DetachBehaviorFromLogicalTree`
- notify `OnDetachedFromLogicalTree` before releasing the same scope
- use `try/finally` so parent, templated-parent, action lifecycle, and command observer cleanup still run if a consumer callback throws
- document that detach triggers retain their binding scope through callback execution

## Tests

### Reported regression

A compiled-XAML headless fixture mirrors the issue:

- a `TabControl` hosts a `TextBlock`
- the text block has `DetachedFromVisualTreeTrigger`
- `InvokeCommandAction.Command` is compiled-bound from the window data context
- switching tabs executes the bound command exactly once

The regression test fails on current `master` and passes with this change.

### Cleanup safeguard

A behavior whose visual-detach callback throws verifies that logical parent and templated parent are still cleared.

## Validation

- focused detach/action-lifetime tests: 17 passed
- focused behavior cleanup tests: 2 passed
- `Xaml.Behaviors.Interactivity.UnitTests`: 94 passed
- `Xaml.Behaviors.Interactions.UnitTests`: 90 passed, 2 pre-existing skipped
- `git diff --check`: clean

Closes #353